### PR TITLE
fix(startup): unregister legacy background tasks on app init

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import {ScraperProvider} from '@app/modules/recipe-scraper';
 import {RecipeDatabase} from '@utils/RecipeDatabase';
 import {init as initFileSystem} from '@utils/FileGestion';
 import {cleanupOrphanedImages} from '@utils/FileGestion';
+import {unregisterLegacyBackgroundTasks} from '@utils/legacyTaskCleanup';
 
 // TODO manage horizontal mode
 
@@ -45,6 +46,8 @@ function AppContent() {
         const initialize = async () => {
             try {
                 appLogger.info('Starting app initialization');
+
+                void unregisterLegacyBackgroundTasks();
 
                 initFileSystem();
 

--- a/src/utils/BugReport.ts
+++ b/src/utils/BugReport.ts
@@ -26,8 +26,8 @@ const DEVELOPER_EMAIL = 'antonin.coupanec.dev@outlook.com';
 
 const LOG_FILE_PREFIX = 'recipedia-logs-';
 const LOG_FILE_SUFFIX = '.txt';
-const LOG_ATTACH_COUNT = 2;
-const LOG_RETENTION_DAYS = 30;
+export const LOG_ATTACH_COUNT = 2;
+export const LOG_RETENTION_DAYS = 30;
 
 /**
  * Returns File references for the most recent log files.

--- a/src/utils/legacyTaskCleanup.ts
+++ b/src/utils/legacyTaskCleanup.ts
@@ -1,0 +1,47 @@
+/**
+ * Legacy background-task cleanup
+ *
+ * Background tasks registered via `expo-task-manager` / `expo-background-task`
+ * persist in the OS scheduler across app upgrades. When a task is removed from
+ * the codebase, its registration must be explicitly cancelled — otherwise the
+ * OS keeps firing it, launching a headless JS context with no matching
+ * `defineTask` handler, which can race with normal app initialization.
+ *
+ * Each entry in {@link LEGACY_BACKGROUND_TASK_NAMES} is the exact task name
+ * that was once registered via `TaskManager.defineTask(name, ...)` and is no
+ * longer defined in the current build.
+ *
+ * @module utils/legacyTaskCleanup
+ */
+
+import * as TaskManager from 'expo-task-manager';
+import { appLogger } from '@utils/logger';
+
+export const LEGACY_BACKGROUND_TASK_NAMES: readonly string[] = ['recipedia.image-repair'];
+
+/**
+ * Unregisters any legacy background task still registered with the OS scheduler
+ *
+ * Idempotent: tasks that aren't registered are silently skipped. Safe to call
+ * on every app startup — once a task is unregistered, subsequent calls are
+ * no-ops.
+ *
+ * Failures are logged but never rethrown, so a broken cleanup cannot block
+ * app initialization.
+ *
+ * @returns Promise that resolves once every entry in
+ * {@link LEGACY_BACKGROUND_TASK_NAMES} has been processed
+ */
+export async function unregisterLegacyBackgroundTasks(): Promise<void> {
+  for (const name of LEGACY_BACKGROUND_TASK_NAMES) {
+    try {
+      const registered = await TaskManager.isTaskRegisteredAsync(name);
+      if (!registered) continue;
+
+      await TaskManager.unregisterTaskAsync(name);
+      appLogger.info('Unregistered legacy background task', { name });
+    } catch (error) {
+      appLogger.warn('Failed to unregister legacy background task', { name, error });
+    }
+  }
+}

--- a/tests/mocks/deps/expo-task-manager-mock.ts
+++ b/tests/mocks/deps/expo-task-manager-mock.ts
@@ -1,11 +1,13 @@
 export const mockDefineTask = jest.fn();
 export const mockIsTaskDefined = jest.fn().mockReturnValue(false);
 export const mockIsTaskRegisteredAsync = jest.fn().mockResolvedValue(false);
+export const mockUnregisterTaskAsync = jest.fn().mockResolvedValue(undefined);
 
 export function expoTaskManagerMock() {
   return {
     defineTask: mockDefineTask,
     isTaskDefined: mockIsTaskDefined,
     isTaskRegisteredAsync: mockIsTaskRegisteredAsync,
+    unregisterTaskAsync: mockUnregisterTaskAsync,
   };
 }

--- a/tests/unit/utils/legacyTaskCleanup.test.ts
+++ b/tests/unit/utils/legacyTaskCleanup.test.ts
@@ -1,0 +1,139 @@
+import {
+  LEGACY_BACKGROUND_TASK_NAMES,
+  unregisterLegacyBackgroundTasks,
+} from '@utils/legacyTaskCleanup';
+import {
+  mockIsTaskRegisteredAsync,
+  mockUnregisterTaskAsync,
+} from '@mocks/deps/expo-task-manager-mock';
+import { appLogger } from '@utils/logger';
+
+jest.mock('expo-task-manager', () =>
+  require('@mocks/deps/expo-task-manager-mock').expoTaskManagerMock()
+);
+
+describe('legacyTaskCleanup', () => {
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockIsTaskRegisteredAsync.mockReset().mockResolvedValue(false);
+    mockUnregisterTaskAsync.mockReset().mockResolvedValue(undefined);
+    infoSpy = jest.spyOn(appLogger, 'info').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(appLogger, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  describe('LEGACY_BACKGROUND_TASK_NAMES', () => {
+    it('includes the removed orphan image cleanup task', () => {
+      expect(LEGACY_BACKGROUND_TASK_NAMES).toContain('recipedia.image-repair');
+    });
+  });
+
+  describe('unregisterLegacyBackgroundTasks', () => {
+    it('unregisters every legacy task that is still registered', async () => {
+      mockIsTaskRegisteredAsync.mockResolvedValue(true);
+
+      await unregisterLegacyBackgroundTasks();
+
+      for (const name of LEGACY_BACKGROUND_TASK_NAMES) {
+        expect(mockUnregisterTaskAsync).toHaveBeenCalledWith(name);
+      }
+      expect(mockUnregisterTaskAsync).toHaveBeenCalledTimes(LEGACY_BACKGROUND_TASK_NAMES.length);
+    });
+
+    it('skips unregistration when the task is not registered', async () => {
+      mockIsTaskRegisteredAsync.mockResolvedValue(false);
+
+      await unregisterLegacyBackgroundTasks();
+
+      expect(mockUnregisterTaskAsync).not.toHaveBeenCalled();
+    });
+
+    it('continues processing remaining tasks when one fails to be checked', async () => {
+      if (LEGACY_BACKGROUND_TASK_NAMES.length < 2) {
+        mockIsTaskRegisteredAsync.mockRejectedValueOnce(new Error('boom'));
+        await expect(unregisterLegacyBackgroundTasks()).resolves.toBeUndefined();
+        return;
+      }
+
+      mockIsTaskRegisteredAsync.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(true);
+
+      await unregisterLegacyBackgroundTasks();
+
+      expect(mockUnregisterTaskAsync).toHaveBeenCalledTimes(
+        LEGACY_BACKGROUND_TASK_NAMES.length - 1
+      );
+    });
+
+    it('does not throw when unregisterTaskAsync rejects', async () => {
+      mockIsTaskRegisteredAsync.mockResolvedValue(true);
+      mockUnregisterTaskAsync.mockRejectedValue(new Error('os error'));
+
+      await expect(unregisterLegacyBackgroundTasks()).resolves.toBeUndefined();
+    });
+
+    it('processes tasks in declared order', async () => {
+      mockIsTaskRegisteredAsync.mockResolvedValue(true);
+
+      await unregisterLegacyBackgroundTasks();
+
+      const calledNames = mockUnregisterTaskAsync.mock.calls.map(call => call[0]);
+      expect(calledNames).toEqual([...LEGACY_BACKGROUND_TASK_NAMES]);
+    });
+
+    it('logs an info entry for each successfully unregistered task', async () => {
+      mockIsTaskRegisteredAsync.mockResolvedValue(true);
+
+      await unregisterLegacyBackgroundTasks();
+
+      for (const name of LEGACY_BACKGROUND_TASK_NAMES) {
+        expect(infoSpy).toHaveBeenCalledWith('Unregistered legacy background task', { name });
+      }
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not log an info entry when the task is not registered', async () => {
+      mockIsTaskRegisteredAsync.mockResolvedValue(false);
+
+      await unregisterLegacyBackgroundTasks();
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning with the error when isTaskRegisteredAsync rejects', async () => {
+      const failure = new Error('registry read failure');
+      mockIsTaskRegisteredAsync.mockRejectedValue(failure);
+
+      await unregisterLegacyBackgroundTasks();
+
+      for (const name of LEGACY_BACKGROUND_TASK_NAMES) {
+        expect(warnSpy).toHaveBeenCalledWith('Failed to unregister legacy background task', {
+          name,
+          error: failure,
+        });
+      }
+      expect(mockUnregisterTaskAsync).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning with the error when unregisterTaskAsync rejects', async () => {
+      const failure = new Error('os error');
+      mockIsTaskRegisteredAsync.mockResolvedValue(true);
+      mockUnregisterTaskAsync.mockRejectedValue(failure);
+
+      await unregisterLegacyBackgroundTasks();
+
+      for (const name of LEGACY_BACKGROUND_TASK_NAMES) {
+        expect(warnSpy).toHaveBeenCalledWith('Failed to unregister legacy background task', {
+          name,
+          error: failure,
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Drops stale OS-scheduler registration for the removed `OrphanCleanupTask` (`recipedia.image-repair`) on every app startup.
- Adds centralized `LEGACY_BACKGROUND_TASK_NAMES` list + idempotent `unregisterLegacyBackgroundTasks()` helper in `src/utils/legacyTaskCleanup.ts`.
- Wires it as fire-and-forget (`void`) early in `App.tsx` init so it never blocks the splash-screen critical path.

## Why
A user report came in with a startup ANR followed by a successful relaunch. The log (~188k lines in ~4 minutes during boot) showed:

1. App init started.
2. `OrphanCleanupTask: background task fired` from a stale OS-scheduler registration (the task file was deleted in commit `1498ae0b`).
3. The headless task path raced the foreground init, triggered repeated `NativeDatabase.prepareAsync` rejections with `java.lang.NullPointerException`, and each rejection emitted a multi-line `Database` warning per recipe ingredient/tag.
4. The flood blocked the JS thread → Android ANR.

`RecipeDatabase.getInstance()`/`init()` is already concurrency-safe (single `_initPromise`), so the root cause is the stale OS registration surviving the upgrade. Once users open this build once, the registration is dropped and the race can't recur.

## Implementation
- Helper iterates `LEGACY_BACKGROUND_TASK_NAMES`, checks `TaskManager.isTaskRegisteredAsync`, calls `unregisterTaskAsync` only when registered, logs success/failure via `appLogger`. All errors are swallowed so cleanup cannot block boot.
- Called as `void unregisterLegacyBackgroundTasks();` in `App.tsx` — no consumer of the result, no need to block init.
- Future legacy task removals: append the task name to `LEGACY_BACKGROUND_TASK_NAMES`.

## Test plan
- [x] `npm run test:unit -- tests/unit/utils/legacyTaskCleanup.test.ts` — 10/10 pass (registered/not-registered branches, both error paths, log payloads, declared iteration order).
- [x] `npm run typecheck` clean.
- [ ] Manual: install build over a prior build with the stale registration → confirm `Unregistered legacy background task` log entry on first launch and no `OrphanCleanupTask: background task fired` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)