### PR TITLE
chore(deps): tighten dependabot to exclude Expo-managed packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,25 +30,15 @@ updates:
       - "automated"
     # Group React Native related packages together
     groups:
-      react-native:
-        patterns:
-          - "react-native*"
-          - "@react-native*"
-          - "react-native-*"
       expo:
         patterns:
           - "expo*"
           - "@expo*"
-      react:
-        patterns:
-          - "react"
-          - "react-*"
-          - "@types/react*"
       testing:
         patterns:
           - "*jest*"
-          - "@testing-library/*"
-          - "maestro*"
+          - "babel-jest"
+          - "reassure"
       linting:
         patterns:
           - "eslint*"
@@ -71,9 +61,18 @@ updates:
       # All Expo related packages should be updated manually
       - dependency-name: "expo*"
       - dependency-name: "@expo*"
+      # React versions must track Expo SDK — update manually
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-compiler-runtime"
+      - dependency-name: "@types/react*"
+      # React Navigation is tightly coupled to React Native version
+      - dependency-name: "@react-navigation/*"
+      # React Native Testing Library must match React Native version
+      - dependency-name: "@testing-library/react-native"
       # Node.js types often have issues with automatic updates
       - dependency-name: "@types/node"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- Remove dead `react-native` group (all patterns were already in `ignore:`)
- Ignore `react`, `react-dom`, `react-compiler-runtime`, `@types/react*` — versions dictated by Expo SDK
- Ignore `@react-navigation/*` — tightly coupled to React Native version
- Ignore `@testing-library/react-native` — must match React Native version
- Remove `maestro*` from `testing` group — Maestro is a CLI tool, not an npm dependency
- Scope `testing` group to Jest-only packages (`*jest*`, `babel-jest`, `reassure`)

## Why

Dependabot was opening PRs for React and testing packages whose versions are governed by the Expo SDK. Bumping them independently risks breaking the managed workflow; `expo-doctor` in CI already catches version mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)