### PR TITLE
feat(ItemDialog): migrate form to react-hook-form + zod

### DIFF
--- a/src/components/dialogs/ItemDialog.tsx
+++ b/src/components/dialogs/ItemDialog.tsx
@@ -69,9 +69,11 @@
  * ```
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { Button, Dialog, HelperText, Portal, Text } from 'react-native-paper';
+import { Controller, Resolver, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useI18n } from '@utils/i18n';
 import { CustomTextInput } from '@components/atomic/CustomTextInput';
 import { useTags } from '@hooks/useTags';
@@ -88,6 +90,8 @@ import { SelectableAccordion } from '@components/molecules/SelectableAccordion';
 import { SeasonalityCalendar } from '@components/molecules/SeasonalityCalendar';
 import { uiLogger } from '@utils/logger';
 import { dialogMaxHeight, padding } from '@styles/spacing';
+import { ingredientDialogSchema, tagDialogSchema } from '@schemas/itemDialogSchema';
+import { buildItemFormValues, ItemDialogFormValues } from '@customTypes/ItemDialogTypes';
 
 /** Available dialog operation modes */
 export type DialogMode = 'add' | 'edit' | 'delete';
@@ -132,7 +136,6 @@ export type ItemDialogProps = {
  * @param props - The component props with operation configuration
  * @returns JSX element representing a multi-purpose item management dialog
  */
-type ValidationState = 'none' | 'duplicate' | 'similar';
 
 export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialogProps) {
   const { t } = useI18n();
@@ -140,34 +143,25 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
   const { tags } = useTags();
   const { ingredients } = useIngredients();
 
-  const [validationState, setValidationState] = useState<ValidationState>('none');
-  const [helperMessage, setHelperMessage] = useState('');
+  const isIngredient = item.type === 'Ingredient';
 
-  const [itemName, setItemName] = useState(item.value.name ?? '');
-  const [ingType, setIngType] = useState<ingredientType | undefined>(
-    item.type === 'Ingredient' ? item.value.type : undefined
-  );
-  const [ingUnit, setIngUnit] = useState(item.type === 'Ingredient' ? (item.value.unit ?? '') : '');
-  const [ingSeason, setIngSeason] = useState(
-    item.type === 'Ingredient' ? (item.value.season ?? []) : []
-  );
+  const { control, handleSubmit, watch, reset, setError, clearErrors, formState } =
+    useForm<ItemDialogFormValues>({
+      resolver: zodResolver(
+        isIngredient ? ingredientDialogSchema : tagDialogSchema
+      ) as unknown as Resolver<ItemDialogFormValues>,
+      defaultValues: buildItemFormValues(item),
+      mode: 'onChange',
+    });
 
-  // Keep a ref to the latest item so we can read it inside the effect without
-  // making it a reactive dependency. This prevents cursor-position resets that
-  // occur when callers pass new inline object references on every render.
-  const itemRef = useRef(item);
-  itemRef.current = item;
-
+  // item intentionally excluded from deps — avoids mid-edit resets when caller
+  // passes new inline object references on every render.
   useEffect(() => {
-    if (isVisible) {
-      setItemName(itemRef.current.value.name ?? '');
-      if (itemRef.current.type === 'Ingredient') {
-        setIngType(itemRef.current.value.type);
-        setIngUnit(itemRef.current.value.unit ?? '');
-        setIngSeason(itemRef.current.value.season ?? []);
-      }
-    }
+    if (isVisible) reset(buildItemFormValues(item));
   }, [isVisible]);
+
+  const nameValue = watch('name');
+  const [similarNames, setSimilarNames] = useState('');
 
   /**
    * Validates item name against database for duplicates and similar items.
@@ -183,17 +177,12 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
    */
   useEffect(() => {
     if (!isVisible || mode === 'delete') {
-      setValidationState('none');
-      setHelperMessage('');
+      clearErrors('name');
       return;
     }
 
-    const trimmedName = itemName.trim();
-    if (!trimmedName) {
-      setValidationState('none');
-      setHelperMessage('');
-      return;
-    }
+    const trimmedName = nameValue.trim();
+    if (!trimmedName) return;
 
     const timeoutId = setTimeout(() => {
       const messageKeys =
@@ -203,7 +192,12 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
 
       const result =
         item.type === 'Tag'
-          ? fuzzySearch<tagTableElement>(tags, trimmedName, t => t.name, FuzzyMatchLevel.MODERATE)
+          ? fuzzySearch<tagTableElement>(
+              tags,
+              trimmedName,
+              tag => tag.name,
+              FuzzyMatchLevel.MODERATE
+            )
           : fuzzySearch<ingredientTableElement>(
               ingredients,
               cleanIngredientName(trimmedName),
@@ -214,11 +208,9 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
       if (result.exact) {
         const isSameElement = item.value.id !== undefined && result.exact.id === item.value.id;
         if (isSameElement) {
-          setValidationState('none');
-          setHelperMessage('');
+          clearErrors('name');
         } else {
-          setValidationState('duplicate');
-          setHelperMessage(t(messageKeys.duplicate));
+          setError('name', { type: 'duplicate', message: messageKeys.duplicate });
         }
       } else {
         const otherSimilar = result.similar.filter(
@@ -226,51 +218,62 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
         );
 
         if (otherSimilar.length > 0) {
-          const names = otherSimilar.map(similarItem => similarItem.name).join(', ');
-          setValidationState('similar');
-          setHelperMessage(`${t(messageKeys.similar)}: ${names}`);
+          setSimilarNames(otherSimilar.map(similarItem => similarItem.name).join(', '));
+          setError('name', { type: 'similar', message: messageKeys.similar });
         } else {
-          setValidationState('none');
-          setHelperMessage('');
+          clearErrors('name');
         }
       }
     }, 300);
 
     return () => clearTimeout(timeoutId);
-  }, [itemName, item.type, item.value.id, isVisible, mode, tags, ingredients, t]);
+  }, [nameValue, item.type, item.value.id, isVisible, mode, tags, ingredients, t]);
 
-  const handleConfirm = () => {
-    callOnConfirmWithNewItem();
-    onClose();
-  };
+  const typeValue = watch('type');
 
-  const callOnConfirmWithNewItem = () => {
+  const isConfirmDisabled =
+    mode !== 'delete' &&
+    (!nameValue.trim() ||
+      (isIngredient && typeValue === undefined) ||
+      formState.errors.name?.type === 'duplicate');
+
+  const onSubmit = (data: ItemDialogFormValues) => {
     switch (item.type) {
       case 'Ingredient':
         item.onConfirmIngredient(mode, {
           id: item.value.id,
-          name: itemName,
-          type: ingType as ingredientType,
-          unit: ingUnit,
-          season: ingSeason,
+          name: data.name,
+          type: data.type as ingredientType,
+          unit: data.unit,
+          season: data.season,
         });
         break;
       case 'Tag':
-        item.onConfirmTag(mode, { id: item.value.id, name: itemName });
+        item.onConfirmTag(mode, { id: item.value.id, name: data.name });
         break;
       default:
         uiLogger.error('Unreachable code in ItemDialog');
     }
+    onClose();
   };
 
-  const isConfirmDisabled =
-    !itemName.trim() ||
-    (mode !== 'delete' &&
-      (validationState === 'duplicate' || (item.type === 'Ingredient' && ingType === undefined)));
+  const handleDeleteConfirm = () => {
+    switch (item.type) {
+      case 'Ingredient':
+        item.onConfirmIngredient(mode, item.value as ingredientTableElement);
+        break;
+      case 'Tag':
+        item.onConfirmTag(mode, item.value as tagTableElement);
+        break;
+      default:
+        uiLogger.error('Unreachable code in ItemDialog');
+    }
+    onClose();
+  };
 
   const titleByMode: Record<DialogMode, string> = {
-    add: item.type === 'Ingredient' ? t('add_ingredient') : t('add_tag'),
-    edit: item.type === 'Ingredient' ? t('edit_ingredient') : t('edit_tag'),
+    add: isIngredient ? t('add_ingredient') : t('add_tag'),
+    edit: isIngredient ? t('edit_ingredient') : t('edit_tag'),
     delete: t('delete'),
   };
 
@@ -298,59 +301,88 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
           <Dialog.Content>
             <Text testID={modalTestId + '::Text'} variant='bodyMedium'>
               {t('confirmDelete')}
-              {` ${itemName}${t('interrogationMark')}`}
+              {` ${nameValue}${t('interrogationMark')}`}
             </Text>
           </Dialog.Content>
         ) : (
           <Dialog.ScrollArea>
             <ScrollView contentContainerStyle={styles.formContainer}>
-              {item.type === 'Ingredient' ? (
+              {isIngredient ? (
                 <Text testID={modalTestId + '::FormHint'} variant='bodySmall'>
                   {t('ingredient_form_hint')}
                 </Text>
               ) : null}
-              <CustomTextInput
-                label={item.type === 'Ingredient' ? t('ingredient_name') : t('tag_name')}
-                value={itemName}
-                onChangeText={setItemName}
-                testID={modalTestId + '::Name'}
-                error={validationState === 'duplicate'}
-                dense={true}
-                style={styles.nameInput}
+              <Controller
+                control={control}
+                name='name'
+                render={({ field: { onChange, value } }) => (
+                  <CustomTextInput
+                    label={isIngredient ? t('ingredient_name') : t('tag_name')}
+                    value={value}
+                    onChangeText={onChange}
+                    testID={modalTestId + '::Name'}
+                    error={
+                      formState.errors.name?.type === 'duplicate' ||
+                      formState.errors.name?.type === 'too_small'
+                    }
+                    dense={true}
+                    style={styles.nameInput}
+                  />
+                )}
               />
-              {validationState !== 'none' && (
+              {formState.errors.name && (
                 <HelperText
-                  type={validationState === 'duplicate' ? 'error' : 'info'}
+                  type={formState.errors.name.type === 'similar' ? 'info' : 'error'}
                   testID={modalTestId + '::HelperText'}
                 >
-                  {helperMessage}
+                  {formState.errors.name.type === 'similar'
+                    ? `${t(formState.errors.name.message ?? '')}: ${similarNames}`
+                    : t(formState.errors.name.message ?? '')}
                 </HelperText>
               )}
 
-              {item.type === 'Ingredient' ? (
+              {isIngredient ? (
                 <>
-                  <CustomTextInput
-                    testID={modalTestId + '::Unit'}
-                    label={t('unit')}
-                    value={ingUnit}
-                    onChangeText={setIngUnit}
-                    dense={true}
-                    style={styles.unitInput}
+                  <Controller
+                    control={control}
+                    name='unit'
+                    render={({ field: { onChange, value } }) => (
+                      <CustomTextInput
+                        testID={modalTestId + '::Unit'}
+                        label={t('unit')}
+                        value={value}
+                        onChangeText={onChange}
+                        dense={true}
+                        style={styles.unitInput}
+                      />
+                    )}
                   />
-                  <SelectableAccordion
-                    testID={modalTestId + '::TypeAccordion'}
-                    title={t('type')}
-                    items={shoppingCategories.map(category => ({
-                      value: category,
-                      label: t(category),
-                    }))}
-                    selectedValues={ingType ? [ingType] : []}
-                    onPress={value => setIngType(value as ingredientType)}
+                  <Controller
+                    control={control}
+                    name='type'
+                    render={({ field: { onChange, value } }) => (
+                      <SelectableAccordion
+                        testID={modalTestId + '::TypeAccordion'}
+                        title={t('type')}
+                        items={shoppingCategories.map(category => ({
+                          value: category,
+                          label: t(category),
+                        }))}
+                        selectedValues={value ? [value] : []}
+                        onPress={val => onChange(val as ingredientType)}
+                      />
+                    )}
                   />
-                  <SeasonalityCalendar
-                    testID={modalTestId}
-                    selectedMonths={ingSeason}
-                    onMonthsChange={setIngSeason}
+                  <Controller
+                    control={control}
+                    name='season'
+                    render={({ field: { onChange, value } }) => (
+                      <SeasonalityCalendar
+                        testID={modalTestId}
+                        selectedMonths={value ?? []}
+                        onMonthsChange={onChange}
+                      />
+                    )}
                   />
                 </>
               ) : null}
@@ -365,7 +397,7 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
             <Button
               testID={modalTestId + '::ConfirmButton'}
               mode='contained'
-              onPress={handleConfirm}
+              onPress={mode === 'delete' ? handleDeleteConfirm : handleSubmit(onSubmit)}
               disabled={isConfirmDisabled}
             >
               {confirmButtonText}

--- a/src/customTypes/ItemDialogTypes.ts
+++ b/src/customTypes/ItemDialogTypes.ts
@@ -1,0 +1,53 @@
+/**
+ * ItemDialogTypes - Types and utilities for the ItemDialog form
+ *
+ * Centralises the RHF form value type and the helper that builds default
+ * values from the dialog's item prop, so the logic is reusable and testable
+ * independently of the component.
+ */
+
+import {
+  FormIngredientElement,
+  ingredientType,
+  tagTableElement,
+} from '@customTypes/DatabaseElementTypes';
+
+/**
+ * Minimal structural type covering both item configurations accepted by the dialog.
+ * Avoids importing the full ItemIngredientType / ItemTagType (which include callbacks)
+ * to prevent a circular dependency with the component file.
+ */
+type ItemProp =
+  | { type: 'Ingredient'; value: FormIngredientElement }
+  | { type: 'Tag'; value: tagTableElement };
+
+/**
+ * Unified RHF form value shape covering both Tag and Ingredient dialogs.
+ * Ingredient-only fields are `undefined` when the dialog is used for a tag.
+ */
+export type ItemDialogFormValues = {
+  name: string;
+  /** Required for ingredients; undefined for tags. */
+  type: ingredientType | undefined;
+  /** Empty string when not applicable (tags) or not yet filled in. */
+  unit: string;
+  /** Empty array when not applicable (tags) or not yet filled in. */
+  season: string[];
+};
+
+/**
+ * Builds the initial RHF form values from the dialog's item prop.
+ * Ingredient fields default to empty / undefined when not yet filled in.
+ *
+ * @param item - The item configuration passed to ItemDialog
+ * @returns Form values ready to be passed to `useForm({ defaultValues })` or `reset()`
+ */
+export function buildItemFormValues(item: ItemProp): ItemDialogFormValues {
+  const ing = item.type === 'Ingredient' ? (item.value as FormIngredientElement) : null;
+  return {
+    name: item.value.name ?? '',
+    type: ing?.type,
+    unit: ing?.unit ?? '',
+    season: ing?.season ?? [],
+  };
+}

--- a/src/schemas/itemDialogSchema.ts
+++ b/src/schemas/itemDialogSchema.ts
@@ -1,0 +1,19 @@
+/**
+ * itemDialogSchema - Zod validation schemas for the ItemDialog form
+ */
+
+import { z } from 'zod';
+import { ingredientType } from '@customTypes/DatabaseElementTypes';
+
+const nameField = z.string().trim().min(1, 'name_required');
+
+export const tagDialogSchema = z.object({
+  name: nameField,
+});
+
+export const ingredientDialogSchema = z.object({
+  name: nameField,
+  type: z.nativeEnum(ingredientType),
+  unit: z.string().default(''),
+  season: z.array(z.string()).default([]),
+});

--- a/src/screens/IngredientsSettings.tsx
+++ b/src/screens/IngredientsSettings.tsx
@@ -162,18 +162,19 @@ export function IngredientsSettings() {
         label={t('add_ingredient')}
       />
 
-      {/* Dialog for add/edit/delete operations */}
-      <ItemDialog
-        isVisible={isDialogOpen}
-        onClose={closeDialog}
-        testId={testId + '::ItemDialog'}
-        mode={dialogMode}
-        item={{
-          type: 'Ingredient',
-          value: getDialogIngredientValue(),
-          onConfirmIngredient: handleDialogConfirm,
-        }}
-      />
+      {isDialogOpen && (
+        <ItemDialog
+          isVisible={isDialogOpen}
+          onClose={closeDialog}
+          testId={testId + '::ItemDialog'}
+          mode={dialogMode}
+          item={{
+            type: 'Ingredient',
+            value: getDialogIngredientValue(),
+            onConfirmIngredient: handleDialogConfirm,
+          }}
+        />
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/screens/TagsSettings.tsx
+++ b/src/screens/TagsSettings.tsx
@@ -145,18 +145,19 @@ export function TagsSettings() {
         label={t('add_tag')}
       />
 
-      {/* ItemDialog for add/edit/delete operations */}
-      <ItemDialog
-        testId={testId + '::ItemDialog'}
-        isVisible={dialogVisible}
-        mode={dialogMode}
-        onClose={closeDialog}
-        item={{
-          type: 'Tag',
-          value: currentTag,
-          onConfirmTag: handleDialogConfirm,
-        }}
-      />
+      {dialogVisible && (
+        <ItemDialog
+          testId={testId + '::ItemDialog'}
+          isVisible={dialogVisible}
+          mode={dialogMode}
+          onClose={closeDialog}
+          item={{
+            type: 'Tag',
+            value: currentTag,
+            onConfirmTag: handleDialogConfirm,
+          }}
+        />
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/translations/en/parameters.ts
+++ b/src/translations/en/parameters.ts
@@ -27,4 +27,5 @@ export default {
   search_items: 'Search...',
   ingredient_form_hint:
     'Name and type are required. The more details you provide, the better your experience.',
+  name_required: 'Name is required.',
 };

--- a/src/translations/fr/parameters.ts
+++ b/src/translations/fr/parameters.ts
@@ -27,4 +27,5 @@ export default {
   search_items: 'Rechercher...',
   ingredient_form_hint:
     'Le nom et le type sont requis. Plus vous renseignez de détails, meilleure sera votre expérience.',
+  name_required: 'Le nom est requis.',
 };

--- a/tests/e2e/asserts/parameters/bugReport/en/assertDescriptionRequiredError.yaml
+++ b/tests/e2e/asserts/parameters/bugReport/en/assertDescriptionRequiredError.yaml
@@ -1,0 +1,11 @@
+appId: "com.recipedia"
+---
+- assertVisible:
+    id: "BugReport::Description::Error"
+    text: "Please describe the issue."
+    label: "Description required error is displayed"
+
+- assertVisible:
+    id: "BugReport::Send::Button"
+    enabled: false
+    label: "Send button is disabled when description is empty"

--- a/tests/e2e/cases/ingredients-db/5_edge_cases.yaml
+++ b/tests/e2e/cases/ingredients-db/5_edge_cases.yaml
@@ -25,5 +25,9 @@ tags:
     label: "Action - Test canceling delete operation"
 
 - runFlow:
+    file: "../../flows/parameters/ingredients/assertNameRequiredError.yaml"
+    label: "Action - Assert name required error on blur"
+
+- runFlow:
     file: "../../flows/parameters/ingredients/insertTextAtCursorBeginning.yaml"
     label: "Action - Test cursor position preservation on re-render"

--- a/tests/e2e/cases/settings/5_bug_report.yaml
+++ b/tests/e2e/cases/settings/5_bug_report.yaml
@@ -46,6 +46,31 @@ tags:
 
 - tapOn:
     id: "BugReport::Description::Input::CustomTextInput"
+    label: "Action - Focus description input to trigger validation"
+
+- runFlow:
+    file: "../../flows/waitForKeyboard.yaml"
+    label: "Wait for keyboard to appear"
+
+- inputText: "test"
+
+- eraseText:
+    label: "Action - Clear description input"
+
+- tapOn:
+    id: "BugReport::Screenshots::AddButton"
+    label: "Action - Tap add screenshot to dismiss keyboard"
+
+- runFlow:
+    file: "../../flows/waitForKeyboardDismiss.yaml"
+    label: "Wait for keyboard to dismiss"
+
+- runFlow:
+    file: "../../asserts/parameters/bugReport/en/assertDescriptionRequiredError.yaml"
+    label: "Assert - Description required error shown after clearing field"
+
+- tapOn:
+    id: "BugReport::Description::Input::CustomTextInput"
     label: "Action - Focus description input"
 
 - runFlow:

--- a/tests/e2e/cases/tags-db/5_edge_cases.yaml
+++ b/tests/e2e/cases/tags-db/5_edge_cases.yaml
@@ -25,5 +25,9 @@ tags:
     label: "Action - Test canceling delete operation"
 
 - runFlow:
+    file: "../../flows/parameters/tags/assertNameRequiredError.yaml"
+    label: "Action - Assert name required error on blur"
+
+- runFlow:
     file: "../../flows/parameters/tags/insertTextAtCursorBeginning.yaml"
     label: "Action - Test cursor position preservation on re-render"

--- a/tests/e2e/flows/parameters/ingredients/assertNameRequiredError.yaml
+++ b/tests/e2e/flows/parameters/ingredients/assertNameRequiredError.yaml
@@ -18,6 +18,12 @@ appId: "com.recipedia"
     file: "../../waitForKeyboard.yaml"
     label: "Wait for keyboard to appear"
 
+- inputText:
+    text: "A name"
+    label: "Enter a name in the ingredient input field"
+
+- eraseText
+
 - runFlow:
     when:
       platform: Android

--- a/tests/e2e/flows/parameters/ingredients/assertNameRequiredError.yaml
+++ b/tests/e2e/flows/parameters/ingredients/assertNameRequiredError.yaml
@@ -1,0 +1,68 @@
+appId: "com.recipedia"
+---
+- tapOn:
+    id: "IngredientsSettings::BottomActionButton"
+    label: "Open Add ingredient dialog"
+
+- extendedWaitUntil:
+    visible:
+      id: "IngredientsSettings::ItemDialog::AddModal::Title"
+    timeout: 20000
+    label: "Wait for Add ingredient modal to appear"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::Name::CustomTextInput"
+    label: "Focus on ingredient name input"
+
+- runFlow:
+    file: "../../waitForKeyboard.yaml"
+    label: "Wait for keyboard to appear"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard:
+          label: "Dismiss keyboard on Android"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "Done"
+          label: "Tap Done key to dismiss keyboard on iOS"
+
+- runFlow:
+    file: "../../waitForKeyboardDismiss.yaml"
+    label: "Wait for keyboard to dismiss"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::FormHint"
+    label: "Tap form hint to blur the name input"
+
+- extendedWaitUntil:
+    visible:
+      id: "IngredientsSettings::ItemDialog::AddModal::HelperText"
+    timeout: 5000
+    label: "Wait for required error to appear"
+
+- assertVisible:
+    id: "IngredientsSettings::ItemDialog::AddModal::HelperText"
+    text: "Name is required."
+    label: "Verify Name is required error appears"
+
+- assertVisible:
+    id: "IngredientsSettings::ItemDialog::AddModal::ConfirmButton"
+    enabled: false
+    label: "Verify Confirm button is disabled"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::CancelButton"
+    label: "Cancel the dialog"
+
+- extendedWaitUntil:
+    notVisible:
+      id: "IngredientsSettings::ItemDialog::AddModal::Title"
+    timeout: 20000
+    label: "Wait for modal to dismiss"

--- a/tests/e2e/flows/parameters/tags/assertNameRequiredError.yaml
+++ b/tests/e2e/flows/parameters/tags/assertNameRequiredError.yaml
@@ -18,6 +18,12 @@ appId: "com.recipedia"
     file: "../../waitForKeyboard.yaml"
     label: "Wait for keyboard to appear"
 
+- inputText:
+    text: "A name"
+    label: "Enter a name in the tag input field"
+
+- eraseText
+
 - runFlow:
     when:
       platform: Android

--- a/tests/e2e/flows/parameters/tags/assertNameRequiredError.yaml
+++ b/tests/e2e/flows/parameters/tags/assertNameRequiredError.yaml
@@ -1,0 +1,68 @@
+appId: "com.recipedia"
+---
+- tapOn:
+    id: "TagsSettings::BottomActionButton"
+    label: "Open Add tag dialog"
+
+- extendedWaitUntil:
+    visible:
+      id: "TagsSettings::ItemDialog::AddModal::Title"
+    timeout: 20000
+    label: "Wait for Add tag modal to appear"
+
+- tapOn:
+    id: "TagsSettings::ItemDialog::AddModal::Name::CustomTextInput"
+    label: "Focus on tag name input"
+
+- runFlow:
+    file: "../../waitForKeyboard.yaml"
+    label: "Wait for keyboard to appear"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard:
+          label: "Dismiss keyboard on Android"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "Done"
+          label: "Tap Done key to dismiss keyboard on iOS"
+
+- runFlow:
+    file: "../../waitForKeyboardDismiss.yaml"
+    label: "Wait for keyboard to dismiss"
+
+- tapOn:
+    id: "TagsSettings::ItemDialog::AddModal::Title"
+    label: "Tap dialog title to blur the name input"
+
+- extendedWaitUntil:
+    visible:
+      id: "TagsSettings::ItemDialog::AddModal::HelperText"
+    timeout: 5000
+    label: "Wait for required error to appear"
+
+- assertVisible:
+    id: "TagsSettings::ItemDialog::AddModal::HelperText"
+    text: "Name is required."
+    label: "Verify Name is required error appears"
+
+- assertVisible:
+    id: "TagsSettings::ItemDialog::AddModal::ConfirmButton"
+    enabled: false
+    label: "Verify Confirm button is disabled"
+
+- tapOn:
+    id: "TagsSettings::ItemDialog::AddModal::CancelButton"
+    label: "Cancel the dialog"
+
+- extendedWaitUntil:
+    notVisible:
+      id: "TagsSettings::ItemDialog::AddModal::Title"
+    timeout: 20000
+    label: "Wait for modal to dismiss"

--- a/tests/mocks/components/atomic/CustomTextInput-mock.tsx
+++ b/tests/mocks/components/atomic/CustomTextInput-mock.tsx
@@ -1,5 +1,6 @@
 import {
   NativeSyntheticEvent,
+  Text,
   TextInput,
   TextInputEndEditingEventData,
   TextStyle,
@@ -14,6 +15,7 @@ export function CustomTextInputMock({
   value,
   multiline = false,
   style,
+  error,
   onFocus,
   onChangeText,
   onEndEditing,
@@ -39,19 +41,22 @@ export function CustomTextInputMock({
   }
 
   return (
-    <TextInput
-      testID={testID + '::CustomTextInput'}
-      style={style as TextStyle}
-      editable={editable}
-      value={displayValue}
-      multiline={multiline}
-      onFocus={onFocus}
-      onChangeText={handleChangeText}
-      onEndEditing={handleEndEditing}
-      onBlur={onBlur}
-      onLayout={onLayout}
-    >
-      {label}
-    </TextInput>
+    <>
+      <TextInput
+        testID={testID + '::CustomTextInput'}
+        style={style as TextStyle}
+        editable={editable}
+        value={displayValue}
+        multiline={multiline}
+        onFocus={onFocus}
+        onChangeText={handleChangeText}
+        onEndEditing={handleEndEditing}
+        onBlur={onBlur}
+        onLayout={onLayout}
+      >
+        {label}
+      </TextInput>
+      {error !== undefined && <Text testID={testID + '::error'}>{String(error)}</Text>}
+    </>
   );
 }

--- a/tests/unit/components/dialogs/ItemDialog.test.tsx
+++ b/tests/unit/components/dialogs/ItemDialog.test.tsx
@@ -181,17 +181,21 @@ describe('ItemDialog Component', () => {
       });
     });
     describe('calls onConfirm when confirm button is pressed in ', () => {
-      test('add mode', () => {
+      test('add mode', async () => {
         const { getByTestId } = render(<ItemDialog {...props} />);
 
-        fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+        await act(async () => {
+          fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+        });
 
         expect(mockOnConfirmIngredient).toHaveBeenCalled();
       });
-      test('edit mode', () => {
+      test('edit mode', async () => {
         const { getByTestId } = render(<ItemDialog {...props} mode={'edit'} />);
 
-        fireEvent.press(getByTestId('IngredientDialog::EditModal::ConfirmButton'));
+        await act(async () => {
+          fireEvent.press(getByTestId('IngredientDialog::EditModal::ConfirmButton'));
+        });
 
         expect(mockOnConfirmIngredient).toHaveBeenCalled();
       });
@@ -294,17 +298,21 @@ describe('ItemDialog Component', () => {
     });
 
     describe('calls onConfirm when confirm button is pressed in ', () => {
-      test('add mode', () => {
+      test('add mode', async () => {
         const { getByTestId } = render(<ItemDialog {...props} />);
 
-        fireEvent.press(getByTestId('TagDialog::AddModal::ConfirmButton'));
+        await act(async () => {
+          fireEvent.press(getByTestId('TagDialog::AddModal::ConfirmButton'));
+        });
 
         expect(mockOnConfirmTag).toHaveBeenCalledWith('add', mockTag);
       });
-      test('edit mode', () => {
+      test('edit mode', async () => {
         const { getByTestId } = render(<ItemDialog {...props} mode={'edit'} />);
 
-        fireEvent.press(getByTestId('TagDialog::EditModal::ConfirmButton'));
+        await act(async () => {
+          fireEvent.press(getByTestId('TagDialog::EditModal::ConfirmButton'));
+        });
 
         expect(mockOnConfirmTag).toHaveBeenCalledWith('edit', mockTag);
       });
@@ -317,7 +325,7 @@ describe('ItemDialog Component', () => {
       });
     });
 
-    describe('calls onClose when confirm button is pressed in ', () => {
+    describe('calls onClose when cancel button is pressed in ', () => {
       test('add mode', () => {
         const { getByTestId } = render(<ItemDialog {...props} />);
 
@@ -362,7 +370,7 @@ describe('ItemDialog Component', () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  test('calls onConfirmIngredient when confirm button is pressed in add mode', () => {
+  test('calls onConfirmIngredient when confirm button is pressed in add mode', async () => {
     const props: ItemDialogProps = {
       testId: 'IngredientDialog',
       mode: 'add',
@@ -377,12 +385,14 @@ describe('ItemDialog Component', () => {
 
     const { getByTestId } = render(<ItemDialog {...props} />);
 
-    fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+    await act(async () => {
+      fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+    });
 
     expect(mockOnConfirmIngredient).toHaveBeenCalledWith('add', mockIngredient);
   });
 
-  test('calls onConfirmIngredient when confirm button is pressed in edit mode', () => {
+  test('calls onConfirmIngredient when confirm button is pressed in edit mode', async () => {
     const props: ItemDialogProps = {
       testId: 'IngredientDialog',
       mode: 'edit',
@@ -397,7 +407,9 @@ describe('ItemDialog Component', () => {
 
     const { getByTestId } = render(<ItemDialog {...props} />);
 
-    fireEvent.press(getByTestId('IngredientDialog::EditModal::ConfirmButton'));
+    await act(async () => {
+      fireEvent.press(getByTestId('IngredientDialog::EditModal::ConfirmButton'));
+    });
 
     expect(mockOnConfirmIngredient).toHaveBeenCalledWith('edit', mockIngredient);
   });
@@ -504,7 +516,7 @@ describe('ItemDialog Component', () => {
       ).toBe(false);
     });
 
-    test('passes empty unit to onConfirmIngredient callback', () => {
+    test('passes empty unit to onConfirmIngredient callback', async () => {
       const ingredientWithoutUnit: ingredientTableElement = {
         id: 1,
         name: 'Salt',
@@ -527,7 +539,9 @@ describe('ItemDialog Component', () => {
 
       const { getByTestId } = render(<ItemDialog {...props} />);
 
-      fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+      });
 
       expect(mockOnConfirmIngredient).toHaveBeenCalledWith('add', ingredientWithoutUnit);
     });
@@ -584,6 +598,51 @@ describe('ItemDialog Component', () => {
       expect(
         getByTestId('IngredientDialog::AddModal::ConfirmButton').props.accessibilityState.disabled
       ).toBe(false);
+    });
+
+    test('disables confirm button when ingredient name is whitespace only', () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: '   ', type: ingredientType.fruit, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      expect(
+        getByTestId('IngredientDialog::AddModal::ConfirmButton').props.accessibilityState.disabled
+      ).toBe(true);
+    });
+
+    test('trims ingredient name before passing to onConfirmIngredient', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: '  Flour  ', type: ingredientType.cereal, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+      });
+
+      expect(mockOnConfirmIngredient).toHaveBeenCalledWith(
+        'add',
+        expect.objectContaining({ name: 'Flour' })
+      );
     });
 
     test('enables confirm button in delete mode regardless of type or unit', () => {
@@ -810,6 +869,37 @@ describe('ItemDialog Component', () => {
         'pieces'
       );
     });
+
+    test('clears duplicate error when dialog closes and reopens', async () => {
+      const existingTag: tagTableElement = { id: 99, name: 'Italian' };
+      setMockTags([existingTag]);
+
+      const props: ItemDialogProps = {
+        testId: 'TagDialog',
+        mode: 'add',
+        isVisible: true,
+        onClose: mockOnClose,
+        item: { type: 'Tag', value: { name: 'Italian' }, onConfirmTag: mockOnConfirmTag },
+      };
+
+      const { getByTestId, queryByTestId, rerender } = render(<ItemDialog {...props} />);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(queryByTestId('TagDialog::AddModal::HelperText')).toBeTruthy();
+
+      rerender(<ItemDialog {...props} isVisible={false} />);
+      rerender(<ItemDialog {...props} isVisible={true} />);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(queryByTestId('TagDialog::AddModal::HelperText')).toBeTruthy();
+      expect(getByTestId('TagDialog::AddModal::HelperText').props.type).toBe('error');
+    });
   });
 
   describe('type accordion', () => {
@@ -837,7 +927,7 @@ describe('ItemDialog Component', () => {
       expect(getByTestId('IngredientDialog::EditModal::TypeAccordion')).toBeTruthy();
     });
 
-    test('pressing a type item and confirming calls onConfirmIngredient with selected type', () => {
+    test('pressing a type item and confirming calls onConfirmIngredient with selected type', async () => {
       const ingredientNoType: FormIngredientElement = {
         name: 'Test Ingredient',
         type: undefined,
@@ -859,7 +949,10 @@ describe('ItemDialog Component', () => {
       fireEvent.press(
         getByTestId('IngredientDialog::AddModal::TypeAccordion::' + ingredientType.fruit)
       );
-      fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+      });
 
       expect(mockOnConfirmIngredient).toHaveBeenCalledWith('add', {
         id: undefined,
@@ -1039,6 +1132,212 @@ describe('ItemDialog Component', () => {
     });
   });
 
+  describe('calls onClose after confirm button is pressed', () => {
+    test('ingredient add mode', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: mockIngredient,
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+      });
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    test('ingredient edit mode', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='edit'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: mockIngredient,
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::EditModal::ConfirmButton'));
+      });
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    test('ingredient delete mode', () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='delete'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: mockIngredient,
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      fireEvent.press(getByTestId('IngredientDialog::DeleteModal::ConfirmButton'));
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    test('tag add mode', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: mockTag, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('TagDialog::AddModal::ConfirmButton'));
+      });
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    test('tag edit mode', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='edit'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: mockTag, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('TagDialog::EditModal::ConfirmButton'));
+      });
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    test('tag delete mode', () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='delete'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: mockTag, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      fireEvent.press(getByTestId('TagDialog::DeleteModal::ConfirmButton'));
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('reflects changed form values in confirm callback', () => {
+    test('changed ingredient name is passed to onConfirmIngredient', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: mockIngredient,
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      fireEvent.changeText(
+        getByTestId('IngredientDialog::AddModal::Name::CustomTextInput'),
+        'Updated Ingredient'
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::AddModal::ConfirmButton'));
+      });
+
+      expect(mockOnConfirmIngredient).toHaveBeenCalledWith(
+        'add',
+        expect.objectContaining({ name: 'Updated Ingredient' })
+      );
+    });
+
+    test('changed ingredient unit is passed to onConfirmIngredient', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='edit'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: mockIngredient,
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      fireEvent.changeText(
+        getByTestId('IngredientDialog::EditModal::Unit::CustomTextInput'),
+        'liters'
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('IngredientDialog::EditModal::ConfirmButton'));
+      });
+
+      expect(mockOnConfirmIngredient).toHaveBeenCalledWith(
+        'edit',
+        expect.objectContaining({ unit: 'liters' })
+      );
+    });
+
+    test('changed tag name is passed to onConfirmTag', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='edit'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: mockTag, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      fireEvent.changeText(
+        getByTestId('TagDialog::EditModal::Name::CustomTextInput'),
+        'Updated Tag'
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('TagDialog::EditModal::ConfirmButton'));
+      });
+
+      expect(mockOnConfirmTag).toHaveBeenCalledWith(
+        'edit',
+        expect.objectContaining({ name: 'Updated Tag' })
+      );
+    });
+  });
+
   describe('duplicate detection for ingredients', () => {
     beforeEach(() => {
       setMockIngredients([]);
@@ -1153,6 +1452,363 @@ describe('ItemDialog Component', () => {
       expect(
         getByTestId('IngredientDialog::EditModal::ConfirmButton').props.accessibilityState.disabled
       ).toBe(false);
+    });
+  });
+
+  describe('HelperText type attribute', () => {
+    test('is error for duplicate ingredient name', async () => {
+      const existingIngredient: ingredientTableElement = {
+        id: 99,
+        name: 'Flour',
+        type: ingredientType.cereal,
+        unit: 'cups',
+        season: [],
+      };
+      setMockIngredients([existingIngredient]);
+
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: 'Flour', type: ingredientType.cereal, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('IngredientDialog::AddModal::HelperText').props.type).toBe('error');
+    });
+
+    test('is info for similar ingredient name', async () => {
+      const similarIngredient: ingredientTableElement = {
+        id: 99,
+        name: 'Tomatoes',
+        type: ingredientType.vegetable,
+        unit: 'pieces',
+        season: [],
+      };
+      setMockIngredients([similarIngredient]);
+
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: 'Tomato', type: ingredientType.vegetable, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('IngredientDialog::AddModal::HelperText').props.type).toBe('info');
+    });
+
+    test('is error for duplicate tag name', async () => {
+      const existingTag: tagTableElement = { id: 99, name: 'Italian' };
+      setMockTags([existingTag]);
+
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: 'Italian' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('TagDialog::AddModal::HelperText').props.type).toBe('error');
+    });
+  });
+
+  describe('duplicate error clears when name changes to unique', () => {
+    test('ingredient', async () => {
+      const existingIngredient: ingredientTableElement = {
+        id: 99,
+        name: 'Flour',
+        type: ingredientType.cereal,
+        unit: 'cups',
+        season: [],
+      };
+      setMockIngredients([existingIngredient]);
+
+      const { getByTestId, queryByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: 'Flour', type: ingredientType.cereal, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(queryByTestId('IngredientDialog::AddModal::HelperText')).toBeTruthy();
+
+      fireEvent.changeText(
+        getByTestId('IngredientDialog::AddModal::Name::CustomTextInput'),
+        'Unique Ingredient'
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(queryByTestId('IngredientDialog::AddModal::HelperText')).toBeNull();
+      expect(
+        getByTestId('IngredientDialog::AddModal::ConfirmButton').props.accessibilityState.disabled
+      ).toBe(false);
+    });
+
+    test('tag', async () => {
+      const existingTag: tagTableElement = { id: 99, name: 'Italian' };
+      setMockTags([existingTag]);
+
+      const { getByTestId, queryByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: 'Italian' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(queryByTestId('TagDialog::AddModal::HelperText')).toBeTruthy();
+
+      fireEvent.changeText(getByTestId('TagDialog::AddModal::Name::CustomTextInput'), 'Unique Tag');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(queryByTestId('TagDialog::AddModal::HelperText')).toBeNull();
+      expect(
+        getByTestId('TagDialog::AddModal::ConfirmButton').props.accessibilityState.disabled
+      ).toBe(false);
+    });
+  });
+
+  describe('similar detection for tags', () => {
+    test('shows info HelperText when tag name is similar but not exact', async () => {
+      const similarTag: tagTableElement = { id: 99, name: 'Italian' };
+      setMockTags([similarTag]);
+
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: 'Italians' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('TagDialog::AddModal::HelperText').props.type).toBe('info');
+      expect(
+        getByTestId('TagDialog::AddModal::ConfirmButton').props.accessibilityState.disabled
+      ).toBe(false);
+    });
+  });
+
+  describe('required name validation', () => {
+    test('shows required HelperText when user types then clears name for ingredient', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: '', type: ingredientType.fruit, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      expect(queryByTestId('IngredientDialog::AddModal::HelperText')).toBeNull();
+
+      await act(async () => {
+        fireEvent.changeText(
+          getByTestId('IngredientDialog::AddModal::Name::CustomTextInput'),
+          'abc'
+        );
+      });
+
+      await act(async () => {
+        fireEvent.changeText(getByTestId('IngredientDialog::AddModal::Name::CustomTextInput'), '');
+      });
+
+      expect(getByTestId('IngredientDialog::AddModal::HelperText')).toBeTruthy();
+      expect(getByTestId('IngredientDialog::AddModal::HelperText').props.type).toBe('error');
+    });
+
+    test('shows required HelperText when user types then clears name for tag', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: '' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      expect(queryByTestId('TagDialog::AddModal::HelperText')).toBeNull();
+
+      await act(async () => {
+        fireEvent.changeText(getByTestId('TagDialog::AddModal::Name::CustomTextInput'), 'abc');
+      });
+
+      await act(async () => {
+        fireEvent.changeText(getByTestId('TagDialog::AddModal::Name::CustomTextInput'), '');
+      });
+
+      expect(getByTestId('TagDialog::AddModal::HelperText')).toBeTruthy();
+      expect(getByTestId('TagDialog::AddModal::HelperText').props.type).toBe('error');
+    });
+
+    test('does not show required HelperText when name is empty and never typed', () => {
+      const { queryByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: '' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      expect(queryByTestId('TagDialog::AddModal::HelperText')).toBeNull();
+    });
+  });
+
+  describe('error prop on name input', () => {
+    test('is true when duplicate ingredient detected', async () => {
+      const existingIngredient: ingredientTableElement = {
+        id: 99,
+        name: 'Flour',
+        type: ingredientType.cereal,
+        unit: 'cups',
+        season: [],
+      };
+      setMockIngredients([existingIngredient]);
+
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='IngredientDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{
+            type: 'Ingredient',
+            value: { name: 'Flour', type: ingredientType.cereal, unit: '', season: [] },
+            onConfirmIngredient: mockOnConfirmIngredient,
+          }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('IngredientDialog::AddModal::Name::error').props.children).toBe('true');
+    });
+
+    test('is true when duplicate tag detected', async () => {
+      const existingTag: tagTableElement = { id: 99, name: 'Italian' };
+      setMockTags([existingTag]);
+
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: 'Italian' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('TagDialog::AddModal::Name::error').props.children).toBe('true');
+    });
+
+    test('is false when no duplicate detected', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: 'Unique Tag' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+
+      expect(getByTestId('TagDialog::AddModal::Name::error').props.children).toBe('false');
+    });
+
+    test('is true when user types then clears name', async () => {
+      const { getByTestId } = render(
+        <ItemDialog
+          testId='TagDialog'
+          mode='add'
+          isVisible={true}
+          onClose={mockOnClose}
+          item={{ type: 'Tag', value: { name: '' }, onConfirmTag: mockOnConfirmTag }}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.changeText(getByTestId('TagDialog::AddModal::Name::CustomTextInput'), 'abc');
+      });
+
+      await act(async () => {
+        fireEvent.changeText(getByTestId('TagDialog::AddModal::Name::CustomTextInput'), '');
+      });
+
+      expect(getByTestId('TagDialog::AddModal::Name::error').props.children).toBe('true');
     });
   });
 });

--- a/tests/unit/customTypes/ItemDialogTypes.test.ts
+++ b/tests/unit/customTypes/ItemDialogTypes.test.ts
@@ -1,0 +1,82 @@
+import { buildItemFormValues } from '@customTypes/ItemDialogTypes';
+import {
+  ingredientTableElement,
+  ingredientType,
+  tagTableElement,
+} from '@customTypes/DatabaseElementTypes';
+
+describe('buildItemFormValues', () => {
+  describe('tag item', () => {
+    const tag: tagTableElement = { id: 1, name: 'Italian' };
+
+    test('maps name from tag value', () => {
+      const result = buildItemFormValues({ type: 'Tag', value: tag });
+      expect(result.name).toBe('Italian');
+    });
+
+    test('sets ingredient-only fields to empty defaults', () => {
+      const result = buildItemFormValues({ type: 'Tag', value: tag });
+      expect(result.type).toBeUndefined();
+      expect(result.unit).toBe('');
+      expect(result.season).toEqual([]);
+    });
+
+    test('defaults name to empty string when tag name is undefined', () => {
+      const result = buildItemFormValues({
+        type: 'Tag',
+        value: { name: undefined as unknown as string },
+      });
+      expect(result.name).toBe('');
+    });
+  });
+
+  describe('ingredient item', () => {
+    const ingredient: ingredientTableElement = {
+      id: 2,
+      name: 'Flour',
+      type: ingredientType.cereal,
+      unit: 'cups',
+      season: ['1', '2', '3'],
+    };
+
+    test('maps all ingredient fields', () => {
+      const result = buildItemFormValues({ type: 'Ingredient', value: ingredient });
+      expect(result.name).toBe('Flour');
+      expect(result.type).toBe(ingredientType.cereal);
+      expect(result.unit).toBe('cups');
+      expect(result.season).toEqual(['1', '2', '3']);
+    });
+
+    test('defaults unit to empty string when undefined', () => {
+      const result = buildItemFormValues({
+        type: 'Ingredient',
+        value: { name: 'Salt', type: ingredientType.spice },
+      });
+      expect(result.unit).toBe('');
+    });
+
+    test('defaults season to empty array when undefined', () => {
+      const result = buildItemFormValues({
+        type: 'Ingredient',
+        value: { name: 'Salt', type: ingredientType.spice },
+      });
+      expect(result.season).toEqual([]);
+    });
+
+    test('type is undefined when ingredient type not set', () => {
+      const result = buildItemFormValues({
+        type: 'Ingredient',
+        value: { name: 'Salt' },
+      });
+      expect(result.type).toBeUndefined();
+    });
+
+    test('defaults name to empty string when ingredient name is undefined', () => {
+      const result = buildItemFormValues({
+        type: 'Ingredient',
+        value: { type: ingredientType.cereal },
+      });
+      expect(result.name).toBe('');
+    });
+  });
+});

--- a/tests/unit/schemas/itemDialogSchema.test.ts
+++ b/tests/unit/schemas/itemDialogSchema.test.ts
@@ -1,0 +1,112 @@
+import { ingredientDialogSchema, tagDialogSchema } from '@schemas/itemDialogSchema';
+import { ingredientType } from '@customTypes/DatabaseElementTypes';
+
+describe('tagDialogSchema', () => {
+  test('fails when name is empty', () => {
+    const result = tagDialogSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  test('fails when name is whitespace only', () => {
+    const result = tagDialogSchema.safeParse({ name: '   ' });
+    expect(result.success).toBe(false);
+  });
+
+  test('passes with valid name', () => {
+    const result = tagDialogSchema.safeParse({ name: 'Italian' });
+    expect(result.success).toBe(true);
+  });
+
+  test('trims name before validation', () => {
+    const result = tagDialogSchema.safeParse({ name: '  Italian  ' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('Italian');
+    }
+  });
+
+  test('error message key matches i18n key for empty name', () => {
+    const result = tagDialogSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('name_required');
+    }
+  });
+});
+
+describe('ingredientDialogSchema', () => {
+  const validIngredient = {
+    name: 'Flour',
+    type: ingredientType.cereal,
+    unit: 'cups',
+    season: ['1', '2'],
+  };
+
+  test('fails when name is empty', () => {
+    const result = ingredientDialogSchema.safeParse({ ...validIngredient, name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  test('fails when name is whitespace only', () => {
+    const result = ingredientDialogSchema.safeParse({ ...validIngredient, name: '   ' });
+    expect(result.success).toBe(false);
+  });
+
+  test('trims name before validation', () => {
+    const result = ingredientDialogSchema.safeParse({ ...validIngredient, name: '  Flour  ' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('Flour');
+    }
+  });
+
+  test('fails when type is missing', () => {
+    const { type: _type, ...withoutType } = validIngredient;
+    const result = ingredientDialogSchema.safeParse(withoutType);
+    expect(result.success).toBe(false);
+  });
+
+  test('fails when type is not a valid ingredientType', () => {
+    const result = ingredientDialogSchema.safeParse({ ...validIngredient, type: 'invalid_type' });
+    expect(result.success).toBe(false);
+  });
+
+  test('passes with valid ingredient', () => {
+    const result = ingredientDialogSchema.safeParse(validIngredient);
+    expect(result.success).toBe(true);
+  });
+
+  test('defaults unit to empty string when not provided', () => {
+    const { unit: _unit, ...withoutUnit } = validIngredient;
+    const result = ingredientDialogSchema.safeParse(withoutUnit);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.unit).toBe('');
+    }
+  });
+
+  test('defaults season to empty array when not provided', () => {
+    const { season: _season, ...withoutSeason } = validIngredient;
+    const result = ingredientDialogSchema.safeParse(withoutSeason);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.season).toEqual([]);
+    }
+  });
+
+  test('passes with empty unit', () => {
+    const result = ingredientDialogSchema.safeParse({ ...validIngredient, unit: '' });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts all valid ingredientType values', () => {
+    const result = ingredientDialogSchema.safeParse({
+      ...validIngredient,
+      type: ingredientType.vegetable,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe(ingredientType.vegetable);
+    }
+  });
+});

--- a/tests/unit/screens/IngredientsSettings.test.tsx
+++ b/tests/unit/screens/IngredientsSettings.test.tsx
@@ -56,11 +56,8 @@ const renderIngredientsSettings = async () => {
 
 type QueryByIdType = QueryByQuery<TextMatch, CommonQueryOptions & TextMatchOptions>;
 
-function dialogIsNotOpen(getByTestId: QueryByIdType) {
-  expect(getByTestId('IngredientsSettings::ItemDialog::IsVisible').props.children).toEqual(false);
-  expect(getByTestId('IngredientsSettings::ItemDialog::Mode')).toBeTruthy();
-  expect(getByTestId('IngredientsSettings::ItemDialog::OnClose')).toBeTruthy();
-  expect(getByTestId('IngredientsSettings::ItemDialog::Item')).toBeTruthy();
+function dialogIsNotOpen(queryByTestId: (id: string) => HTMLElement | null) {
+  expect(queryByTestId('IngredientsSettings::ItemDialog::IsVisible')).toBeNull();
 }
 
 function dialogIsOpen(
@@ -114,7 +111,7 @@ describe('IngredientsSettings Screen', () => {
     expect(getByTestId('IngredientsSettings::SettingsItemList::OnEdit')).toBeTruthy();
     expect(getByTestId('IngredientsSettings::SettingsItemList::OnDelete')).toBeTruthy();
 
-    dialogIsNotOpen(getByTestId);
+    dialogIsNotOpen(queryByTestId);
   });
 
   test('opens add dialog with empty template when add button is pressed', async () => {

--- a/tests/unit/screens/TagsSettings.test.tsx
+++ b/tests/unit/screens/TagsSettings.test.tsx
@@ -51,11 +51,8 @@ const renderTagsSettings = async () => {
 
 type QueryByIdType = QueryByQuery<TextMatch, CommonQueryOptions & TextMatchOptions>;
 
-function dialogIsNotOpen(getByTestId: QueryByIdType) {
-  expect(getByTestId('TagsSettings::ItemDialog::IsVisible').props.children).toEqual(false);
-  expect(getByTestId('TagsSettings::ItemDialog::Mode')).toBeTruthy();
-  expect(getByTestId('TagsSettings::ItemDialog::OnClose')).toBeTruthy();
-  expect(getByTestId('TagsSettings::ItemDialog::Item')).toBeTruthy();
+function dialogIsNotOpen(queryByTestId: (id: string) => HTMLElement | null) {
+  expect(queryByTestId('TagsSettings::ItemDialog::IsVisible')).toBeNull();
 }
 
 function dialogIsOpen(item: tagTableElement, mode: DialogMode, getByTestId: QueryByIdType) {
@@ -91,7 +88,7 @@ describe('TagsSettings Screen', () => {
   });
 
   test('renders correctly with initial tags', async () => {
-    const { getByTestId } = await renderTagsSettings();
+    const { getByTestId, queryByTestId } = await renderTagsSettings();
 
     expect(getByTestId('TagsSettings::SettingsItemList::Type').props.children).toEqual('tag');
     expect(getByTestId('TagsSettings::SettingsItemList::Items').props.children).toEqual(
@@ -101,7 +98,7 @@ describe('TagsSettings Screen', () => {
     expect(getByTestId('TagsSettings::SettingsItemList::OnEdit')).toBeTruthy();
     expect(getByTestId('TagsSettings::SettingsItemList::OnDelete')).toBeTruthy();
 
-    dialogIsNotOpen(getByTestId);
+    dialogIsNotOpen(queryByTestId);
   });
 
   test('opens add dialog when add button is pressed and save value', async () => {


### PR DESCRIPTION
## Summary

- Replace manual `useState` form state in `ItemDialog` with react-hook-form + zod — eliminates `ValidationState` enum, `itemRef` workaround, and 5 separate state variables
- Add `itemDialogSchema.ts` (zod schemas for tag/ingredient) and `ItemDialogTypes.ts` (unified `ItemDialogFormValues` type + `buildItemFormValues` helper)
- Required name error surfaces via zod's `too_small` type after first `onChange` (not on mount); duplicate/similar errors use `setError`/`clearErrors`

## Test plan

- [ ] Unit tests: `ItemDialog.test.tsx` (97 total — added required name validation, similar tags, whitespace, trim, reopen clears errors), `itemDialogSchema.test.ts`, `ItemDialogTypes.test.ts`
- [ ] E2E: `assertNameRequiredError` flows wired into ingredient + tag edge case suites; description required error added to bug report case
- [ ] Open add ingredient dialog — confirm button disabled, no HelperText shown on open
- [ ] Type then clear name — HelperText with required error appears, confirm stays disabled
- [ ] Type duplicate name — error HelperText, confirm disabled; type unique name — clears
- [ ] Type similar name — info HelperText, confirm still enabled
- [ ] Edit existing item — save with same name works (no false duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)