### PR TITLE
feat(BugReport): migrate form to react-hook-form + zod

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
         '^@styles/(.*)$': '<rootDir>/src/styles/$1',
         '^@customTypes/(.*)$': '<rootDir>/src/customTypes/$1',
         '^@utils/(.*)$': '<rootDir>/src/utils/$1',
+        '^@schemas/(.*)$': '<rootDir>/src/schemas/$1',
         '^@hooks/(.*)$': '<rootDir>/src/hooks/$1',
         '^@providers/(.*)$': '<rootDir>/src/providers/$1',
         '^@test-data/(.*)$': '<rootDir>/tests/data/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@babel/core": "~7.28.4",
         "@expo/vector-icons": "^15.0.3",
+        "@hookform/resolvers": "5.2.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/slider": "5.1.2",
         "@react-native-ml-kit/text-recognition": "~1.5.2",
@@ -45,6 +46,7 @@
         "react": "19.2.0",
         "react-compiler-runtime": "1.0.0",
         "react-dom": "19.2.0",
+        "react-hook-form": "7.75.0",
         "react-i18next": "^15.5.1",
         "react-native": "0.83.2",
         "react-native-copilot": "3.3.3",
@@ -57,7 +59,8 @@
         "react-native-screens": "~4.23.0",
         "react-native-svg": "15.15.3",
         "react-native-webview": "13.16.1",
-        "typescript": "~5.9.2"
+        "typescript": "~5.9.2",
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@babel/preset-env": "~7.28.3",
@@ -2389,6 +2392,16 @@
         "zod": "^3.24.2"
       }
     },
+    "node_modules/@callstack/reassure-compare/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@callstack/reassure-danger": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@callstack/reassure-danger/-/reassure-danger-1.4.0.tgz",
@@ -3906,6 +3919,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@expo/cli/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
@@ -4932,6 +4954,18 @@
         "@shikijs/themes": "^3.23.0",
         "@shikijs/types": "^3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -8827,6 +8861,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@testing-library/react-native": {
       "version": "13.3.3",
@@ -13331,6 +13371,16 @@
       },
       "peerDependencies": {
         "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -26347,6 +26397,22 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
@@ -31403,9 +31469,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@babel/core": "~7.28.4",
     "@expo/vector-icons": "^15.0.3",
+    "@hookform/resolvers": "5.2.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/slider": "5.1.2",
     "@react-native-ml-kit/text-recognition": "~1.5.2",
@@ -109,6 +110,7 @@
     "react": "19.2.0",
     "react-compiler-runtime": "1.0.0",
     "react-dom": "19.2.0",
+    "react-hook-form": "7.75.0",
     "react-i18next": "^15.5.1",
     "react-native": "0.83.2",
     "react-native-copilot": "3.3.3",
@@ -121,7 +123,8 @@
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3",
     "react-native-webview": "13.16.1",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "zod": "4.4.3"
   },
   "resolutions": {
     "react": "19.2.0",

--- a/src/schemas/bugReportSchema.ts
+++ b/src/schemas/bugReportSchema.ts
@@ -1,0 +1,23 @@
+/**
+ * bugReportSchema - Zod validation schema for the bug report form
+ */
+
+import { z } from 'zod';
+
+export const bugReportSchema = z.object({
+  description: z.string().trim().min(1, 'bugReport.descriptionRequired'),
+  screenshots: z.array(z.string()).default([]),
+});
+
+/**
+ * Output type inferred from the bug report schema (post-transform).
+ * Use for the validated submit handler — `screenshots` is always `string[]`.
+ */
+export type BugReportFormData = z.infer<typeof bugReportSchema>;
+
+/**
+ * Input type inferred from the bug report schema (pre-transform).
+ * Use for `useForm` field values — `screenshots` is `string[] | undefined`
+ * because the schema supplies a default.
+ */
+export type BugReportFormInput = z.input<typeof bugReportSchema>;

--- a/src/screens/BugReport.tsx
+++ b/src/screens/BugReport.tsx
@@ -13,7 +13,7 @@
 import React, { useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
-import { Button, Snackbar } from 'react-native-paper';
+import { Button, HelperText, Snackbar } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { AppBar } from '@components/organisms/AppBar';
 import { ImageThumbnail } from '@components/molecules/ImageThumbnail';
@@ -27,6 +27,9 @@ import { smallCardWidth } from '@styles/buttons';
 import { Icons } from '@assets/Icons';
 import { CustomTextInput } from '@components/atomic/CustomTextInput';
 import { getDatasetType } from '@utils/DatasetLoader';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { bugReportSchema, BugReportFormData, BugReportFormInput } from '@schemas/bugReportSchema';
 
 const screenTestId = 'BugReport';
 
@@ -39,10 +42,21 @@ export function BugReport() {
   const { t } = useI18n();
   const { goBack } = useNavigation<StackScreenNavigation>();
 
-  const [description, setDescription] = useState('');
-  const [screenshots, setScreenshots] = useState<string[]>([]);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    getValues,
+    setValue,
+    formState: { isValid, errors },
+  } = useForm<BugReportFormInput, unknown, BugReportFormData>({
+    resolver: zodResolver(bugReportSchema),
+    defaultValues: { description: '', screenshots: [] },
+    mode: 'onChange',
+  });
 
   const showSnackbar = (message: string) => {
     setSnackbarMessage(message);
@@ -52,17 +66,20 @@ export function BugReport() {
   const handleAddScreenshots = async () => {
     try {
       const uris = await pickScreenshots();
-      setScreenshots(prev => [...prev, ...uris]);
+      setValue('screenshots', [...(getValues('screenshots') ?? []), ...uris]);
     } catch (error) {
       bugReportLogger.warn('Screenshot picker cancelled or failed', { error });
     }
   };
 
   const handleRemoveScreenshot = (uri: string) => {
-    setScreenshots(prev => prev.filter(s => s !== uri));
+    setValue(
+      'screenshots',
+      (getValues('screenshots') ?? []).filter(s => s !== uri)
+    );
   };
 
-  const handleSend = async () => {
+  const onSubmit = async (data: BugReportFormData) => {
     bugReportLogger.info('User initiated bug report submission');
     const available = await isMailAvailable();
     if (!available) {
@@ -72,7 +89,7 @@ export function BugReport() {
     }
 
     try {
-      const result = await sendBugReport(description, screenshots);
+      const result = await sendBugReport(data.description, data.screenshots);
       if (result.status === MailComposerStatus.SENT) {
         bugReportLogger.info('Bug report sent successfully');
         goBack();
@@ -95,19 +112,33 @@ export function BugReport() {
     }
   };
 
+  const screenshots = watch('screenshots') ?? [];
+
   return (
     <ScreenWrapper>
       <AppBar title={t('bugReport.title')} onGoBack={goBack} testID={screenTestId + '::Bar'} />
 
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <CustomTextInput
-          testID={screenTestId + '::Description::Input'}
-          label={t('bugReport.descriptionLabel')}
-          placeholder={t('bugReport.descriptionPlaceholder')}
-          value={description}
-          onChangeText={setDescription}
-          multiline
+        <Controller
+          control={control}
+          name='description'
+          render={({ field: { onChange, value } }) => (
+            <CustomTextInput
+              testID={screenTestId + '::Description::Input'}
+              label={t('bugReport.descriptionLabel')}
+              placeholder={t('bugReport.descriptionPlaceholder')}
+              value={value}
+              onChangeText={onChange}
+              multiline
+              error={!!errors.description}
+            />
+          )}
         />
+        {errors.description && (
+          <HelperText testID={screenTestId + '::Description::Error'} type='error'>
+            {t(errors.description.message ?? '')}
+          </HelperText>
+        )}
 
         <View style={styles.screenshotsSection}>
           <View style={styles.screenshotsThumbnails}>
@@ -137,8 +168,8 @@ export function BugReport() {
         <Button
           testID={screenTestId + '::Send::Button'}
           mode='contained'
-          onPress={handleSend}
-          disabled={description.trim().length === 0}
+          onPress={handleSubmit(onSubmit)}
+          disabled={!isValid}
           style={styles.screenshotsSection}
         >
           {t('bugReport.send')}

--- a/src/translations/en/bugReport.ts
+++ b/src/translations/en/bugReport.ts
@@ -9,4 +9,5 @@ export default {
   send: 'Send report',
   mailUnavailable: 'No email app found. Please configure an email account on your device.',
   sendError: 'Failed to open email client.',
+  descriptionRequired: 'Please describe the issue.',
 };

--- a/src/translations/fr/bugReport.ts
+++ b/src/translations/fr/bugReport.ts
@@ -10,4 +10,5 @@ export default {
   mailUnavailable:
     'Aucune application e-mail trouvée. Veuillez configurer un compte e-mail sur votre appareil.',
   sendError: "Impossible d'ouvrir le client de messagerie.",
+  descriptionRequired: 'Veuillez décrire le problème.',
 };

--- a/tests/unit/schemas/bugReportSchema.test.ts
+++ b/tests/unit/schemas/bugReportSchema.test.ts
@@ -1,0 +1,61 @@
+import { bugReportSchema } from '@schemas/bugReportSchema';
+
+describe('bugReportSchema', () => {
+  test('fails when description is empty', () => {
+    const result = bugReportSchema.safeParse({ description: '' });
+    expect(result.success).toBe(false);
+  });
+
+  test('fails when description is whitespace only', () => {
+    const result = bugReportSchema.safeParse({ description: '   ' });
+    expect(result.success).toBe(false);
+  });
+
+  test('passes with valid description', () => {
+    const result = bugReportSchema.safeParse({ description: 'App crashed on launch' });
+    expect(result.success).toBe(true);
+  });
+
+  test('trims description before validation', () => {
+    const result = bugReportSchema.safeParse({ description: '  valid  ' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBe('valid');
+    }
+  });
+
+  test('defaults screenshots to empty array when not provided', () => {
+    const result = bugReportSchema.safeParse({ description: 'bug' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.screenshots).toEqual([]);
+    }
+  });
+
+  test('passes with valid screenshots array', () => {
+    const result = bugReportSchema.safeParse({
+      description: 'bug',
+      screenshots: ['file:///screenshot1.jpg', 'file:///screenshot2.jpg'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.screenshots).toHaveLength(2);
+    }
+  });
+
+  test('fails when screenshots contains non-string values', () => {
+    const result = bugReportSchema.safeParse({
+      description: 'bug',
+      screenshots: [123, 456],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('error message key matches i18n key for empty description', () => {
+    const result = bugReportSchema.safeParse({ description: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('bugReport.descriptionRequired');
+    }
+  });
+});

--- a/tests/unit/screens/BugReport.test.tsx
+++ b/tests/unit/screens/BugReport.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { BugReport } from '@screens/BugReport';
-import { mockNavigate, mockGoBack } from '@mocks/deps/react-navigation-mock';
+import { mockGoBack } from '@mocks/deps/react-navigation-mock';
 
 jest.mock('@react-navigation/native', () =>
   require('@mocks/deps/react-navigation-mock').reactNavigationMock()
@@ -21,8 +21,18 @@ const {
 } = require('@mocks/utils/BugReport-mock');
 
 const descriptionInputTestID = 'BugReport::Description::Input::CustomTextInput';
+const descriptionErrorTestID = 'BugReport::Description::Error';
 const thumbnailTestID = 'BugReport::0::Screenshots';
 const removeButtonTestID = 'BugReport::0::Screenshots::Thumbnail::IconButton';
+
+async function typeDescription(
+  getByTestId: ReturnType<typeof render>['getByTestId'],
+  text: string
+) {
+  await act(async () => {
+    fireEvent.changeText(getByTestId(descriptionInputTestID), text);
+  });
+}
 
 describe('BugReport Screen', () => {
   const renderBugReport = () => render(<BugReport />);
@@ -61,10 +71,10 @@ describe('BugReport Screen', () => {
     expect(sendButton.props.accessibilityState.disabled).toBe(true);
   });
 
-  test('send button is enabled when description has text', () => {
+  test('send button is enabled when description has text', async () => {
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'App crashed on launch');
+    await typeDescription(getByTestId, 'App crashed on launch');
 
     const sendButton = getByTestId('BugReport::Send::Button');
     expect(sendButton.props.accessibilityState.disabled).toBe(false);
@@ -74,7 +84,7 @@ describe('BugReport Screen', () => {
     mockSendBugReport.mockResolvedValue({ status: 'sent' });
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug description');
+    await typeDescription(getByTestId, 'Test bug description');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -86,7 +96,7 @@ describe('BugReport Screen', () => {
     mockSendBugReport.mockResolvedValue({ status: 'sent' });
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -98,7 +108,7 @@ describe('BugReport Screen', () => {
     mockIsMailAvailable.mockResolvedValue(false);
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -164,7 +174,7 @@ describe('BugReport Screen', () => {
     mockSendBugReport.mockResolvedValue({ status: 'cancelled' });
     const { getByTestId, queryByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -178,7 +188,7 @@ describe('BugReport Screen', () => {
     mockSendBugReport.mockResolvedValue({ status: 'saved' });
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -191,7 +201,7 @@ describe('BugReport Screen', () => {
     mockSendBugReport.mockRejectedValue(new Error('Mail composer failed'));
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -204,7 +214,7 @@ describe('BugReport Screen', () => {
     mockIsMailAvailable.mockResolvedValue(false);
     const { getByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -221,7 +231,7 @@ describe('BugReport Screen', () => {
     mockIsMailAvailable.mockResolvedValue(false);
     const { getByTestId, queryByTestId } = renderBugReport();
 
-    fireEvent.changeText(getByTestId(descriptionInputTestID), 'Test bug');
+    await typeDescription(getByTestId, 'Test bug');
     fireEvent.press(getByTestId('BugReport::Send::Button'));
 
     await waitFor(() => {
@@ -231,5 +241,100 @@ describe('BugReport Screen', () => {
     fireEvent.press(getByTestId('BugReport::Snackbar::Dismiss'));
 
     expect(queryByTestId('BugReport::Snackbar')).toBeNull();
+  });
+
+  test('description error message is not shown initially', () => {
+    const { queryByTestId } = renderBugReport();
+
+    expect(queryByTestId(descriptionErrorTestID)).toBeNull();
+  });
+
+  test('description error message appears after typing then clearing description', async () => {
+    const { getByTestId, queryByTestId } = renderBugReport();
+
+    await typeDescription(getByTestId, 'Something');
+    await typeDescription(getByTestId, '');
+
+    expect(queryByTestId(descriptionErrorTestID)).toBeTruthy();
+    expect(getByTestId(descriptionErrorTestID).props.children).toBe(
+      'bugReport.descriptionRequired'
+    );
+  });
+
+  test('description error message disappears after re-entering valid text', async () => {
+    const { getByTestId, queryByTestId } = renderBugReport();
+
+    await typeDescription(getByTestId, 'Something');
+    await typeDescription(getByTestId, '');
+
+    expect(queryByTestId(descriptionErrorTestID)).toBeTruthy();
+
+    await typeDescription(getByTestId, 'Fixed');
+
+    expect(queryByTestId(descriptionErrorTestID)).toBeNull();
+  });
+
+  test('send button stays disabled for whitespace-only description', async () => {
+    const { getByTestId } = renderBugReport();
+
+    await typeDescription(getByTestId, '   ');
+
+    expect(getByTestId('BugReport::Send::Button').props.accessibilityState.disabled).toBe(true);
+  });
+
+  test('sendBugReport receives trimmed description', async () => {
+    mockSendBugReport.mockResolvedValue({ status: 'sent' });
+    const { getByTestId } = renderBugReport();
+
+    await typeDescription(getByTestId, '  trimmed description  ');
+    fireEvent.press(getByTestId('BugReport::Send::Button'));
+
+    await waitFor(() => {
+      expect(mockSendBugReport).toHaveBeenCalledWith('trimmed description', []);
+    });
+  });
+
+  test('multiple screenshot picks accumulate thumbnails', async () => {
+    mockPickScreenshots
+      .mockResolvedValueOnce(['file:///first.jpg'])
+      .mockResolvedValueOnce(['file:///second.jpg']);
+    const { getByTestId } = renderBugReport();
+
+    fireEvent.press(getByTestId('BugReport::Screenshots::AddButton'));
+    await waitFor(() => {
+      expect(getByTestId('BugReport::0::Screenshots')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('BugReport::Screenshots::AddButton'));
+    await waitFor(() => {
+      expect(getByTestId('BugReport::1::Screenshots')).toBeTruthy();
+    });
+  });
+
+  test('sendBugReport receives all accumulated screenshots', async () => {
+    mockSendBugReport.mockResolvedValue({ status: 'sent' });
+    mockPickScreenshots
+      .mockResolvedValueOnce(['file:///first.jpg'])
+      .mockResolvedValueOnce(['file:///second.jpg']);
+    const { getByTestId } = renderBugReport();
+
+    fireEvent.press(getByTestId('BugReport::Screenshots::AddButton'));
+    await waitFor(() => {
+      expect(getByTestId('BugReport::0::Screenshots')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('BugReport::Screenshots::AddButton'));
+    await waitFor(() => {
+      expect(getByTestId('BugReport::1::Screenshots')).toBeTruthy();
+    });
+
+    await typeDescription(getByTestId, 'Bug with screenshots');
+    fireEvent.press(getByTestId('BugReport::Send::Button'));
+
+    await waitFor(() => {
+      expect(mockSendBugReport).toHaveBeenCalledWith('Bug with screenshots', [
+        'file:///first.jpg',
+        'file:///second.jpg',
+      ]);
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
       "@utils/*": [
         "utils/*"
       ],
+      "@schemas/*": [
+        "schemas/*"
+      ],
       "@hooks/*": [
         "hooks/*"
       ],


### PR DESCRIPTION
## Summary

- Install `react-hook-form`, `@hookform/resolvers`, `zod` as first RHF+zod adoption in the project
- Add `src/schemas/bugReportSchema.ts` with zod validation + dual types (`BugReportFormInput` / `BugReportFormData`) + `@schemas/*` path alias
- Migrate `BugReport` screen to `useForm` + `Controller`, inline `HelperText` error, `formState.isValid` for button state, `watch` for reactive screenshots; add `descriptionRequired` i18n keys (en + fr); 7 new tests, `typeDescription` helper

## Commits

- `chore(deps)`: add react-hook-form, @hookform/resolvers, zod
- `feat(schemas)`: add bugReportSchema with zod + @schemas path alias
- `feat(BugReport)`: migrate form to react-hook-form + zod

## Test plan

- [ ] `npm run test:unit` passes (43 tests across schema + screen suites)
- [ ] `npm run quality` passes (lint, format, typecheck)
- [ ] Send button disabled on empty/whitespace description, enabled after valid input
- [ ] HelperText appears after typing then clearing description
- [ ] Screenshots accumulate across multiple picks; remove works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)