### PR TITLE
fix(ci): remove invalid security-update from dependabot allow rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,7 @@ updates:
       separator: "/"
     allow:
       - dependency-type: "direct"
-        update-types: ["version-update:semver-major", "version-update:semver-minor", "security-update"]
-      - dependency-type: "indirect"
-        update-types: ["security-update"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
       prefix: "chore"
       prefix-development: "chore"


### PR DESCRIPTION
security-update is not a valid update-types value — only semver variants are accepted. Security PRs bypass allow/ignore rules automatically. Drop the indirect entry entirely as it was both invalid and redundant.