### PR TITLE
fix: first-launch crash and infinite loading for French users

### DIFF
--- a/src/assets/datasets/fr/recipes.ts
+++ b/src/assets/datasets/fr/recipes.ts
@@ -927,8 +927,8 @@ export const frenchRecipes: recipeTableElement[] = [
       },
       {
         name: 'Sésame doré',
-        quantity: '1',
-        unit: 'c. à soupe',
+        quantity: '10',
+        unit: 'g',
         type: ingredientType.topping,
         season: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
       },

--- a/src/screens/Menu.tsx
+++ b/src/screens/Menu.tsx
@@ -104,7 +104,7 @@ export function Menu() {
         </ScrollView>
       )}
 
-      {copilotData && menu.length > 0 && (
+      {copilotData && (
         <CopilotStep text={t('tutorial.menu.description')} order={stepOrder} name={'Menu'}>
           <CopilotView
             style={{

--- a/src/screens/Shopping.tsx
+++ b/src/screens/Shopping.tsx
@@ -108,7 +108,7 @@ export function Shopping() {
       setIsDialogOpen(false);
       setIngredientDataForDialog({ name: '', recipeTitles: [] });
       isDialogOpenRef.current = false;
-    } else {
+    } else if (shoppingList.length > 2) {
       setIngredientDataForDialog(shoppingList[2]);
       setIsDialogOpen(true);
       isDialogOpenRef.current = true;

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -82,7 +82,9 @@ export function WelcomeScreen({ onStartTutorial, onSkip }: WelcomeScreenProps) {
   const { recipes } = useRecipes();
   const isDataLoaded = recipes.length > 0;
   const [datasetLoadError, setDatasetLoadError] = useState<string | undefined>(undefined);
+  const [datasetFailed, setDatasetFailed] = useState(false);
   const dismissDatasetLoadError = () => setDatasetLoadError(undefined);
+  const canProceed = isDataLoaded || datasetFailed;
 
   const [pendingAction, setPendingAction] = useState<'tutorial' | 'skip' | null>(null);
 
@@ -95,37 +97,46 @@ export function WelcomeScreen({ onStartTutorial, onSkip }: WelcomeScreenProps) {
       try {
         await loadFirstLaunchDataset();
       } catch (error) {
-        const errorMessage =
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const fullDetails =
           error instanceof Error
             ? `${error.message}${error.stack ? `\n${error.stack}` : ''}`
             : typeof error === 'object'
               ? JSON.stringify(error, null, 2)
               : String(error);
         appLogger.error('Dataset loading failed - app will work without initial data', {
-          error: errorMessage,
+          error: fullDetails,
         });
         setDatasetLoadError(errorMessage);
+        setDatasetFailed(true);
       }
     });
     return () => task.cancel();
   }, [isDataLoaded]);
 
   useEffect(() => {
-    if (isDataLoaded && pendingAction) {
+    if (canProceed && pendingAction) {
       if (pendingAction === 'tutorial') {
-        tutorialLogger.info('Data loaded - proceeding with tutorial');
+        tutorialLogger.info(
+          datasetFailed
+            ? 'Dataset failed - starting tutorial without initial data'
+            : 'Data loaded - proceeding with tutorial'
+        );
         onStartTutorial();
-        setPendingAction(null);
-      } else if (pendingAction === 'skip') {
-        tutorialLogger.info('Data loaded - proceeding to main app');
+      } else {
+        tutorialLogger.info(
+          datasetFailed
+            ? 'Dataset failed - skipping to main app'
+            : 'Data loaded - proceeding to main app'
+        );
         onSkip();
-        setPendingAction(null);
       }
+      setPendingAction(null);
     }
-  }, [isDataLoaded, pendingAction, onStartTutorial, onSkip]);
+  }, [canProceed, datasetFailed, pendingAction, onStartTutorial, onSkip]);
 
   const handleStartTutorial = () => {
-    if (isDataLoaded) {
+    if (canProceed) {
       tutorialLogger.info('User started tutorial from welcome screen');
       onStartTutorial();
     } else {
@@ -135,7 +146,7 @@ export function WelcomeScreen({ onStartTutorial, onSkip }: WelcomeScreenProps) {
   };
 
   const handleSkip = () => {
-    if (isDataLoaded) {
+    if (canProceed) {
       tutorialLogger.info('User skipped tutorial from welcome screen');
       onSkip();
     } else {
@@ -273,7 +284,7 @@ export function WelcomeScreen({ onStartTutorial, onSkip }: WelcomeScreenProps) {
         </View>
       </View>
       <LoadingOverlay
-        visible={pendingAction !== null}
+        visible={pendingAction !== null && !canProceed}
         message={t('welcome.loadingData')}
         testID={testId + '::LoadingOverlay'}
       />
@@ -288,7 +299,7 @@ export function WelcomeScreen({ onStartTutorial, onSkip }: WelcomeScreenProps) {
           <Dialog.Content>
             <Text variant='bodyMedium'>{t('welcome.datasetError.message')}</Text>
             <Text variant='bodySmall' style={{ marginTop: padding.small, opacity: 0.7 }}>
-              {t('welcome.datasetError.technicalDetails')}: {datasetLoadError}
+              {t('welcome.datasetError.reportHint')}
             </Text>
           </Dialog.Content>
           <Dialog.Actions>

--- a/src/translations/en/onboarding.ts
+++ b/src/translations/en/onboarding.ts
@@ -15,7 +15,7 @@ export default {
       title: 'Dataset Loading Issue',
       message:
         'The app encountered an issue while loading the initial recipe collection. You can still use the app normally by adding your own recipes.',
-      technicalDetails: 'Technical details',
+      reportHint: 'You can report this issue from Parameters > Bug Report.',
       understood: 'OK',
     },
   },

--- a/src/translations/fr/onboarding.ts
+++ b/src/translations/fr/onboarding.ts
@@ -15,7 +15,7 @@ export default {
       title: 'Problème de Chargement',
       message:
         "L'application a rencontré un problème lors du chargement de la collection initiale de recettes. Vous pouvez toujours utiliser l'application normalement en ajoutant vos propres recettes.",
-      technicalDetails: 'Détails techniques',
+      reportHint: 'Vous pouvez signaler ce problème depuis Paramètres > Signaler un bug.',
       understood: 'OK',
     },
   },

--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -164,26 +164,6 @@ export class RecipeDatabase {
   }
 
   /**
-   * Subscribes a callback to notifications for a specific data slice.
-   *
-   * Called by `useSyncExternalStore` to register a re-render callback. Returns
-   * an unsubscribe function that removes the callback from the listener set.
-   *
-   * @param slice - The data slice to subscribe to
-   * @param callback - Function to call when the slice changes
-   * @returns Unsubscribe function
-   */
-  public subscribe(slice: StoreSlice, callback: () => void): () => void {
-    if (!this._listeners.has(slice)) {
-      this._listeners.set(slice, new Set());
-    }
-    this._listeners.get(slice)!.add(callback);
-    return () => {
-      this._listeners.get(slice)?.delete(callback);
-    };
-  }
-
-  /**
    * Scales a recipe's ingredient quantities to a different number of persons
    *
    * Creates a new recipe object with ingredient quantities adjusted proportionally
@@ -227,6 +207,26 @@ export class RecipeDatabase {
       ...recipe,
       persons: targetPersons,
       ingredients: scaledIngredients,
+    };
+  }
+
+  /**
+   * Subscribes a callback to notifications for a specific data slice.
+   *
+   * Called by `useSyncExternalStore` to register a re-render callback. Returns
+   * an unsubscribe function that removes the callback from the listener set.
+   *
+   * @param slice - The data slice to subscribe to
+   * @param callback - Function to call when the slice changes
+   * @returns Unsubscribe function
+   */
+  public subscribe(slice: StoreSlice, callback: () => void): () => void {
+    if (!this._listeners.has(slice)) {
+      this._listeners.set(slice, new Set());
+    }
+    this._listeners.get(slice)!.add(callback);
+    return () => {
+      this._listeners.get(slice)?.delete(callback);
     };
   }
 
@@ -573,11 +573,7 @@ export class RecipeDatabase {
    * ```
    */
   public async addRecipe(rec: recipeTableElement) {
-    const recipe = { ...rec };
-    recipe.tags = this.verifyTagsExist(rec.tags);
-    recipe.ingredients = this.verifyIngredientsExist(rec.ingredients);
-
-    recipe.image_Source = await this.prepareRecipeImage(recipe.image_Source, recipe.title);
+    const recipe = await this.prepareRecipe(rec);
 
     const recipeConverted = this.encodeRecipe(recipe);
 
@@ -617,55 +613,42 @@ export class RecipeDatabase {
     }
   }
 
-  public async addMultipleRecipes(recs: recipeTableElement[]) {
+  /**
+   * Adds multiple recipes to the database, skipping any that fail validation.
+   *
+   * Prepares all recipes in parallel via `Promise.allSettled`, logs a warning
+   * for each rejected one, then batch-inserts the valid ones.
+   *
+   * @param recs - Array of recipes to add
+   */
+  public async addMultipleRecipes(recs: recipeTableElement[]): Promise<void> {
     if (recs.length === 0) return;
 
-    const processedRecipes = await Promise.all(
-      recs.map(async rec => {
-        const recipe = { ...rec };
-        recipe.tags = this.verifyTagsExist(rec.tags);
-        recipe.ingredients = this.verifyIngredientsExist(rec.ingredients);
-        recipe.image_Source = await this.prepareRecipeImage(recipe.image_Source, recipe.title);
-        return recipe;
-      })
-    );
+    const prepareRecipeResult = await Promise.allSettled(recs.map(rec => this.prepareRecipe(rec)));
 
-    const encodedRecipes = processedRecipes.map(recipe => this.encodeRecipe(recipe));
-    databaseLogger.debug('Batch adding recipes to database', {
-      count: recs.length,
+    prepareRecipeResult.forEach((result, i) => {
+      if (result.status === 'rejected') {
+        const reason =
+          result.reason instanceof Error ? result.reason.message : String(result.reason);
+        databaseLogger.warn('Skipping recipe due to validation error', {
+          recipeTitle: recs[i].title,
+          reason,
+        });
+      }
     });
 
-    const success = await this._recipesTable.insertArrayOfElement(
-      encodedRecipes,
-      this._dbConnection
-    );
+    const prepared = prepareRecipeResult
+      .filter((r): r is PromiseFulfilledResult<recipeTableElement> => r.status === 'fulfilled')
+      .map(r => r.value);
 
-    if (!success) {
-      databaseLogger.error('Failed to batch insert recipes');
-      throw new Error('Failed to insert recipes into database');
-    }
-
-    const titles = processedRecipes.map(r => r.title);
-    const searchCriteria = new Map<string, string[]>([['TITLE', titles]]);
-    const insertedRecipes = await this._recipesTable.searchElement<encodedRecipeElement>(
-      this._dbConnection,
-      searchCriteria
-    );
-
-    if (!insertedRecipes || !Array.isArray(insertedRecipes)) {
-      databaseLogger.error('Failed to retrieve inserted recipes');
+    if (prepared.length === 0) {
+      databaseLogger.warn('No valid recipes to insert after validation', {
+        totalRecipes: recs.length,
+      });
       return;
     }
 
-    const decodedRecipes = await Promise.all(
-      insertedRecipes.map(encoded => this.decodeRecipe(encoded))
-    );
-
-    for (const recipe of decodedRecipes) {
-      this.add_recipes(recipe);
-    }
-    this._recipes = [...this._recipes];
-    this.notify('recipes');
+    await this.insertAndCacheRecipes(prepared);
   }
 
   public async editRecipe(recipe: recipeTableElement) {
@@ -1225,8 +1208,6 @@ export class RecipeDatabase {
     databaseLogger.debug('Menu cleared');
   }
 
-  /* PURCHASED INGREDIENTS METHODS */
-
   /**
    * Returns the map of purchased ingredient states
    * Key is ingredient name, value is whether it's purchased
@@ -1262,6 +1243,8 @@ export class RecipeDatabase {
     this.notify('purchased');
     databaseLogger.debug('Purchase state updated', { ingredientName, purchased });
   }
+
+  /* PURCHASED INGREDIENTS METHODS */
 
   /**
    * Clears all purchased ingredient states
@@ -1646,6 +1629,67 @@ export class RecipeDatabase {
     this._importHistory = this._importHistory.filter(
       h => !(h.providerId === providerId && urls.includes(h.recipeUrl))
     );
+  }
+
+  /**
+   * Validates and prepares a single recipe for insertion.
+   *
+   * Verifies that all referenced tags and ingredients exist in the database,
+   * then resolves the image source. Throws if any references are missing.
+   *
+   * @param rec - The recipe to prepare
+   * @returns Prepared recipe ready for encoding and insertion
+   * @throws Error if any tags or ingredients are not found in the database
+   */
+  private async prepareRecipe(rec: recipeTableElement): Promise<recipeTableElement> {
+    const recipe = { ...rec };
+    recipe.tags = this.verifyTagsExist(rec.tags);
+    recipe.ingredients = this.verifyIngredientsExist(rec.ingredients);
+    recipe.image_Source = await this.prepareRecipeImage(recipe.image_Source, recipe.title);
+    return recipe;
+  }
+
+  /**
+   * Batch-inserts prepared recipes into the database and updates the in-memory cache.
+   *
+   * @param recipes - Already-validated and prepared recipes to insert
+   * @throws Error if the batch database insertion fails
+   */
+  private async insertAndCacheRecipes(recipes: recipeTableElement[]): Promise<void> {
+    const encodedRecipes = recipes.map(recipe => this.encodeRecipe(recipe));
+    databaseLogger.debug('Batch adding recipes to database', { count: recipes.length });
+
+    const success = await this._recipesTable.insertArrayOfElement(
+      encodedRecipes,
+      this._dbConnection
+    );
+
+    if (!success) {
+      databaseLogger.error('Failed to batch insert recipes');
+      throw new Error('Failed to insert recipes into database');
+    }
+
+    const titles = recipes.map(r => r.title);
+    const searchCriteria = new Map<string, string[]>([['TITLE', titles]]);
+    const insertedRecipes = await this._recipesTable.searchElement<encodedRecipeElement>(
+      this._dbConnection,
+      searchCriteria
+    );
+
+    if (!insertedRecipes || !Array.isArray(insertedRecipes)) {
+      databaseLogger.error('Failed to retrieve inserted recipes');
+      return;
+    }
+
+    const decodedRecipes = await Promise.all(
+      insertedRecipes.map(encoded => this.decodeRecipe(encoded))
+    );
+
+    for (const recipe of decodedRecipes) {
+      this.add_recipes(recipe);
+    }
+    this._recipes = [...this._recipes];
+    this.notify('recipes');
   }
 
   /**
@@ -2683,7 +2727,9 @@ export class RecipeDatabase {
    */
   private async migrateWildcardSeasons(): Promise<void> {
     const result = await this._dbConnection.runAsync(
-      `UPDATE "${ingredientsTableName}" SET "${ingredientsColumnsNames.season}" = ? WHERE "${ingredientsColumnsNames.season}" = '*'`,
+      `UPDATE "${ingredientsTableName}"
+             SET "${ingredientsColumnsNames.season}" = ?
+             WHERE "${ingredientsColumnsNames.season}" = '*'`,
       [ALL_MONTHS_ENCODED]
     );
     if (result.changes > 0) {

--- a/tests/unit/screens/Menu.test.tsx
+++ b/tests/unit/screens/Menu.test.tsx
@@ -87,16 +87,16 @@ describe('Menu Screen', () => {
       expect(queryByTestId(`${screenId}::ScrollView`)).toBeNull();
     });
 
-    test('does not render tutorial overlay when menu is empty', async () => {
+    test('renders tutorial overlay even when menu is empty', async () => {
       mockUseSafeCopilot.mockReturnValue({
         copilotEvents: {},
         currentStep: { order: 1, name: 'Menu', text: 'Menu step' },
         isActive: true,
       });
 
-      const { queryByTestId } = await renderMenuAndWait();
+      const { getByTestId } = await renderMenuAndWait();
 
-      expect(queryByTestId('CopilotStep::Menu')).toBeNull();
+      expect(getByTestId('CopilotStep::Menu')).toBeTruthy();
     });
   });
 
@@ -278,16 +278,16 @@ describe('Menu Screen', () => {
       expect(queryByTestId('CopilotStep::Menu')).toBeNull();
     });
 
-    test('does not render CopilotStep when menu is empty', async () => {
+    test('renders CopilotStep even when menu has no items', async () => {
       mockUseSafeCopilot.mockReturnValue({
         copilotEvents: {},
         currentStep: { order: 1, name: 'Menu', text: 'Menu step' },
         isActive: true,
       });
 
-      const { queryByTestId } = await renderMenuAndWait();
+      const { getByTestId } = await renderMenuAndWait();
 
-      expect(queryByTestId('CopilotStep::Menu')).toBeNull();
+      expect(getByTestId('CopilotStep::Menu')).toBeTruthy();
     });
   });
 });

--- a/tests/unit/screens/Shopping.test.tsx
+++ b/tests/unit/screens/Shopping.test.tsx
@@ -366,6 +366,23 @@ describe('Shopping Screen', () => {
       expect(mockEvents.on).not.toHaveBeenCalled();
     });
 
+    test('does not crash demo when shopping list has fewer than 3 items', async () => {
+      await database.clearMenu();
+      mockUseSafeCopilot.mockReturnValue(defaultMockValue);
+
+      const { getByTestId } = await renderShoppingAndWaitForButtons();
+
+      expect(getByTestId('CopilotStep::Shopping')).toBeTruthy();
+
+      await waitFor(() => {
+        expect(mockEvents.on).toHaveBeenCalledWith('stepChange', expect.any(Function));
+      });
+
+      expect(() => jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL)).not.toThrow();
+
+      expect(getByTestId('ShoppingScreen::Alert::IsVisible').props.children).toBe(false);
+    });
+
     test('demo toggles dialog state correctly', async () => {
       mockUseSafeCopilot.mockReturnValue(defaultMockValue);
 

--- a/tests/unit/screens/WelcomeScreen.test.tsx
+++ b/tests/unit/screens/WelcomeScreen.test.tsx
@@ -166,16 +166,17 @@ describe('WelcomeScreen Component', () => {
       expect(getByTestId('WelcomeScreen::DatasetErrorDialog::OK')).toBeTruthy();
     });
 
-    test('dataset error dialog shows the error message', async () => {
-      const errorMessage = 'Failed to load dataset: Network error';
+    test('dataset error dialog shows user-friendly message and report hint', async () => {
       const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
-      loadFirstLaunchDataset.mockRejectedValueOnce(new Error(errorMessage));
+      loadFirstLaunchDataset.mockRejectedValueOnce(new Error('Some DB error'));
 
       const { getByText } = renderWelcomeScreen();
 
       await waitFor(() => {
-        expect(getByText(new RegExp(errorMessage))).toBeTruthy();
+        expect(getByText('welcome.datasetError.message')).toBeTruthy();
       });
+
+      expect(getByText('welcome.datasetError.reportHint')).toBeTruthy();
     });
 
     test('dismissing dataset error dialog hides it', async () => {
@@ -195,39 +196,22 @@ describe('WelcomeScreen Component', () => {
       });
     });
 
-    test('formats error message without stack when Error has no stack', async () => {
+    test('does not show technical error details to user', async () => {
       const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
-      const error = new Error('no stack error');
-      error.stack = undefined;
+      const error = new Error('Ingredients not found in database: Sésame doré');
+      error.stack =
+        'Error: Ingredients not found\n    at verifyIngredientsExist (RecipeDatabase.tsx:42)';
       loadFirstLaunchDataset.mockRejectedValueOnce(error);
 
-      const { getByText } = renderWelcomeScreen();
+      const { queryByText, getByText } = renderWelcomeScreen();
 
       await waitFor(() => {
-        expect(getByText(new RegExp('no stack error'))).toBeTruthy();
+        expect(getByText('welcome.datasetError.message')).toBeTruthy();
       });
-    });
 
-    test('formats error message using JSON.stringify when error is a plain object', async () => {
-      const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
-      loadFirstLaunchDataset.mockRejectedValueOnce({ code: 404 });
-
-      const { getByText } = renderWelcomeScreen();
-
-      await waitFor(() => {
-        expect(getByText(new RegExp('"code"'))).toBeTruthy();
-      });
-    });
-
-    test('formats error message using String when error is a primitive', async () => {
-      const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
-      loadFirstLaunchDataset.mockRejectedValueOnce('some error');
-
-      const { getByText } = renderWelcomeScreen();
-
-      await waitFor(() => {
-        expect(getByText(new RegExp('some error'))).toBeTruthy();
-      });
+      expect(queryByText(/verifyIngredientsExist/)).toBeNull();
+      expect(queryByText(/RecipeDatabase\.tsx/)).toBeNull();
+      expect(queryByText(/Sésame doré/)).toBeNull();
     });
   });
 
@@ -300,6 +284,84 @@ describe('WelcomeScreen Component', () => {
       await waitFor(() => {
         expect(mockOnSkip).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe('Dataset failure recovery', () => {
+    test('calls onSkip when start tour clicked after dataset fails', async () => {
+      const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
+      loadFirstLaunchDataset.mockRejectedValueOnce(new Error('DB error'));
+
+      const { getByTestId } = renderWelcomeScreen();
+
+      await waitFor(() => {
+        expect(getByTestId('WelcomeScreen::DatasetErrorDialog')).toBeTruthy();
+      });
+
+      fireEvent.press(getByTestId('WelcomeScreen::DatasetErrorDialog::OK'));
+      fireEvent.press(getByTestId('WelcomeScreen::StartTourButton'));
+
+      expect(mockOnStartTutorial).toHaveBeenCalledTimes(1);
+      expect(mockOnSkip).not.toHaveBeenCalled();
+    });
+
+    test('calls onSkip when skip clicked after dataset fails', async () => {
+      const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
+      loadFirstLaunchDataset.mockRejectedValueOnce(new Error('DB error'));
+
+      const { getByTestId } = renderWelcomeScreen();
+
+      await waitFor(() => {
+        expect(getByTestId('WelcomeScreen::DatasetErrorDialog')).toBeTruthy();
+      });
+
+      fireEvent.press(getByTestId('WelcomeScreen::DatasetErrorDialog::OK'));
+      fireEvent.press(getByTestId('WelcomeScreen::SkipButton'));
+
+      expect(mockOnSkip).toHaveBeenCalledTimes(1);
+    });
+
+    test('proceeds with onStartTutorial when pending tutorial and dataset fails', async () => {
+      const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
+      let rejectFn: (err: Error) => void;
+      loadFirstLaunchDataset.mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectFn = reject;
+        })
+      );
+
+      const { getByTestId } = renderWelcomeScreen();
+
+      await waitFor(() => {
+        expect(getByTestId('WelcomeScreen::StartTourButton')).toBeTruthy();
+      });
+
+      fireEvent.press(getByTestId('WelcomeScreen::StartTourButton'));
+      expect(mockOnStartTutorial).not.toHaveBeenCalled();
+
+      rejectFn!(new Error('Late failure'));
+
+      await waitFor(() => {
+        expect(mockOnStartTutorial).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockOnSkip).not.toHaveBeenCalled();
+    });
+
+    test('does not show loading overlay after dataset fails', async () => {
+      const { loadFirstLaunchDataset } = require('@utils/datasetInitializer');
+      loadFirstLaunchDataset.mockRejectedValueOnce(new Error('DB error'));
+
+      const { getByTestId, queryByTestId } = renderWelcomeScreen();
+
+      await waitFor(() => {
+        expect(getByTestId('WelcomeScreen::DatasetErrorDialog')).toBeTruthy();
+      });
+
+      fireEvent.press(getByTestId('WelcomeScreen::DatasetErrorDialog::OK'));
+      fireEvent.press(getByTestId('WelcomeScreen::SkipButton'));
+
+      expect(queryByTestId('WelcomeScreen::LoadingOverlay::Overlay')).toBeNull();
     });
   });
 });

--- a/tests/unit/utils/DatasetLoader.test.tsx
+++ b/tests/unit/utils/DatasetLoader.test.tsx
@@ -12,6 +12,7 @@ import { frenchRecipes } from '@assets/datasets/fr/recipes';
 import { performanceIngredients } from '@assets/datasets/performance/ingredients';
 import { performanceTags } from '@assets/datasets/performance/tags';
 import { performanceRecipes } from '@assets/datasets/performance/recipes';
+import { isIngredientEqual } from '@customTypes/DatabaseElementTypes';
 
 describe('DatasetLoader Utility', () => {
   const originalEnv = process.env.NODE_ENV;
@@ -203,6 +204,33 @@ describe('DatasetLoader Utility', () => {
       expect(frResult.ingredients).toEqual(performanceIngredients);
       expect(enResult).toEqual(frResult);
     });
+  });
+
+  describe('dataset ingredient integrity', () => {
+    beforeEach(() => {
+      (process.env as any).NODE_ENV = 'production';
+    });
+
+    test.each(Object.keys(SUPPORTED_LANGUAGES) as SupportedLanguage[])(
+      'every recipe ingredient in %s dataset matches an ingredient in the ingredient list',
+      (lang: SupportedLanguage) => {
+        const dataset = getDataset(lang);
+        const mismatches: string[] = [];
+
+        for (const recipe of dataset.recipes) {
+          for (const recipeIng of recipe.ingredients) {
+            const found = dataset.ingredients.some(dbIng => isIngredientEqual(dbIng, recipeIng));
+            if (!found) {
+              mismatches.push(
+                `Recipe "${recipe.title}": ingredient "${recipeIng.name}" (unit: "${recipeIng.unit}") not found in ingredients list`
+              );
+            }
+          }
+        }
+
+        expect(mismatches).toEqual([]);
+      }
+    );
   });
 
   describe('regression tests', () => {

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -1733,30 +1733,48 @@ describe('RecipeDatabase', () => {
       expect(db.get_recipes().length).toBe(1);
     });
 
-    test('addMultipleRecipes throws when ingredients missing', async () => {
+    test('addMultipleRecipes skips recipes with missing ingredients and adds valid ones', async () => {
+      await db.addMultipleIngredients(testIngredients);
       await db.addMultipleTags(testTags);
 
-      const recipesWithMissingIngredients = [
-        { ...testRecipes[0], id: undefined },
-        { ...testRecipes[1], id: undefined },
-      ];
+      const recipeWithBadIngredient = {
+        ...testRecipes[0],
+        id: undefined,
+        title: 'Bad Recipe',
+        ingredients: [
+          {
+            name: 'Nonexistent Ingredient',
+            unit: 'g',
+            type: ingredientType.vegetable,
+            season: ['1'],
+            quantity: '100',
+          },
+        ],
+      };
 
-      await expect(db.addMultipleRecipes(recipesWithMissingIngredients)).rejects.toThrow(
-        /Ingredients not found in database:/
-      );
+      const validRecipe = { ...testRecipes[1], id: undefined };
+
+      await db.addMultipleRecipes([recipeWithBadIngredient, validRecipe]);
+
+      expect(db.get_recipes().length).toBe(1);
     });
 
-    test('addMultipleRecipes throws when tags missing', async () => {
+    test('addMultipleRecipes skips recipes with missing tags and adds valid ones', async () => {
       await db.addMultipleIngredients(testIngredients);
+      await db.addMultipleTags(testTags);
 
-      const recipesWithMissingTags = [
-        { ...testRecipes[0], id: undefined },
-        { ...testRecipes[1], id: undefined },
-      ];
+      const recipeWithBadTag = {
+        ...testRecipes[0],
+        id: undefined,
+        title: 'Bad Tag Recipe',
+        tags: [{ name: 'Nonexistent Tag' }],
+      };
 
-      await expect(db.addMultipleRecipes(recipesWithMissingTags)).rejects.toThrow(
-        /Tags not found in database:/
-      );
+      const validRecipe = { ...testRecipes[1], id: undefined };
+
+      await db.addMultipleRecipes([recipeWithBadTag, validRecipe]);
+
+      expect(db.get_recipes().length).toBe(1);
     });
 
     test('addMultipleRecipes succeeds when all elements exist', async () => {
@@ -1768,8 +1786,31 @@ describe('RecipeDatabase', () => {
         { ...testRecipes[1], id: undefined },
       ];
 
-      await expect(db.addMultipleRecipes(validRecipes)).resolves.not.toThrow();
+      await db.addMultipleRecipes(validRecipes);
+
       expect(db.get_recipes().length).toBe(2);
+    });
+
+    test('addMultipleRecipes returns empty skipped when all recipes fail', async () => {
+      const recipesWithNoIngredients = [
+        {
+          ...testRecipes[0],
+          id: undefined,
+          ingredients: [
+            {
+              name: 'Ghost Ingredient',
+              unit: 'g',
+              type: ingredientType.vegetable,
+              season: ['1'],
+              quantity: '1',
+            },
+          ],
+        },
+      ];
+
+      await db.addMultipleRecipes(recipesWithNoIngredients);
+
+      expect(db.get_recipes().length).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- **Data bug**: `Sésame doré` in the FR recipe dataset used unit `c. à soupe` but the ingredient master had `g` — `verifyIngredientsExist` threw on first launch, no recipes loaded, welcome screen hung forever
- **Resilient batch insert**: `addMultipleRecipes` now uses `Promise.allSettled` + skips bad recipes with a warning instead of aborting the whole batch; refactored into `prepareRecipe` / `insertAndCacheRecipes` private helpers
- **Unblocked welcome screen**: added `datasetFailed` state so `canProceed = isDataLoaded || datasetFailed` — pending actions resolve and loading overlay dismisses even on error; error dialog shows user-friendly message + Parameters > Bug Report hint instead of raw stack trace
- **Tutorial step skip fix**: `Menu` `CopilotStep` was gated on `menu.length > 0` so step 3 was never registered when data was absent, causing copilot to jump to step 4 and break the Previous button; `Shopping` demo interval now guards against empty `shoppingList` to avoid index-out-of-bounds crash

## Commits

- `fix(dataset)`: correct unit mismatch for Sésame doré in FR recipes
- `refactor(db)`: split addMultipleRecipes and make it resilient
- `fix(welcome)`: unblock app when first-launch dataset fails to load
- `fix(tutorial)`: prevent step skip and crash when initial data is empty

## Test plan

- [ ] Fresh install with French locale → app loads, no crash, no infinite spinner
- [ ] Fresh install with simulated dataset failure → error dialog appears, Explore and Jump In both work, loading overlay dismisses
- [ ] Tutorial full flow (Explore button) with and without initial data → all 5 steps reachable, Previous works on step 4
- [ ] `npm run test:unit` — all pass
- [ ] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)