### PR TITLE
feat(logging): daily log rotation, retention, and observability gaps

### DIFF
--- a/.github/scripts/collect-android-logs.sh
+++ b/.github/scripts/collect-android-logs.sh
@@ -7,13 +7,18 @@ LOG_DIR="maestro_logs_${SUITE}"
 
 mkdir -p "$LOG_DIR"
 
-echo "📋 Collecting app log file..."
+echo "📋 Collecting app log files..."
 adb root || true
 sleep 1
-timeout 30 adb pull /data/data/com.recipedia/files/recipedia-logs.txt "$LOG_DIR/recipedia-app-logs.txt" 2>/dev/null || true
+DEVICE_LOGS=$(adb shell "ls -t /data/data/com.recipedia/files/recipedia-logs-*.txt 2>/dev/null" | tr -d '\r')
+if [ -n "$DEVICE_LOGS" ]; then
+  for LOG in $DEVICE_LOGS; do
+    timeout 30 adb shell "cat '$LOG'" >> "$LOG_DIR/recipedia-app-logs.txt" 2>/dev/null || true
+  done
+fi
 
 if [ -s "$LOG_DIR/recipedia-app-logs.txt" ]; then
-  echo "📋 App log file collected"
+  echo "📋 App log files collected"
 else
-  echo "⚠️ App log file not found or empty"
+  echo "⚠️ App log files not found or empty"
 fi

--- a/.github/scripts/collect-ios-logs.sh
+++ b/.github/scripts/collect-ios-logs.sh
@@ -19,13 +19,13 @@ APP_CONTAINER=$(perl -e 'alarm shift; exec @ARGV' 30 xcrun simctl get_app_contai
 echo "📋 APP_CONTAINER: $APP_CONTAINER"
 
 if [ -n "$APP_CONTAINER" ]; then
-  LOG_FILE="$APP_CONTAINER/Documents/recipedia-logs.txt"
-  echo "📋 Checking for log file at: $LOG_FILE"
-  if [ -f "$LOG_FILE" ]; then
-    cp "$LOG_FILE" "$LOG_DIR/recipedia-app-logs.txt"
-    echo "📋 App log file collected ($(wc -l < "$LOG_DIR/recipedia-app-logs.txt") lines)"
+  LOG_FILES=$(ls -t "$APP_CONTAINER/Documents/recipedia-logs-"*.txt 2>/dev/null)
+  echo "📋 Checking for log files in: $APP_CONTAINER/Documents"
+  if [ -n "$LOG_FILES" ]; then
+    echo "$LOG_FILES" | xargs cat > "$LOG_DIR/recipedia-app-logs.txt"
+    echo "📋 App log files collected ($(wc -l < "$LOG_DIR/recipedia-app-logs.txt") lines)"
   else
-    echo "⚠️ App log file not found at $LOG_FILE"
+    echo "⚠️ App log files not found"
     ls -la "$APP_CONTAINER/Documents" || echo "❌ Cannot list Documents directory"
   fi
 else

--- a/src/components/organisms/AppWrapper.tsx
+++ b/src/components/organisms/AppWrapper.tsx
@@ -4,6 +4,7 @@ import { WelcomeScreen } from '@screens/WelcomeScreen';
 import { TutorialProvider } from './TutorialController';
 import { isFirstLaunch, markAsLaunched } from '@utils/firstLaunch';
 import { appLogger, tutorialLogger } from '@utils/logger';
+import { deleteOldLogFiles } from '@utils/BugReport';
 import { useRecipes } from '@hooks/useRecipes';
 import { useMenu } from '@hooks/useMenu';
 
@@ -41,6 +42,7 @@ export default function AppWrapper() {
   const [mode, setMode] = useState<AppMode>(AppMode.Loading);
 
   useEffect(() => {
+    deleteOldLogFiles();
     isFirstLaunch().then(isFirst => {
       if (isFirst) {
         appLogger.info('First launch detected - showing welcome screen');

--- a/src/context/RecipeFormContext.tsx
+++ b/src/context/RecipeFormContext.tsx
@@ -37,6 +37,7 @@ import {
   hasScrapedDataFromProps,
 } from '@utils/RecipeFormHelpers';
 import { useTags } from '@hooks/useTags';
+import { recipeLogger } from '@utils/logger';
 
 /**
  * Recipe form state containing all recipe field values
@@ -113,6 +114,17 @@ export function RecipeFormProvider({ props, children }: RecipeFormProviderProps)
   const { searchRandomlyTags } = useTags();
   const initStateFromProp = hasRecipeFromProps(props);
   const initStateFromScrape = hasScrapedDataFromProps(props);
+
+  useEffect(() => {
+    recipeLogger.debug('Recipe form initialized', {
+      mode: props.mode,
+      source: initStateFromProp
+        ? 'existing-recipe'
+        : initStateFromScrape
+          ? 'scraped-data'
+          : 'blank',
+    });
+  }, []);
 
   const getInitialImage = () => {
     if (initStateFromProp) {
@@ -252,6 +264,7 @@ export function RecipeFormProvider({ props, children }: RecipeFormProviderProps)
   }, [recipePersons]);
 
   const resetToOriginal = () => {
+    recipeLogger.debug('Recipe form reset to original');
     if (initStateFromProp) {
       setRecipeImage(props.recipe.image_Source);
       setRecipeTitle(props.recipe.title);

--- a/src/hooks/useRecipeIngredients.ts
+++ b/src/hooks/useRecipeIngredients.ts
@@ -157,6 +157,7 @@ export function useRecipeIngredients(): UseRecipeIngredientsReturn {
       const existingIndex = prev.findIndex(existing => namesMatch(existing.name, ingredient.name));
 
       if (existingIndex === -1) {
+        recipeLogger.debug('Ingredient added', { name: ingredient.name });
         return [...prev, ingredient];
       } else {
         const updated = [...prev];
@@ -171,15 +172,20 @@ export function useRecipeIngredients(): UseRecipeIngredientsReturn {
           const newNote = ingredient.note?.trim();
 
           if (existingNote && newNote && existingNote !== newNote) {
+            recipeLogger.debug('Ingredient added separately - conflicting notes', {
+              name: ingredient.name,
+            });
             return [...prev, ingredient];
           }
 
+          recipeLogger.debug('Ingredient quantities merged', { name: ingredient.name });
           updated[existingIndex] = {
             ...ingredient,
             quantity: mergeQuantities(existing.quantity, ingredient.quantity),
             note: newNote || existingNote,
           };
         } else {
+          recipeLogger.debug('Ingredient replaced - different unit', { name: ingredient.name });
           updated[existingIndex] = {
             ...ingredient,
             quantity: ingredient.quantity || existing.quantity || '',
@@ -351,6 +357,7 @@ export function useRecipeIngredients(): UseRecipeIngredientsReturn {
    * the user to fill in the details through the UI.
    */
   const addNewIngredient = () => {
+    recipeLogger.debug('Empty ingredient row added');
     setRecipeIngredients(prev => [...prev, { name: '' }]);
   };
 
@@ -360,6 +367,7 @@ export function useRecipeIngredients(): UseRecipeIngredientsReturn {
    * @param index - Index of the ingredient to remove
    */
   const removeIngredient = (index: number) => {
+    recipeLogger.debug('Ingredient removed', { index });
     setRecipeIngredients(prev => prev.filter((_, i) => i !== index));
   };
 

--- a/src/hooks/useRecipeOCR.ts
+++ b/src/hooks/useRecipeOCR.ts
@@ -158,132 +158,139 @@ export function useRecipeOCR(): UseRecipeOCRReturn {
    * @param field - The recipe field type to extract
    */
   const fillOneField = async (uri: string, field: OcrModalTarget) => {
+    ocrLogger.debug('OCR extraction started', { field, uri });
     setIsProcessingOcrExtraction(true);
 
-    const newFieldData = await extractFieldFromImage(
-      uri,
-      field,
-      {
-        recipePreparation: recipePreparation,
-        recipePersons: recipePersons,
-        recipeIngredients: recipeIngredients,
-        recipeTags: recipeTags,
-      },
-      msg => {
-        ocrLogger.warn('OCR processing warning', { message: msg });
-      }
-    );
-
-    if (newFieldData.recipeImage) {
-      setRecipeImage(newFieldData.recipeImage);
-    }
-    if (newFieldData.recipeTitle) {
-      setRecipeTitle(newFieldData.recipeTitle);
-    }
-    if (newFieldData.recipeDescription) {
-      setRecipeDescription(newFieldData.recipeDescription);
-    }
-    if (newFieldData.recipeTags && newFieldData.recipeTags.length > 0) {
-      const filteredTags = filterOutExistingTags(newFieldData.recipeTags, recipeTags);
-      if (filteredTags.length > 0) {
-        validateAndQueueTags(
-          filteredTags,
-          findSimilarTags,
-          addTagIfNotDuplicate,
-          setValidationQueue
-        );
-      }
-    }
-    if (newFieldData.recipePreparation) {
-      setRecipePreparation(newFieldData.recipePreparation);
-    }
-    if (newFieldData.recipePersons) {
-      setRecipePersons(newFieldData.recipePersons);
-    }
-    if (newFieldData.recipeTime) {
-      setRecipeTime(newFieldData.recipeTime);
-    }
-    if (newFieldData.recipeIngredients && newFieldData.recipeIngredients.length > 0) {
-      const ocrIngredients = newFieldData.recipeIngredients;
-      prepopulateIngredients(ocrIngredients);
-      validateAndQueueIngredients(
-        ocrIngredients,
-        findSimilarIngredients,
-        match => {
-          const original = ocrIngredients.find(ing => namesMatch(ing.name, match.name));
-          addOrMergeIngredient({ ...match, quantity: original?.quantity || match.quantity });
+    try {
+      const newFieldData = await extractFieldFromImage(
+        uri,
+        field,
+        {
+          recipePreparation: recipePreparation,
+          recipePersons: recipePersons,
+          recipeIngredients: recipeIngredients,
+          recipeTags: recipeTags,
         },
-        setValidationQueue,
-        { onValidated: (_, validatedIngredient) => addOrMergeIngredient(validatedIngredient) }
-      );
-    }
-    if (newFieldData.ingredientNames !== undefined) {
-      const ingredientsWithNoQuantity: FormIngredientElement[] = newFieldData.ingredientNames.map(
-        ({ name, unit }) => ({ name, unit, quantity: '' })
-      );
-      if (ingredientsWithNoQuantity.length > 0) {
-        const { exactMatches, needsValidation } = processIngredientsForValidation(
-          ingredientsWithNoQuantity,
-          findSimilarIngredients
-        );
-
-        prepopulateIngredients(ingredientsWithNoQuantity);
-
-        if (exactMatches.length > 0) {
-          setRecipeIngredients(prev => addOrMergeIngredientMatches(prev, exactMatches));
+        msg => {
+          ocrLogger.warn('OCR processing warning', { message: msg });
         }
+      );
 
-        if (needsValidation.length > 0) {
-          setValidationQueue({
-            type: 'Ingredient',
-            items: needsValidation,
-            onValidated: (_, validatedIngredient) => addOrMergeIngredient(validatedIngredient),
-          });
+      if (newFieldData.recipeImage) {
+        setRecipeImage(newFieldData.recipeImage);
+      }
+      if (newFieldData.recipeTitle) {
+        setRecipeTitle(newFieldData.recipeTitle);
+      }
+      if (newFieldData.recipeDescription) {
+        setRecipeDescription(newFieldData.recipeDescription);
+      }
+      if (newFieldData.recipeTags && newFieldData.recipeTags.length > 0) {
+        const filteredTags = filterOutExistingTags(newFieldData.recipeTags, recipeTags);
+        if (filteredTags.length > 0) {
+          validateAndQueueTags(
+            filteredTags,
+            findSimilarTags,
+            addTagIfNotDuplicate,
+            setValidationQueue
+          );
         }
       }
-    }
-    if (newFieldData.ingredientQuantities !== undefined) {
-      const quantities = newFieldData.ingredientQuantities.map(parseQuantity);
-      setRecipeIngredients(prev => {
-        if (quantities.length !== prev.length) {
-          ocrLogger.warn('Quantity count mismatch', {
-            expected: prev.length,
-            received: quantities.length,
-          });
-        }
-        const limit = Math.min(prev.length, quantities.length);
-        if (limit === 0) return prev;
-        const next = prev.map((ingredient, index) =>
-          index < limit && ingredient.quantity !== quantities[index]
-            ? { ...ingredient, quantity: quantities[index] }
-            : ingredient
+      if (newFieldData.recipePreparation) {
+        setRecipePreparation(newFieldData.recipePreparation);
+      }
+      if (newFieldData.recipePersons) {
+        setRecipePersons(newFieldData.recipePersons);
+      }
+      if (newFieldData.recipeTime) {
+        setRecipeTime(newFieldData.recipeTime);
+      }
+      if (newFieldData.recipeIngredients && newFieldData.recipeIngredients.length > 0) {
+        const ocrIngredients = newFieldData.recipeIngredients;
+        prepopulateIngredients(ocrIngredients);
+        validateAndQueueIngredients(
+          ocrIngredients,
+          findSimilarIngredients,
+          match => {
+            const original = ocrIngredients.find(ing => namesMatch(ing.name, match.name));
+            addOrMergeIngredient({ ...match, quantity: original?.quantity || match.quantity });
+          },
+          setValidationQueue,
+          { onValidated: (_, validatedIngredient) => addOrMergeIngredient(validatedIngredient) }
         );
-        return next.every((ing, i) => ing === prev[i]) ? prev : next;
-      });
-    }
-    if (newFieldData.recipeNutrition) {
-      const newNutrition: nutritionTableElement = {
-        energyKcal: defaultValueNumber,
-        energyKj: defaultValueNumber,
-        fat: defaultValueNumber,
-        saturatedFat: defaultValueNumber,
-        carbohydrates: defaultValueNumber,
-        sugars: defaultValueNumber,
-        fiber: defaultValueNumber,
-        protein: defaultValueNumber,
-        salt: defaultValueNumber,
-        portionWeight: defaultValueNumber,
-      };
+      }
+      if (newFieldData.ingredientNames !== undefined) {
+        const ingredientsWithNoQuantity: FormIngredientElement[] = newFieldData.ingredientNames.map(
+          ({ name, unit }) => ({ name, unit, quantity: '' })
+        );
+        if (ingredientsWithNoQuantity.length > 0) {
+          const { exactMatches, needsValidation } = processIngredientsForValidation(
+            ingredientsWithNoQuantity,
+            findSimilarIngredients
+          );
 
-      for (const [key, value] of Object.entries(newFieldData.recipeNutrition)) {
-        if (value !== undefined) {
-          newNutrition[key as keyof nutritionTableElement] = value;
+          prepopulateIngredients(ingredientsWithNoQuantity);
+
+          if (exactMatches.length > 0) {
+            setRecipeIngredients(prev => addOrMergeIngredientMatches(prev, exactMatches));
+          }
+
+          if (needsValidation.length > 0) {
+            setValidationQueue({
+              type: 'Ingredient',
+              items: needsValidation,
+              onValidated: (_, validatedIngredient) => addOrMergeIngredient(validatedIngredient),
+            });
+          }
         }
       }
+      if (newFieldData.ingredientQuantities !== undefined) {
+        const quantities = newFieldData.ingredientQuantities.map(parseQuantity);
+        setRecipeIngredients(prev => {
+          if (quantities.length !== prev.length) {
+            ocrLogger.warn('Quantity count mismatch', {
+              expected: prev.length,
+              received: quantities.length,
+            });
+          }
+          const limit = Math.min(prev.length, quantities.length);
+          if (limit === 0) return prev;
+          const next = prev.map((ingredient, index) =>
+            index < limit && ingredient.quantity !== quantities[index]
+              ? { ...ingredient, quantity: quantities[index] }
+              : ingredient
+          );
+          return next.every((ing, i) => ing === prev[i]) ? prev : next;
+        });
+      }
+      if (newFieldData.recipeNutrition) {
+        const newNutrition: nutritionTableElement = {
+          energyKcal: defaultValueNumber,
+          energyKj: defaultValueNumber,
+          fat: defaultValueNumber,
+          saturatedFat: defaultValueNumber,
+          carbohydrates: defaultValueNumber,
+          sugars: defaultValueNumber,
+          fiber: defaultValueNumber,
+          protein: defaultValueNumber,
+          salt: defaultValueNumber,
+          portionWeight: defaultValueNumber,
+        };
 
-      setRecipeNutrition(newNutrition);
+        for (const [key, value] of Object.entries(newFieldData.recipeNutrition)) {
+          if (value !== undefined) {
+            newNutrition[key as keyof nutritionTableElement] = value;
+          }
+        }
+
+        setRecipeNutrition(newNutrition);
+      }
+      ocrLogger.debug('OCR extraction completed', { field });
+    } catch (error) {
+      ocrLogger.error('OCR extraction failed', { field, uri, error });
+    } finally {
+      setIsProcessingOcrExtraction(false);
     }
-    setIsProcessingOcrExtraction(false);
   };
 
   return {

--- a/src/hooks/useRecipeTags.ts
+++ b/src/hooks/useRecipeTags.ts
@@ -15,6 +15,7 @@ import { useRecipeDialogs } from '@context/RecipeDialogsContext';
 import { useRecipeForm } from '@context/RecipeFormContext';
 import { useTags } from '@hooks/useTags';
 import { validateAndQueueTags } from '@utils/RecipeValidationHelpers';
+import { recipeLogger } from '@utils/logger';
 
 /**
  * Return value of the useRecipeTags hook containing tag management operations.
@@ -104,9 +105,11 @@ export function useRecipeTags(): UseRecipeTagsReturn {
     }
 
     if (recipeTags.some(tag => tag.name.toLowerCase() === newTag.toLowerCase())) {
+      recipeLogger.debug('Tag skipped - already in recipe', { tag: newTag });
       return;
     }
 
+    recipeLogger.debug('Tag queued for validation', { tag: newTag });
     validateAndQueueTags(
       [{ id: -1, name: newTag }],
       findSimilarTags,
@@ -124,6 +127,7 @@ export function useRecipeTags(): UseRecipeTagsReturn {
    * @param tagName - The exact name of the tag to remove
    */
   const removeTag = (tagName: string) => {
+    recipeLogger.debug('Tag removed', { tag: tagName });
     setRecipeTags(prev => prev.filter(tagElement => tagElement.name !== tagName));
   };
 

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -97,21 +97,25 @@ export function useRecipes() {
       recipesToScale: recipesToScale.length,
     });
 
-    for (let i = 0; i < recipesToScale.length; i++) {
-      const scaledRecipe = RecipeDatabase.scaleRecipeToPersons(
-        recipesToScale[i],
-        newDefaultPersons
-      );
-      await db.scaleAndUpdateRecipe(scaledRecipe);
-      const progress = Math.floor(((i + 1) / recipesToScale.length) * 100);
-      setScalingProgress(progress);
-      if (i % 20 === 0) {
-        await new Promise(resolve => setTimeout(resolve, 0));
+    try {
+      for (let i = 0; i < recipesToScale.length; i++) {
+        const scaledRecipe = RecipeDatabase.scaleRecipeToPersons(
+          recipesToScale[i],
+          newDefaultPersons
+        );
+        await db.scaleAndUpdateRecipe(scaledRecipe);
+        const progress = Math.floor(((i + 1) / recipesToScale.length) * 100);
+        setScalingProgress(progress);
+        if (i % 20 === 0) {
+          await new Promise(resolve => setTimeout(resolve, 0));
+        }
       }
+      databaseLogger.info('Recipe scaling completed', { updatedCount: recipesToScale.length });
+    } catch (error) {
+      databaseLogger.error('Recipe scaling failed', { error });
+    } finally {
+      setScalingProgress(undefined);
     }
-
-    databaseLogger.info('Recipe scaling completed', { updatedCount: recipesToScale.length });
-    setScalingProgress(undefined);
   };
 
   return {

--- a/src/providers/HelloFreshProvider.ts
+++ b/src/providers/HelloFreshProvider.ts
@@ -86,6 +86,10 @@ export class HelloFreshProvider extends BaseRecipeProvider {
 
     if (!tld) {
       const supportedLanguages = Object.keys(HELLOFRESH_TLD_BY_LANGUAGE).join(', ');
+      bulkImportLogger.warn('HelloFresh not available for language', {
+        language,
+        supportedLanguages,
+      });
       throw new Error(
         `HelloFresh is not available for language "${language}". Supported languages: ${supportedLanguages}`
       );

--- a/src/screens/Recipe.tsx
+++ b/src/screens/Recipe.tsx
@@ -186,6 +186,7 @@ function RecipeContent({ route, navigation }: RecipeScreenProp) {
    * @returns {Promise<void>} Resolves when recipe is added to shopping list
    */
   async function readOnlyValidation() {
+    recipeLogger.info('Adding recipe to menu', { recipeTitle: state.recipeTitle });
     await addRecipeToMenu(actions.createRecipeSnapshot());
     dialogs.showValidationDialog({
       title: t('success'),
@@ -257,6 +258,7 @@ function RecipeContent({ route, navigation }: RecipeScreenProp) {
     const missingElem = validateRecipeData(state, t);
 
     if (missingElem.length > 0) {
+      recipeLogger.warn('Validation failed, missing elements', { missingElements: missingElem });
       dialogs.showValidationErrorDialog(missingElem, t);
       return;
     }
@@ -347,6 +349,7 @@ function RecipeContent({ route, navigation }: RecipeScreenProp) {
    * @returns {void}
    */
   function handleCancel() {
+    recipeLogger.debug('Recipe edit cancelled');
     actions.resetToOriginal();
   }
 

--- a/src/screens/TagsSettings.tsx
+++ b/src/screens/TagsSettings.tsx
@@ -77,7 +77,10 @@ export function TagsSettings() {
   };
 
   const handleDeleteTag = async (tag: tagTableElement) => {
-    await deleteTag(tag);
+    const success = await deleteTag(tag);
+    if (!success) {
+      tagsSettingsLogger.warn('Tag not found for deletion', { tagId: tag.id, tagName: tag.name });
+    }
   };
 
   const handleAddtag = async (newTag: tagTableElement) => {

--- a/src/utils/BugReport.ts
+++ b/src/utils/BugReport.ts
@@ -24,8 +24,56 @@ import { bugReportLogger } from '@utils/logger';
 /** Developer contact email for bug reports */
 const DEVELOPER_EMAIL = 'antonin.coupanec.dev@outlook.com';
 
-/** Log file stored in the document directory */
-export const LOG_FILE = new File(Paths.document, 'recipedia-logs.txt');
+const LOG_FILE_PREFIX = 'recipedia-logs-';
+const LOG_FILE_SUFFIX = '.txt';
+const LOG_ATTACH_COUNT = 2;
+const LOG_RETENTION_DAYS = 30;
+
+/**
+ * Returns File references for the most recent log files.
+ *
+ * Constructs file paths for the last {@link LOG_ATTACH_COUNT} days using the same
+ * ISO date format as the logger's fileAsyncTransport. Files are returned regardless
+ * of whether they exist; callers should check `.exists` before attaching.
+ *
+ * @returns Array of File references ordered from newest to oldest
+ */
+export function getRecentLogFiles(): File[] {
+  const today = new Date();
+  return Array.from({ length: LOG_ATTACH_COUNT }, (_, i) => {
+    const date = new Date(today);
+    date.setDate(today.getDate() - i);
+    const y = date.getFullYear();
+    const m = date.getMonth() + 1;
+    const d = date.getDate();
+    return new File(Paths.document, `${LOG_FILE_PREFIX}${y}-${m}-${d}${LOG_FILE_SUFFIX}`);
+  });
+}
+
+/**
+ * Deletes log files older than {@link LOG_RETENTION_DAYS} days from the documents directory.
+ *
+ * Scans the documents directory for files matching the `recipedia-logs-*.txt` pattern,
+ * parses their date suffix, and removes those past the retention threshold.
+ */
+export function deleteOldLogFiles(): void {
+  try {
+    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    Paths.document.list().forEach(item => {
+      const filename = item.uri.split('/').pop() ?? '';
+      if (!filename.startsWith(LOG_FILE_PREFIX) || !filename.endsWith(LOG_FILE_SUFFIX)) return;
+      const datePart = filename.slice(LOG_FILE_PREFIX.length, -LOG_FILE_SUFFIX.length);
+      const [y, m, d] = datePart.split('-').map(Number);
+      if (!y || !m || !d) return;
+      if (new Date(y, m - 1, d).getTime() < cutoff) {
+        item.delete();
+        bugReportLogger.debug('Deleted old log file', { filename });
+      }
+    });
+  } catch (error) {
+    bugReportLogger.warn('Failed to clean up old log files', { error });
+  }
+}
 
 /**
  * Builds the email subject line for a bug report.
@@ -59,9 +107,9 @@ export function buildEmailBody(description: string): string {
 }
 
 /**
- * Sends a bug report email with optional log file and screenshot attachments.
+ * Sends a bug report email with optional log files and screenshot attachments.
  *
- * Checks if the log file exists before attaching it; skips silently if not found.
+ * Attaches the most recent log files (up to {@link LOG_ATTACH_COUNT} days) if they exist.
  * Opens the system email composer with pre-filled fields.
  *
  * @param description - User-provided description of the issue
@@ -77,18 +125,18 @@ export async function sendBugReport(
   const body = buildEmailBody(description);
 
   const attachments: string[] = [];
+  const logFiles = getRecentLogFiles().filter(f => f.exists);
+  attachments.push(...logFiles.map(f => f.uri));
 
-  if (LOG_FILE.exists) {
-    attachments.push(LOG_FILE.uri);
-  } else {
-    bugReportLogger.warn('Log file not found, skipping attachment', { logPath: LOG_FILE.uri });
+  if (logFiles.length === 0) {
+    bugReportLogger.warn('No log files found, skipping attachment');
   }
 
   attachments.push(...screenshotUris);
 
   bugReportLogger.info('Composing bug report email', {
     screenshotCount: screenshotUris.length,
-    logAttached: LOG_FILE.exists,
+    logFilesAttached: logFiles.length,
   });
 
   const result = await composeAsync({

--- a/src/utils/RecipeImportOrchestrator.ts
+++ b/src/utils/RecipeImportOrchestrator.ts
@@ -201,7 +201,8 @@ export async function fetchRecipeImageUrl(
     }
 
     return null;
-  } catch {
+  } catch (error) {
+    bulkImportLogger.warn('Failed to fetch recipe image URL', { url, error });
     return null;
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -100,7 +100,8 @@ const log = __DEV__
       transportOptions: {
         FS: { File, Paths },
         filePath: Paths.document.uri,
-        fileName: 'recipedia-logs.txt',
+        fileName: 'recipedia-logs-{date-today}.txt',
+        fileNameDateType: 'iso',
       },
     });
 

--- a/tests/mocks/utils/BugReport-mock.tsx
+++ b/tests/mocks/utils/BugReport-mock.tsx
@@ -9,4 +9,8 @@ export const isMailAvailable = mockIsMailAvailable;
 export const pickScreenshots = mockPickScreenshots;
 export const buildEmailSubject = mockBuildEmailSubject;
 export const buildEmailBody = mockBuildEmailBody;
-export const LOG_FILE = { uri: '/mock/recipedia-logs.txt', exists: false };
+export const mockDeleteOldLogFiles = jest.fn();
+export const deleteOldLogFiles = mockDeleteOldLogFiles;
+export const getRecentLogFiles = jest
+  .fn()
+  .mockReturnValue([{ uri: '/mock/recipedia-logs.txt', exists: false }]);

--- a/tests/unit/components/organisms/AppWrapper.test.tsx
+++ b/tests/unit/components/organisms/AppWrapper.test.tsx
@@ -17,9 +17,11 @@ jest.mock('@components/organisms/TutorialController', () =>
 );
 
 jest.mock('@utils/firstLaunch', () => require('@mocks/utils/firstLaunch-mock').firstLaunchMock());
+jest.mock('@utils/BugReport', () => require('@mocks/utils/BugReport-mock'));
 
 describe('AppWrapper Component', () => {
   const { isFirstLaunch, markAsLaunched } = require('@utils/firstLaunch');
+  const { mockDeleteOldLogFiles } = require('@utils/BugReport');
   const database = RecipeDatabase.getInstance();
 
   beforeEach(async () => {
@@ -171,6 +173,16 @@ describe('AppWrapper Component', () => {
     expect(database.get_menu().map(m => m.recipeTitle)).toEqual(
       testRecipes.slice(0, 3).map(r => r.title)
     );
+  });
+
+  test('calls deleteOldLogFiles on mount', async () => {
+    isFirstLaunch.mockResolvedValue(false);
+
+    render(<AppWrapper />);
+
+    await waitFor(() => {
+      expect(mockDeleteOldLogFiles).toHaveBeenCalledTimes(1);
+    });
   });
 
   test('clears menu on app launch', async () => {

--- a/tests/unit/context/RecipeFormContext.test.tsx
+++ b/tests/unit/context/RecipeFormContext.test.tsx
@@ -80,6 +80,22 @@ describe('RecipeFormContext', () => {
       expect(result.current.initStateFromProp).toBe(false);
     });
 
+    test('initializes state from scraped data in addFromScrape mode', async () => {
+      const wrapper = createFormWrapper(createMockRecipeProp('addFromScrape', defaultTestRecipe));
+      const { result } = renderHook(() => useRecipeForm(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.state.stackMode).toBe(recipeStateType.addScrape);
+      });
+
+      expect(result.current.state.recipeTitle).toBe(defaultTestRecipe.title);
+      expect(result.current.state.recipeDescription).toBe(defaultTestRecipe.description);
+      expect(result.current.state.recipeIngredients).toHaveLength(
+        defaultTestRecipe.ingredients.length
+      );
+      expect(result.current.initStateFromProp).toBe(false);
+    });
+
     test('loads default persons for add modes', async () => {
       const wrapper = createFormWrapper(createMockRecipeProp('addManually'));
       const { result } = renderHook(() => useRecipeForm(), { wrapper });
@@ -224,6 +240,27 @@ describe('RecipeFormContext', () => {
       expect(result.current.state.recipeIngredients[0].quantity).toBe(
         defaultTestRecipe.ingredients[0].quantity
       );
+    });
+
+    test('resetToOriginal in add mode only switches to readOnly without resetting fields', async () => {
+      const wrapper = createFormWrapper(createMockRecipeProp('addManually'));
+      const { result } = renderHook(() => useRecipeForm(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.state.stackMode).toBe(recipeStateType.addManual);
+      });
+
+      act(() => {
+        result.current.setters.setRecipeTitle('Draft Recipe');
+        result.current.setters.setStackMode(recipeStateType.edit);
+      });
+
+      act(() => {
+        result.current.actions.resetToOriginal();
+      });
+
+      expect(result.current.state.stackMode).toBe(recipeStateType.readOnly);
+      expect(result.current.state.recipeTitle).toBe('Draft Recipe');
     });
 
     test('switches to readOnly mode after reset', async () => {

--- a/tests/unit/utils/BugReport.test.ts
+++ b/tests/unit/utils/BugReport.test.ts
@@ -1,12 +1,13 @@
 import {
   buildEmailBody,
   buildEmailSubject,
+  deleteOldLogFiles,
+  getRecentLogFiles,
   isMailAvailable,
-  LOG_FILE,
   pickScreenshots,
   sendBugReport,
 } from '@utils/BugReport';
-import { mockFileExists } from '@mocks/deps/expo-file-system-mock';
+import { mockDirectoryList, mockFileExists } from '@mocks/deps/expo-file-system-mock';
 import ImageCropPicker from 'react-native-image-crop-picker';
 import { mockComposeAsync, mockIsAvailableAsync } from '@mocks/deps/expo-mail-composer-mock';
 
@@ -20,15 +21,112 @@ describe('BugReport utils', () => {
 
   beforeEach(() => {
     mockFileExists.mockReset().mockReturnValue(false);
+    mockDirectoryList.mockReset().mockReturnValue([]);
   });
 
-  describe('LOG_FILE', () => {
-    it('has a URI ending with recipedia-logs.txt', () => {
-      expect(LOG_FILE.uri).toMatch(/recipedia-logs\.txt$/);
+  describe('getRecentLogFiles', () => {
+    it('returns files with URIs matching recipedia-logs-<date>.txt pattern', () => {
+      getRecentLogFiles().forEach(f => {
+        expect(f.uri).toMatch(/recipedia-logs-\d{4}-\d{1,2}-\d{1,2}\.txt$/);
+      });
     });
 
-    it('does not contain double slashes', () => {
-      expect(LOG_FILE.uri).not.toMatch(/\/\//);
+    it('returns files with no double slashes in URIs', () => {
+      getRecentLogFiles().forEach(f => {
+        expect(f.uri).not.toMatch(/\/\//);
+      });
+    });
+
+    it('returns today and yesterday files', () => {
+      const files = getRecentLogFiles();
+      expect(files).toHaveLength(2);
+      const today = new Date();
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      const todayStr = `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+      const yesterdayStr = `${yesterday.getFullYear()}-${yesterday.getMonth() + 1}-${yesterday.getDate()}`;
+      expect(files[0].uri).toContain(todayStr);
+      expect(files[1].uri).toContain(yesterdayStr);
+    });
+  });
+
+  describe('deleteOldLogFiles', () => {
+    it('deletes log files older than 30 days', () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 31);
+      const oldFilename = `recipedia-logs-${oldDate.getFullYear()}-${oldDate.getMonth() + 1}-${oldDate.getDate()}.txt`;
+      const mockDelete = jest.fn();
+      mockDirectoryList.mockReturnValue([{ uri: `/documents/${oldFilename}`, delete: mockDelete }]);
+
+      deleteOldLogFiles();
+
+      expect(mockDelete).toHaveBeenCalled();
+    });
+
+    it('keeps log files within 30 days', () => {
+      const today = new Date();
+      const recentFilename = `recipedia-logs-${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}.txt`;
+      const mockDelete = jest.fn();
+      mockDirectoryList.mockReturnValue([
+        { uri: `/documents/${recentFilename}`, delete: mockDelete },
+      ]);
+
+      deleteOldLogFiles();
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('ignores files not matching the log file pattern', () => {
+      const mockDelete = jest.fn();
+      mockDirectoryList.mockReturnValue([
+        { uri: '/documents/some-other-file.txt', delete: mockDelete },
+      ]);
+
+      deleteOldLogFiles();
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('keeps log files 29 days old', () => {
+      const twentyNineDaysAgo = new Date();
+      twentyNineDaysAgo.setDate(twentyNineDaysAgo.getDate() - 29);
+      const filename = `recipedia-logs-${twentyNineDaysAgo.getFullYear()}-${twentyNineDaysAgo.getMonth() + 1}-${twentyNineDaysAgo.getDate()}.txt`;
+      const mockDelete = jest.fn();
+      mockDirectoryList.mockReturnValue([{ uri: `/documents/${filename}`, delete: mockDelete }]);
+
+      deleteOldLogFiles();
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes only old files when directory contains mixed ages', () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 31);
+      const oldFilename = `recipedia-logs-${oldDate.getFullYear()}-${oldDate.getMonth() + 1}-${oldDate.getDate()}.txt`;
+      const today = new Date();
+      const recentFilename = `recipedia-logs-${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}.txt`;
+      const mockDeleteOld = jest.fn();
+      const mockDeleteRecent = jest.fn();
+      mockDirectoryList.mockReturnValue([
+        { uri: `/documents/${oldFilename}`, delete: mockDeleteOld },
+        { uri: `/documents/${recentFilename}`, delete: mockDeleteRecent },
+      ]);
+
+      deleteOldLogFiles();
+
+      expect(mockDeleteOld).toHaveBeenCalled();
+      expect(mockDeleteRecent).not.toHaveBeenCalled();
+    });
+
+    it('ignores files with malformed date suffix', () => {
+      const mockDelete = jest.fn();
+      mockDirectoryList.mockReturnValue([
+        { uri: '/documents/recipedia-logs-notadate.txt', delete: mockDelete },
+      ]);
+
+      deleteOldLogFiles();
+
+      expect(mockDelete).not.toHaveBeenCalled();
     });
   });
 
@@ -78,22 +176,37 @@ describe('BugReport utils', () => {
       );
     });
 
-    it('includes log file in attachments when the log file exists', async () => {
+    it('includes existing log files in attachments', async () => {
       mockFileExists.mockReturnValue(true);
 
       await sendBugReport('Test description', []);
 
       const callArgs = mockComposeAsync.mock.calls[0][0];
-      expect(callArgs.attachments).toContain(LOG_FILE.uri);
+      getRecentLogFiles().forEach(f => {
+        expect(callArgs.attachments).toContain(f.uri);
+      });
     });
 
-    it('excludes log file from attachments when the log file does not exist', async () => {
+    it('attaches only existing log files when some are missing', async () => {
+      const logFiles = getRecentLogFiles();
+      mockFileExists.mockImplementation((uri: string) => uri === logFiles[0].uri);
+
+      await sendBugReport('Test description', []);
+
+      const callArgs = mockComposeAsync.mock.calls[0][0];
+      expect(callArgs.attachments).toContain(logFiles[0].uri);
+      expect(callArgs.attachments).not.toContain(logFiles[1].uri);
+    });
+
+    it('excludes log files from attachments when none exist', async () => {
       mockFileExists.mockReturnValue(false);
 
       await sendBugReport('Test description', []);
 
       const callArgs = mockComposeAsync.mock.calls[0][0];
-      expect(callArgs.attachments).not.toContain(LOG_FILE.uri);
+      getRecentLogFiles().forEach(f => {
+        expect(callArgs.attachments).not.toContain(f.uri);
+      });
     });
 
     it('includes screenshot URIs in attachments', async () => {


### PR DESCRIPTION
## Summary

- **Daily log rotation** — switch from a single static `recipedia-logs.txt` to per-day files (`recipedia-logs-YYYY-M-D.txt`) using react-native-logs `{date-today}` template; same-day launches append, no unbounded growth
- **30-day retention** — `deleteOldLogFiles()` scans the documents directory on startup and prunes files older than 30 days; wrapped in try/catch so a missing directory cannot crash the startup `useEffect`
- **Bug report attachment** — `getRecentLogFiles()` returns the last 2 days' files; `sendBugReport()` attaches whichever exist rather than one hard-coded path
- **Logging gaps** — add missing debug/warn logs across `RecipeFormContext`, `useRecipeIngredients`, `useRecipeTags`, `Recipe`, `TagsSettings`, `HelloFreshProvider`, `RecipeImportOrchestrator`
- **Error-handling fixes** — wrap `fillOneField` (OCR) and `scaleAllRecipesForNewDefaultPersons` (recipes) in try/catch/finally so loading spinners and progress bars cannot get permanently stuck on failure
- **CI** — update `collect-android-logs.sh` and `collect-ios-logs.sh` to collect all daily log files (glob loop) instead of pulling one static filename; quote path variables

## Test plan

- [ ] Unit tests: `npm run test:unit` — 3400 tests, all green
- [ ] Bug report screen: trigger a report and verify today's + yesterday's log files are attached
- [ ] OCR extraction: force a failure (bad image) and confirm spinner resets
- [ ] Default persons change: verify progress bar clears after DB error
- [ ] Log cleanup: manually place a 31-day-old log file in the documents dir and confirm it is deleted on next launch
- [ ] E2E: run a Maestro suite and verify `recipedia-app-logs.txt` artifact is non-empty in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)