### PR TITLE
fix(input): commit-on-blur architecture to prevent E2E dropped characters

### DIFF
--- a/src/components/atomic/CustomTextInput.tsx
+++ b/src/components/atomic/CustomTextInput.tsx
@@ -71,8 +71,8 @@ export type CustomTextInputProps = {
   onFocus?: () => void;
   /** Callback fired when text changes */
   onChangeText?: (text: string) => void;
-  /** Callback fired when editing ends */
-  onEndEditing?: () => void;
+  /** Callback fired when editing ends, with the current displayed text */
+  onEndEditing?: (text: string) => void;
   /** Callback fired when input loses focus */
   onBlur?: () => void;
   /** Callback fired when component layout changes */
@@ -118,6 +118,7 @@ export function CustomTextInput({
 }: CustomTextInputProps) {
   const [displayValue, setDisplayValue] = useState(value ?? '');
   const prevExternalValueRef = useRef(value);
+  const lastCommittedValueRef = useRef<string | null>(null);
 
   if (value !== prevExternalValueRef.current) {
     prevExternalValueRef.current = value;
@@ -126,9 +127,25 @@ export function CustomTextInput({
 
   const { colors } = useTheme();
 
+  function commitChange() {
+    if (lastCommittedValueRef.current !== displayValue) {
+      lastCommittedValueRef.current = displayValue;
+      onEndEditing?.(displayValue);
+    }
+  }
+
   function handleOnChangeText(text: string) {
     setDisplayValue(text);
     onChangeText?.(text);
+  }
+
+  function handleEndEditing() {
+    commitChange();
+  }
+
+  function handleBlur() {
+    commitChange();
+    onBlur?.();
   }
 
   return (
@@ -149,13 +166,13 @@ export function CustomTextInput({
       ]}
       onFocus={onFocus}
       onChangeText={handleOnChangeText}
-      onEndEditing={onEndEditing}
+      onEndEditing={handleEndEditing}
       mode={mode}
       dense={dense}
       multiline={multiline}
       editable={editable}
       keyboardType={keyboardType}
-      onBlur={onBlur}
+      onBlur={handleBlur}
       onLayout={onLayout}
       error={error}
       right={right}

--- a/src/components/molecules/TextInputWithDropDown.tsx
+++ b/src/components/molecules/TextInputWithDropDown.tsx
@@ -191,12 +191,12 @@ export function TextInputWithDropDown({
     onValidate?.(text);
   }
 
-  function handleEndEditing() {
+  function handleEndEditing(text: string) {
     if (isSelectingRef.current) {
       isSelectingRef.current = false;
       return;
     }
-    onValidate?.(textInput);
+    onValidate?.(text);
   }
 
   function handleLayout() {

--- a/src/components/organisms/RecipePreparation.tsx
+++ b/src/components/organisms/RecipePreparation.tsx
@@ -76,10 +76,10 @@ export type ReadOnlyProps = BaseProps & {
 export type EditableBaseProps = BaseProps & {
   /** Prefix text displayed above the steps */
   prefixText: string;
-  /** Callback fired when a step title changes */
-  onTitleChange: (index: number, title: string) => void;
-  /** Callback fired when a step description changes */
-  onDescriptionChange: (index: number, description: string) => void;
+  /** Callback fired when a step title is committed (on blur) */
+  onTitleEditingEnded: (index: number, title: string) => void;
+  /** Callback fired when a step description is committed (on blur) */
+  onDescriptionEditingEnded: (index: number, description: string) => void;
   /** Callback fired to add a new step */
   onAddStep: () => void;
 };
@@ -172,29 +172,25 @@ function EditableStep({
   testID,
   index,
   item,
-  onTitleChange,
-  onDescriptionChange,
+  onTitleEditingEnded,
+  onDescriptionEditingEnded,
 }: {
   testID: string;
   index: number;
   item: preparationStepElement;
-  onTitleChange: (index: number, title: string) => void;
-  onDescriptionChange: (index: number, description: string) => void;
+  onTitleEditingEnded: (index: number, title: string) => void;
+  onDescriptionEditingEnded: (index: number, description: string) => void;
 }) {
   const testId = testID + `::EditableStep::${index}`;
 
   const { t } = useI18n();
 
   const handleTitleChange = (newTitle: string) => {
-    if (newTitle !== item.title) {
-      onTitleChange(index, newTitle);
-    }
+    onTitleEditingEnded(index, newTitle);
   };
 
   const handleDescriptionChange = (newDescription: string) => {
-    if (newDescription !== item.description) {
-      onDescriptionChange(index, newDescription);
-    }
+    onDescriptionEditingEnded(index, newDescription);
   };
 
   return (
@@ -219,7 +215,7 @@ function EditableStep({
           testID={testId + `::TextInputTitle`}
           value={item.title}
           style={recipeTextRenderStyles.containerElement}
-          onChangeText={handleTitleChange}
+          onEndEditing={handleTitleChange}
           multiline={true}
         />
         <Text
@@ -233,7 +229,7 @@ function EditableStep({
           testID={testId + `::TextInputContent`}
           style={recipeTextRenderStyles.containerElement}
           value={item.description}
-          onChangeText={handleDescriptionChange}
+          onEndEditing={handleDescriptionChange}
           multiline={true}
         />
       </View>
@@ -247,8 +243,8 @@ function EditableStep({
 function EditablePreparation({
   steps,
   prefixText,
-  onTitleChange,
-  onDescriptionChange,
+  onTitleEditingEnded,
+  onDescriptionEditingEnded,
   onAddStep,
 }: EditableProps) {
   return (
@@ -259,8 +255,8 @@ function EditablePreparation({
           testID={testID}
           index={index}
           item={item}
-          onTitleChange={onTitleChange}
-          onDescriptionChange={onDescriptionChange}
+          onTitleEditingEnded={onTitleEditingEnded}
+          onDescriptionEditingEnded={onDescriptionEditingEnded}
         />
       ))}
 

--- a/src/hooks/useRecipePreparation.ts
+++ b/src/hooks/useRecipePreparation.ts
@@ -28,10 +28,10 @@ import { useRecipeForm } from '@context/RecipeFormContext';
  * Return value from the useRecipePreparation hook
  */
 export interface UseRecipePreparationReturn {
-  /** Updates the title of a preparation step at the specified index */
-  editPreparationTitle: (stepIndex: number, newTitle: string) => void;
-  /** Updates the description of a preparation step at the specified index */
-  editPreparationDescription: (stepIndex: number, newDescription: string) => void;
+  /** Commits the title of a preparation step at the specified index */
+  commitPreparationTitle: (stepIndex: number, title: string) => void;
+  /** Commits the description of a preparation step at the specified index */
+  commitPreparationDescription: (stepIndex: number, description: string) => void;
   /** Adds a new empty preparation step to the end of the list */
   addNewPreparationStep: () => void;
 }
@@ -51,49 +51,46 @@ export function useRecipePreparation(): UseRecipePreparationReturn {
   const { setRecipePreparation } = setters;
 
   /**
-   * Updates the title of a preparation step at the specified index.
+   * Commits the title of a preparation step at the specified index.
    *
    * Validates the index before updating. If the index is out of bounds,
    * logs a warning and returns without making changes.
    *
    * @param stepIndex - Zero-based index of the step to update
-   * @param newTitle - The new title text for the step
+   * @param title - The committed title text for the step
    */
-  const editPreparationTitle = (stepIndex: number, newTitle: string) => {
+  const commitPreparationTitle = (stepIndex: number, title: string) => {
     if (stepIndex < 0 || stepIndex >= recipePreparation.length) {
-      recipeLogger.warn('Cannot edit preparation step title - invalid index', {
+      recipeLogger.warn('Cannot commit preparation step title - invalid index', {
         stepIndex,
         preparationCount: recipePreparation.length,
       });
       return;
     }
     const updatedPreparation = [...recipePreparation];
-    updatedPreparation[stepIndex] = { ...updatedPreparation[stepIndex], title: newTitle };
+    updatedPreparation[stepIndex] = { ...updatedPreparation[stepIndex], title };
     setRecipePreparation(updatedPreparation);
   };
 
   /**
-   * Updates the description of a preparation step at the specified index.
+   * Commits the description of a preparation step at the specified index.
    *
    * Validates the index before updating. If the index is out of bounds,
    * logs a warning and returns without making changes.
    *
    * @param stepIndex - Zero-based index of the step to update
-   * @param newDescription - The new description text for the step
+   * @param description - The committed description text for the step
    */
-  const editPreparationDescription = (stepIndex: number, newDescription: string) => {
+  const commitPreparationDescription = (stepIndex: number, description: string) => {
     if (stepIndex < 0 || stepIndex >= recipePreparation.length) {
-      recipeLogger.warn('Cannot edit preparation step description - invalid index', {
+      recipeLogger.warn('Cannot commit preparation step description - invalid index', {
         stepIndex,
         preparationCount: recipePreparation.length,
       });
       return;
     }
     const updatedPreparation = [...recipePreparation];
-    updatedPreparation[stepIndex] = {
-      ...updatedPreparation[stepIndex],
-      description: newDescription,
-    };
+    updatedPreparation[stepIndex] = { ...updatedPreparation[stepIndex], description };
     setRecipePreparation(updatedPreparation);
   };
 
@@ -108,8 +105,8 @@ export function useRecipePreparation(): UseRecipePreparationReturn {
   };
 
   return {
-    editPreparationTitle,
-    editPreparationDescription,
+    commitPreparationTitle,
+    commitPreparationDescription,
     addNewPreparationStep,
   };
 }

--- a/src/screens/Recipe.tsx
+++ b/src/screens/Recipe.tsx
@@ -450,8 +450,8 @@ function RecipeContent({ route, navigation }: RecipeScreenProp) {
             {...buildRecipePreparationProps(
               state.stackMode,
               state.recipePreparation,
-              preparation.editPreparationTitle,
-              preparation.editPreparationDescription,
+              preparation.commitPreparationTitle,
+              preparation.commitPreparationDescription,
               preparation.addNewPreparationStep,
               ocr.openModalForField,
               t

--- a/src/utils/RecipeFormHelpers.tsx
+++ b/src/utils/RecipeFormHelpers.tsx
@@ -667,8 +667,8 @@ export function buildRecipeIngredientsProps(
 export function buildRecipePreparationProps(
   stackMode: recipeStateType,
   recipePreparation: preparationStepElement[],
-  editPreparationTitle: (stepIndex: number, newTitle: string) => void,
-  editPreparationDescription: (stepIndex: number, newDescription: string) => void,
+  commitPreparationTitle: (stepIndex: number, title: string) => void,
+  commitPreparationDescription: (stepIndex: number, description: string) => void,
   addNewPreparationStep: () => void,
   openModalForField: (field: recipeColumnsNames) => void,
   t: (key: string) => string
@@ -683,8 +683,8 @@ export function buildRecipePreparationProps(
   const editableProps = {
     steps: recipePreparation,
     prefixText: t('preparationReadOnly'),
-    onTitleChange: editPreparationTitle,
-    onDescriptionChange: editPreparationDescription,
+    onTitleEditingEnded: commitPreparationTitle,
+    onDescriptionEditingEnded: commitPreparationDescription,
     onAddStep: addNewPreparationStep,
   };
 

--- a/src/utils/RecipeFormHelpers.tsx
+++ b/src/utils/RecipeFormHelpers.tsx
@@ -657,8 +657,8 @@ export function buildRecipeIngredientsProps(
  *
  * @param stackMode - Current recipe screen mode
  * @param recipePreparation - Current preparation steps array
- * @param editPreparationTitle - Callback to edit step title
- * @param editPreparationDescription - Callback to edit step description
+ * @param commitPreparationTitle - Callback to commit a step title on blur
+ * @param commitPreparationDescription - Callback to commit a step description on blur
  * @param addNewPreparationStep - Callback to add a new step
  * @param openModalForField - Callback to open OCR modal
  * @param t - Translation function

--- a/tests/mocks/components/atomic/CustomTextInput-mock.tsx
+++ b/tests/mocks/components/atomic/CustomTextInput-mock.tsx
@@ -1,32 +1,53 @@
-import { TextInput, TextStyle } from 'react-native';
-import React from 'react';
+import {
+  NativeSyntheticEvent,
+  TextInput,
+  TextInputEndEditingEventData,
+  TextStyle,
+} from 'react-native';
+import React, { useRef, useState } from 'react';
 import { CustomTextInputProps } from '@components/atomic/CustomTextInput';
 
-export function customTextInputMock({
+export function CustomTextInputMock({
   testID,
   editable = true,
   label,
   value,
   multiline = false,
-  keyboardType = 'default',
   style,
-  contentStyle,
   onFocus,
   onChangeText,
   onEndEditing,
   onBlur,
   onLayout,
 }: CustomTextInputProps) {
+  const [displayValue, setDisplayValue] = useState(value ?? '');
+  const prevValueRef = useRef(value);
+
+  if (value !== prevValueRef.current) {
+    prevValueRef.current = value;
+    setDisplayValue(value ?? '');
+  }
+
+  function handleChangeText(text: string) {
+    setDisplayValue(text);
+    onChangeText?.(text);
+  }
+
+  function handleEndEditing(e: NativeSyntheticEvent<TextInputEndEditingEventData>) {
+    const text = e?.nativeEvent?.text ?? displayValue;
+    onEndEditing?.(text);
+  }
+
   return (
     <TextInput
       testID={testID + '::CustomTextInput'}
       style={style as TextStyle}
       editable={editable}
-      value={value}
+      value={displayValue}
       multiline={multiline}
       onFocus={onFocus}
-      onChangeText={onChangeText}
-      onEndEditing={onEndEditing}
+      onChangeText={handleChangeText}
+      onEndEditing={handleEndEditing}
       onBlur={onBlur}
       onLayout={onLayout}
     >

--- a/tests/mocks/components/organisms/RecipePreparation-mock.tsx
+++ b/tests/mocks/components/organisms/RecipePreparation-mock.tsx
@@ -9,27 +9,15 @@ function EditableStepMock({
   step,
   index,
   mode,
-  onTitleChange,
-  onDescriptionChange,
+  onTitleEditingEnded,
+  onDescriptionEditingEnded,
 }: {
   step: preparationStepElement;
   index: number;
   mode: 'readOnly' | 'editable' | 'add';
-  onTitleChange?: (index: number, title: string) => void;
-  onDescriptionChange?: (index: number, description: string) => void;
+  onTitleEditingEnded?: (index: number, title: string) => void;
+  onDescriptionEditingEnded?: (index: number, description: string) => void;
 }) {
-  const handleTitleChange = (newTitle: string) => {
-    if (onTitleChange) {
-      onTitleChange(index, newTitle);
-    }
-  };
-
-  const handleDescriptionChange = (newDescription: string) => {
-    if (onDescriptionChange) {
-      onDescriptionChange(index, newDescription);
-    }
-  };
-
   return (
     <View key={index}>
       {mode === 'readOnly' ? (
@@ -50,7 +38,7 @@ function EditableStepMock({
           <TextInput
             testID={`${testID}::EditableStep::${index}::TextInputTitle::CustomTextInput`}
             value={step.title}
-            onChangeText={handleTitleChange}
+            onEndEditing={e => onTitleEditingEnded?.(index, e?.nativeEvent?.text ?? step.title)}
           />
           <Text testID={`${testID}::EditableStep::${index}::Content`}>
             Content of step {index + 1} :{' '}
@@ -58,7 +46,9 @@ function EditableStepMock({
           <TextInput
             testID={`${testID}::EditableStep::${index}::TextInputContent::CustomTextInput`}
             value={step.description}
-            onChangeText={handleDescriptionChange}
+            onEndEditing={e =>
+              onDescriptionEditingEnded?.(index, e?.nativeEvent?.text ?? step.description)
+            }
           />
         </>
       )}
@@ -80,9 +70,11 @@ export function recipePreparationMock(props: RecipePreparationProps) {
           step={step}
           index={index}
           mode={mode}
-          onTitleChange={'onTitleChange' in props ? props.onTitleChange : undefined}
-          onDescriptionChange={
-            'onDescriptionChange' in props ? props.onDescriptionChange : undefined
+          onTitleEditingEnded={
+            'onTitleEditingEnded' in props ? props.onTitleEditingEnded : undefined
+          }
+          onDescriptionEditingEnded={
+            'onDescriptionEditingEnded' in props ? props.onDescriptionEditingEnded : undefined
           }
         />
       ))}

--- a/tests/unit/components/atomic/CustomTextInput.test.tsx
+++ b/tests/unit/components/atomic/CustomTextInput.test.tsx
@@ -150,4 +150,75 @@ describe('CustomTextInput', () => {
       expect(input.props.value).toBe('server-reset');
     });
   });
+
+  describe('commit-on-blur behavior', () => {
+    test('fires onEndEditing with current displayed text on endEditing', () => {
+      const onEndEditing = jest.fn();
+      const { getByTestId } = render(
+        <CustomTextInput {...baseProps} value='hello' onEndEditing={onEndEditing} />
+      );
+      const input = getByTestId('custom-input::CustomTextInput');
+
+      fireEvent.changeText(input, 'hello world');
+      fireEvent(input, 'endEditing');
+
+      expect(onEndEditing).toHaveBeenCalledWith('hello world');
+    });
+
+    test('fires onEndEditing with current text on blur', () => {
+      const onEndEditing = jest.fn();
+      const { getByTestId } = render(
+        <CustomTextInput {...baseProps} value='initial' onEndEditing={onEndEditing} />
+      );
+      const input = getByTestId('custom-input::CustomTextInput');
+
+      fireEvent.changeText(input, 'typed text');
+      fireEvent(input, 'blur');
+
+      expect(onEndEditing).toHaveBeenCalledWith('typed text');
+    });
+
+    test('does not fire onEndEditing twice when Done key fires both endEditing and blur', () => {
+      const onEndEditing = jest.fn();
+      const { getByTestId } = render(
+        <CustomTextInput {...baseProps} value='initial' onEndEditing={onEndEditing} />
+      );
+      const input = getByTestId('custom-input::CustomTextInput');
+
+      fireEvent.changeText(input, 'committed');
+      fireEvent(input, 'endEditing');
+      fireEvent(input, 'blur');
+
+      expect(onEndEditing).toHaveBeenCalledTimes(1);
+      expect(onEndEditing).toHaveBeenCalledWith('committed');
+    });
+
+    test('onChangeText still fires per-keystroke when provided', () => {
+      const onChangeText = jest.fn();
+      const { getByTestId } = render(
+        <CustomTextInput {...baseProps} onChangeText={onChangeText} />
+      );
+      const input = getByTestId('custom-input::CustomTextInput');
+
+      fireEvent.changeText(input, 'a');
+      fireEvent.changeText(input, 'ab');
+
+      expect(onChangeText).toHaveBeenCalledTimes(2);
+      expect(onChangeText).toHaveBeenNthCalledWith(1, 'a');
+      expect(onChangeText).toHaveBeenNthCalledWith(2, 'ab');
+    });
+
+    test('displayValue updates immediately regardless of onEndEditing usage', () => {
+      const onEndEditing = jest.fn();
+      const { getByTestId } = render(
+        <CustomTextInput {...baseProps} value='start' onEndEditing={onEndEditing} />
+      );
+      const input = getByTestId('custom-input::CustomTextInput');
+
+      fireEvent.changeText(input, 'typing...');
+
+      expect(input.props.value).toBe('typing...');
+      expect(onEndEditing).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/unit/components/dialogs/ItemDialog.test.tsx
+++ b/tests/unit/components/dialogs/ItemDialog.test.tsx
@@ -11,7 +11,7 @@ import {
 jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
 
 jest.mock('@components/atomic/CustomTextInput', () => ({
-  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').customTextInputMock,
+  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').CustomTextInputMock,
 }));
 
 jest.mock('@components/molecules/SelectableAccordion', () => ({

--- a/tests/unit/components/molecules/TextInputWithDropDown.test.tsx
+++ b/tests/unit/components/molecules/TextInputWithDropDown.test.tsx
@@ -22,7 +22,7 @@ MockNativeMethods.measureInWindow.mockImplementation(
 );
 
 jest.mock('@components/atomic/CustomTextInput', () => ({
-  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').customTextInputMock,
+  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').CustomTextInputMock,
 }));
 
 describe('TextInputWithDropDown Component', () => {

--- a/tests/unit/components/organisms/RecipeIngredients.test.tsx
+++ b/tests/unit/components/organisms/RecipeIngredients.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@components/atomic/NumericTextInput', () => ({
   NumericTextInput: require('@mocks/components/atomic/NumericTextInput-mock').numericTextInputMock,
 }));
 jest.mock('@components/atomic/CustomTextInput', () => ({
-  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').customTextInputMock,
+  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').CustomTextInputMock,
 }));
 jest.mock('@components/molecules/TextInputWithDropDown', () => ({
   TextInputWithDropDown: require('@mocks/components/molecules/TextInputWithDropDown-mock.tsx')

--- a/tests/unit/components/organisms/RecipePreparation.test.tsx
+++ b/tests/unit/components/organisms/RecipePreparation.test.tsx
@@ -8,7 +8,7 @@ jest.mock('@components/atomic/RoundButton', () => ({
   RoundButton: require('@mocks/components/atomic/RoundButton-mock').roundButtonMock,
 }));
 jest.mock('@components/atomic/CustomTextInput', () => ({
-  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').customTextInputMock,
+  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').CustomTextInputMock,
 }));
 
 describe('RecipePreparation Component', () => {
@@ -66,16 +66,16 @@ describe('RecipePreparation Component', () => {
   });
 
   describe('editable mode', () => {
-    const mockOnTitleChange = jest.fn();
-    const mockOnDescriptionChange = jest.fn();
+    const mockOnTitleEditingEnded = jest.fn();
+    const mockOnDescriptionEditingEnded = jest.fn();
     const mockOnAddStep = jest.fn();
 
     const editableProps: RecipePreparationProps = {
       mode: 'editable',
       steps: sampleSteps,
       prefixText: 'Preparation :',
-      onTitleChange: mockOnTitleChange,
-      onDescriptionChange: mockOnDescriptionChange,
+      onTitleEditingEnded: mockOnTitleEditingEnded,
+      onDescriptionEditingEnded: mockOnDescriptionEditingEnded,
       onAddStep: mockOnAddStep,
     };
 
@@ -133,55 +133,29 @@ describe('RecipePreparation Component', () => {
       expect(mockOnAddStep).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onTitleChange when title changes', async () => {
+    it('calls onTitleEditingEnded when title editing ends', async () => {
       const { getByTestId } = await renderRecipePreparation(editableProps);
 
       const titleInput = getByTestId(
         'RecipePreparation::EditableStep::0::TextInputTitle::CustomTextInput'
       );
-      fireEvent.changeText(titleInput, 'Updated title');
+      fireEvent(titleInput, 'endEditing', { nativeEvent: { text: 'Updated title' } });
 
-      expect(mockOnTitleChange).toHaveBeenCalledWith(0, 'Updated title');
+      expect(mockOnTitleEditingEnded).toHaveBeenCalledWith(0, 'Updated title');
     });
 
-    it('calls onDescriptionChange when description changes', async () => {
+    it('calls onDescriptionEditingEnded when description editing ends', async () => {
       const { getByTestId } = await renderRecipePreparation(editableProps);
 
       const descriptionInput = getByTestId(
         'RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput'
       );
-      fireEvent.changeText(descriptionInput, 'Updated description');
+      fireEvent(descriptionInput, 'endEditing', { nativeEvent: { text: 'Updated description' } });
 
-      expect(mockOnDescriptionChange).toHaveBeenCalledWith(0, 'Updated description');
+      expect(mockOnDescriptionEditingEnded).toHaveBeenCalledWith(0, 'Updated description');
     });
 
-    it('does not call callbacks if value unchanged', async () => {
-      const { getByTestId } = await renderRecipePreparation(editableProps);
-
-      const titleInput = getByTestId(
-        'RecipePreparation::EditableStep::0::TextInputTitle::CustomTextInput'
-      );
-
-      // Change to same value - callback should not be called
-      fireEvent.changeText(titleInput, sampleSteps[0].title);
-
-      expect(mockOnTitleChange).not.toHaveBeenCalled();
-      expect(mockOnDescriptionChange).not.toHaveBeenCalled();
-    });
-
-    it('calls callback immediately when user types', async () => {
-      const { getByTestId } = await renderRecipePreparation(editableProps);
-
-      const titleInput = getByTestId(
-        'RecipePreparation::EditableStep::0::TextInputTitle::CustomTextInput'
-      );
-      fireEvent.changeText(titleInput, 'Typing...');
-
-      // Callback should be called immediately on change
-      expect(mockOnTitleChange).toHaveBeenCalledWith(0, 'Typing...');
-    });
-
-    it('calls both callbacks when both fields are edited', async () => {
+    it('calls both callbacks independently when both fields finish editing', async () => {
       const { getByTestId } = await renderRecipePreparation(editableProps);
 
       const titleInput = getByTestId(
@@ -191,17 +165,19 @@ describe('RecipePreparation Component', () => {
         'RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput'
       );
 
-      fireEvent.changeText(titleInput, 'Modified title');
-      fireEvent.changeText(descriptionInput, 'Modified description');
+      fireEvent(titleInput, 'endEditing', { nativeEvent: { text: 'Modified title' } });
+      fireEvent(descriptionInput, 'endEditing', {
+        nativeEvent: { text: 'Modified description' },
+      });
 
-      expect(mockOnTitleChange).toHaveBeenCalledWith(0, 'Modified title');
-      expect(mockOnDescriptionChange).toHaveBeenCalledWith(0, 'Modified description');
+      expect(mockOnTitleEditingEnded).toHaveBeenCalledWith(0, 'Modified title');
+      expect(mockOnDescriptionEditingEnded).toHaveBeenCalledWith(0, 'Modified description');
     });
   });
 
   describe('add mode', () => {
-    const mockOnTitleChange = jest.fn();
-    const mockOnDescriptionChange = jest.fn();
+    const mockOnTitleEditingEnded = jest.fn();
+    const mockOnDescriptionEditingEnded = jest.fn();
     const mockOnAddStep = jest.fn();
     const mockOpenModal = jest.fn();
 
@@ -209,8 +185,8 @@ describe('RecipePreparation Component', () => {
       mode: 'add',
       steps: sampleSteps,
       prefixText: 'Preparation :',
-      onTitleChange: mockOnTitleChange,
-      onDescriptionChange: mockOnDescriptionChange,
+      onTitleEditingEnded: mockOnTitleEditingEnded,
+      onDescriptionEditingEnded: mockOnDescriptionEditingEnded,
       onAddStep: mockOnAddStep,
       openModal: mockOpenModal,
     };
@@ -219,8 +195,8 @@ describe('RecipePreparation Component', () => {
       mode: 'add',
       steps: [],
       prefixText: 'Preparation :',
-      onTitleChange: mockOnTitleChange,
-      onDescriptionChange: mockOnDescriptionChange,
+      onTitleEditingEnded: mockOnTitleEditingEnded,
+      onDescriptionEditingEnded: mockOnDescriptionEditingEnded,
       onAddStep: mockOnAddStep,
       openModal: mockOpenModal,
     };
@@ -275,16 +251,16 @@ describe('RecipePreparation Component', () => {
   });
 
   describe('prop updates', () => {
-    const mockOnTitleChange = jest.fn();
-    const mockOnDescriptionChange = jest.fn();
+    const mockOnTitleEditingEnded = jest.fn();
+    const mockOnDescriptionEditingEnded = jest.fn();
     const mockOnAddStep = jest.fn();
 
     const editableProps: RecipePreparationProps = {
       mode: 'editable',
       steps: sampleSteps,
       prefixText: 'Preparation :',
-      onTitleChange: mockOnTitleChange,
-      onDescriptionChange: mockOnDescriptionChange,
+      onTitleEditingEnded: mockOnTitleEditingEnded,
+      onDescriptionEditingEnded: mockOnDescriptionEditingEnded,
       onAddStep: mockOnAddStep,
     };
 
@@ -317,15 +293,15 @@ describe('RecipePreparation Component', () => {
         mode: 'editable',
         steps: [],
         prefixText: 'Test',
-        onTitleChange: jest.fn(),
-        onDescriptionChange: jest.fn(),
+        onTitleEditingEnded: jest.fn(),
+        onDescriptionEditingEnded: jest.fn(),
         onAddStep: jest.fn(),
       };
 
       expect(editableProps.mode).toEqual('editable');
       expect(editableProps.prefixText).toBeDefined();
-      expect(editableProps.onTitleChange).toBeDefined();
-      expect(editableProps.onDescriptionChange).toBeDefined();
+      expect(editableProps.onTitleEditingEnded).toBeDefined();
+      expect(editableProps.onDescriptionEditingEnded).toBeDefined();
       expect(editableProps.onAddStep).toBeDefined();
     });
 
@@ -334,8 +310,8 @@ describe('RecipePreparation Component', () => {
         mode: 'add',
         steps: [],
         prefixText: 'Test',
-        onTitleChange: jest.fn(),
-        onDescriptionChange: jest.fn(),
+        onTitleEditingEnded: jest.fn(),
+        onDescriptionEditingEnded: jest.fn(),
         onAddStep: jest.fn(),
         openModal: jest.fn(),
       };
@@ -352,8 +328,8 @@ describe('RecipePreparation Component', () => {
 
       expect(readOnlyProps.mode).toEqual('readOnly');
       expect('prefixText' in readOnlyProps).toBeFalsy();
-      expect('onTitleChange' in readOnlyProps).toBeFalsy();
-      expect('onDescriptionChange' in readOnlyProps).toBeFalsy();
+      expect('onTitleEditingEnded' in readOnlyProps).toBeFalsy();
+      expect('onDescriptionEditingEnded' in readOnlyProps).toBeFalsy();
     });
   });
 });

--- a/tests/unit/components/organisms/RecipeText.test.tsx
+++ b/tests/unit/components/organisms/RecipeText.test.tsx
@@ -8,7 +8,7 @@ import {
 import React from 'react';
 
 jest.mock('@components/atomic/CustomTextInput', () => ({
-  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').customTextInputMock,
+  CustomTextInput: require('@mocks/components/atomic/CustomTextInput-mock').CustomTextInputMock,
 }));
 jest.mock('@components/atomic/RoundButton', () => ({
   RoundButton: require('@mocks/components/atomic/RoundButton-mock').roundButtonMock,

--- a/tests/unit/hooks/useRecipePreparation.test.tsx
+++ b/tests/unit/hooks/useRecipePreparation.test.tsx
@@ -66,8 +66,8 @@ describe('useRecipePreparation', () => {
     loggerWarnSpy.mockRestore();
   });
 
-  describe('editPreparationTitle', () => {
-    test('updates title at valid index', async () => {
+  describe('commitPreparationTitle', () => {
+    test('updates title at valid index, preserving description', async () => {
       const wrapper = createPreparationWrapper(createMockRecipeProp('edit', recipeWithPreparation));
 
       const { result } = renderHook(
@@ -83,7 +83,7 @@ describe('useRecipePreparation', () => {
       });
 
       act(() => {
-        result.current.preparation.editPreparationTitle(1, 'Updated Step 2');
+        result.current.preparation.commitPreparationTitle(1, 'Updated Step 2');
       });
 
       expect(result.current.form.state.recipePreparation[1].title).toBe('Updated Step 2');
@@ -108,7 +108,7 @@ describe('useRecipePreparation', () => {
       });
 
       act(() => {
-        result.current.preparation.editPreparationTitle(0, 'New First Step');
+        result.current.preparation.commitPreparationTitle(0, 'New First Step');
       });
 
       expect(result.current.form.state.recipePreparation[0].title).toBe('New First Step');
@@ -120,15 +120,15 @@ describe('useRecipePreparation', () => {
       const { result } = renderHook(() => useRecipePreparation(), { wrapper });
 
       await waitFor(() => {
-        expect(result.current.editPreparationTitle).toBeDefined();
+        expect(result.current.commitPreparationTitle).toBeDefined();
       });
 
       act(() => {
-        result.current.editPreparationTitle(-1, 'Invalid');
+        result.current.commitPreparationTitle(-1, 'Invalid');
       });
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Cannot edit preparation step title - invalid index',
+        'Cannot commit preparation step title - invalid index',
         expect.objectContaining({ stepIndex: -1 })
       );
     });
@@ -139,22 +139,22 @@ describe('useRecipePreparation', () => {
       const { result } = renderHook(() => useRecipePreparation(), { wrapper });
 
       await waitFor(() => {
-        expect(result.current.editPreparationTitle).toBeDefined();
+        expect(result.current.commitPreparationTitle).toBeDefined();
       });
 
       act(() => {
-        result.current.editPreparationTitle(10, 'Invalid');
+        result.current.commitPreparationTitle(10, 'Invalid');
       });
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Cannot edit preparation step title - invalid index',
+        'Cannot commit preparation step title - invalid index',
         expect.objectContaining({ stepIndex: 10 })
       );
     });
   });
 
-  describe('editPreparationDescription', () => {
-    test('updates description at valid index', async () => {
+  describe('commitPreparationDescription', () => {
+    test('updates description at valid index, preserving title', async () => {
       const wrapper = createPreparationWrapper(createMockRecipeProp('edit', recipeWithPreparation));
 
       const { result } = renderHook(
@@ -170,7 +170,10 @@ describe('useRecipePreparation', () => {
       });
 
       act(() => {
-        result.current.preparation.editPreparationDescription(1, 'Updated description for step 2');
+        result.current.preparation.commitPreparationDescription(
+          1,
+          'Updated description for step 2'
+        );
       });
 
       expect(result.current.form.state.recipePreparation[1].description).toBe(
@@ -195,7 +198,7 @@ describe('useRecipePreparation', () => {
       });
 
       act(() => {
-        result.current.preparation.editPreparationDescription(2, 'Final step updated');
+        result.current.preparation.commitPreparationDescription(2, 'Final step updated');
       });
 
       expect(result.current.form.state.recipePreparation[2].description).toBe('Final step updated');
@@ -207,15 +210,15 @@ describe('useRecipePreparation', () => {
       const { result } = renderHook(() => useRecipePreparation(), { wrapper });
 
       await waitFor(() => {
-        expect(result.current.editPreparationDescription).toBeDefined();
+        expect(result.current.commitPreparationDescription).toBeDefined();
       });
 
       act(() => {
-        result.current.editPreparationDescription(-5, 'Invalid');
+        result.current.commitPreparationDescription(-5, 'Invalid');
       });
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Cannot edit preparation step description - invalid index',
+        'Cannot commit preparation step description - invalid index',
         expect.objectContaining({ stepIndex: -5 })
       );
     });
@@ -226,15 +229,15 @@ describe('useRecipePreparation', () => {
       const { result } = renderHook(() => useRecipePreparation(), { wrapper });
 
       await waitFor(() => {
-        expect(result.current.editPreparationDescription).toBeDefined();
+        expect(result.current.commitPreparationDescription).toBeDefined();
       });
 
       act(() => {
-        result.current.editPreparationDescription(100, 'Invalid');
+        result.current.commitPreparationDescription(100, 'Invalid');
       });
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'Cannot edit preparation step description - invalid index',
+        'Cannot commit preparation step description - invalid index',
         expect.objectContaining({ stepIndex: 100 })
       );
     });

--- a/tests/unit/screens/Recipe.test.tsx
+++ b/tests/unit/screens/Recipe.test.tsx
@@ -963,7 +963,9 @@ describe('Recipe Component tests', () => {
     const descriptionInput = getByTestId(
       'RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput'
     );
-    fireEvent.changeText(descriptionInput, newEditProp.recipe.preparation[0].description);
+    fireEvent(descriptionInput, 'endEditing', {
+      nativeEvent: { text: newEditProp.recipe.preparation[0].description },
+    });
 
     await waitFor(() => {
       checkPreparation(newEditProp, getByTestId, queryByTestId);
@@ -1041,8 +1043,9 @@ describe('Recipe Component tests', () => {
     const descriptionInput = getByTestId(
       'RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput'
     );
-    fireEvent.changeText(descriptionInput, newPropEdit.recipe.preparation[0].description);
-    fireEvent(descriptionInput, 'endEditing');
+    fireEvent(descriptionInput, 'endEditing', {
+      nativeEvent: { text: newPropEdit.recipe.preparation[0].description },
+    });
 
     await waitFor(() => {
       checkPreparation(newPropEdit, getByTestId, queryByTestId);

--- a/tests/unit/utils/RecipeFormHelpers.test.tsx
+++ b/tests/unit/utils/RecipeFormHelpers.test.tsx
@@ -1090,8 +1090,8 @@ describe('RecipeFormHelpers', () => {
 
   describe('buildRecipePreparationProps', () => {
     const mockT = (key: string) => key;
-    const mockEditTitle = jest.fn();
-    const mockEditDescription = jest.fn();
+    const mockCommitTitle = jest.fn();
+    const mockCommitDescription = jest.fn();
     const mockAddStep = jest.fn();
     const mockOpenModal = jest.fn();
     const mockSteps: preparationStepElement[] = [{ title: 'Step 1', description: 'Do something' }];
@@ -1100,8 +1100,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.readOnly,
         mockSteps,
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT
@@ -1113,8 +1113,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.edit,
         mockSteps,
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT
@@ -1126,8 +1126,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.addOCR,
         [],
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT
@@ -1139,8 +1139,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.addOCR,
         [],
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT
@@ -1155,8 +1155,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.addOCR,
         mockSteps,
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT
@@ -1168,8 +1168,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.addManual,
         mockSteps,
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT
@@ -1181,8 +1181,8 @@ describe('RecipeFormHelpers', () => {
       const result = buildRecipePreparationProps(
         recipeStateType.addScrape,
         mockSteps,
-        mockEditTitle,
-        mockEditDescription,
+        mockCommitTitle,
+        mockCommitDescription,
         mockAddStep,
         mockOpenModal,
         mockT


### PR DESCRIPTION
## Summary

- **Root cause**: `CustomTextInput` propagated `onChangeText` to the parent on every keystroke, triggering a re-render that reset the native text buffer mid-injection — causing Maestro/XCTest `typeText` to drop characters on iOS CI
- **Fix**: Input owns its text state internally (`displayValue`) and only commits to the parent on blur/`onEndEditing`, eliminating the re-render race entirely
- **Renamed semantics**: `onTitleChange`/`onDescriptionChange` → `onTitleEditingEnded`/`onDescriptionEditingEnded` and `editPreparationTitle`/`Description` → `commitPreparationTitle`/`Description` to reflect commit-not-change semantics

## Commits

- `fix(input)`: commit-on-blur in `CustomTextInput` — `onEndEditing(text)` fires on blur with deduplication (Done key fires both `endEditing` and `blur`); keyboard listener removed; `onChangeText` kept for `TextInputWithDropDown` real-time filtering
- `refactor(preparation)`: propagate pattern to `RecipePreparation`, `useRecipePreparation`, `TextInputWithDropDown`, `buildRecipePreparationProps`, `Recipe`
- `test`: update all affected tests and mocks

## Test plan

- [ ] Run `npm run test:unit` — all tests pass
- [ ] Run `npm run quality` — no lint/type errors
- [ ] Verify Maestro E2E preparation step input no longer drops characters on iOS CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)