### PR TITLE
docs: add TSDoc, architecture guide, and developer guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,365 @@
+# Architecture
+
+Recipedia is a single-user, local-first recipe management app built with React Native and Expo. It runs entirely on-device: no backend, no cloud sync. Recipes, ingredients, tags, and shopping data live in a SQLite database. The app is iOS and Android only (portrait orientation).
+
+---
+
+## Table of contents
+
+1. [System overview](#1-system-overview)
+2. [Data flow](#2-data-flow)
+3. [Database architecture](#3-database-architecture)
+4. [State management](#4-state-management)
+5. [Navigation structure](#5-navigation-structure)
+6. [Component hierarchy](#6-component-hierarchy)
+7. [Recipe form architecture](#7-recipe-form-architecture)
+8. [Bulk import pipeline](#8-bulk-import-pipeline)
+9. [Key invariants](#9-key-invariants)
+10. [File naming conventions](#10-file-naming-conventions)
+11. [Adding a new feature checklist](#11-adding-a-new-feature-checklist)
+
+---
+
+## 1. System overview
+
+Core capabilities:
+
+- Create, view, edit, and delete recipes with images, ingredients, preparation steps, tags, and nutrition data
+- OCR extraction from photos (`@react-native-ml-kit/text-recognition`)
+- Import recipes from 400+ websites via an embedded Python scraper (`modules/recipe-scraper`)
+- Bulk import from HelloFresh and Quitoque with a validation workflow
+- Fuzzy search (MiniSearch) across recipe titles, ingredient names, and tags
+- Shopping list derived from a weekly menu
+- Seasonal ingredient awareness
+- English and French UI
+
+Everything runs offline. The recipe scraper network-fetches URLs during import, but the app does not require connectivity for any core function.
+
+---
+
+## 2. Data flow
+
+The canonical data flow for a user action that reads or writes recipe data:
+
+```
+User action in a component
+        |
+        v
+Custom hook (useRecipes, useIngredients, useTags, useMenu, useShopping)
+        |
+        v
+RecipeDatabase singleton  <----> In-memory cache (_recipes, _ingredients, ...)
+        |
+        v
+expo-sqlite (SQLite on device)
+        |
+        v  notify(slice)
+useSyncExternalStore callbacks in hooks
+        |
+        v
+Components re-render with new data
+```
+
+Key points:
+
+- Hooks call `RecipeDatabase.getInstance()` to obtain the singleton and then call its methods.
+- Mutation methods (`addRecipe`, `editRecipe`, etc.) write to SQLite, update the in-memory cache, then call `notify('recipes')` (or the relevant slice name).
+- `useSyncExternalStore` in each hook subscribes to that slice. Only hooks subscribed to the mutated slice re-render; a tag change does not re-render components that only subscribe to `recipes`.
+- Read operations (`get_recipes()`, `get_ingredients()`) return the in-memory array synchronously — no async await needed in the UI layer for reads after initialization.
+
+---
+
+## 3. Database architecture
+
+### Singleton
+
+`RecipeDatabase` in `src/utils/RecipeDatabase.tsx` is the only entry point to SQLite. It is a private-constructor singleton accessed via `RecipeDatabase.getInstance()`. It initializes once (`init()`) on app startup, creating tables and running schema migrations if necessary.
+
+**Never call `RecipeDatabase.getInstance()` inside a React component.** Components must go through the focused hooks instead. The singleton may be called from non-React utility code that runs outside the component tree (e.g. `datasetInitializer.ts`).
+
+### Tables
+
+| Table | Type file key | Purpose |
+|---|---|---|
+| `RecipesTable` | `recipeTableElement` | Core recipe data |
+| `IngredientsTable` | `ingredientTableElement` | Ingredient master data (shared across recipes) |
+| `TagsTable` | `tagTableElement` | Tag definitions |
+| `MenuTable` | `menuTableElement` | User's weekly cooking menu |
+| `PurchasedIngredientsTable` | `purchasedIngredientElement` | Purchase state for shopping list items |
+| `ImportHistoryTable` | `importHistoryTableElement` | Records of previously discovered bulk-import recipes |
+
+All table and column name constants live in `src/customTypes/DatabaseElementTypes.tsx`.
+
+### Encoding and decoding
+
+SQLite stores only primitive types. Complex fields (ingredient arrays, tag arrays, preparation steps, nutrition) are serialized to TEXT using custom separators defined in `src/styles/typography.ts` (`textSeparator`, `unitySeparator`, `EncodingSeparator`, `noteSeparator`). Each table has a corresponding `encoded*Element` type (e.g. `encodedRecipeElement`) and a `*ColumnsEncoding` array that declares each column's SQLite type.
+
+When reading: `RecipeDatabase` decodes rows from `encoded*Element` back to the rich TypeScript type.  
+When writing: the rich type is encoded to flat primitives before the SQL statement.
+
+### In-memory cache and pub/sub
+
+On initialization, all rows are loaded into memory (`_recipes`, `_ingredients`, `_tags`, `_menu`, `_purchasedIngredients`). After any mutation, `notify(slice)` fires all listeners registered for that slice via `subscribe(slice, callback)`. The focused hooks bind this to `useSyncExternalStore`.
+
+The `StoreSlice` type enumerates the available slices: `'recipes' | 'ingredients' | 'tags' | 'menu' | 'purchased'`.
+
+### Schema migrations
+
+Add new columns inside `init()` using `ALTER TABLE ... ADD COLUMN ...` guarded by a `PRAGMA table_info` check so the migration is idempotent across fresh installs and upgrades.
+
+---
+
+## 4. State management
+
+There is no Redux or Zustand. State falls into three categories:
+
+### Global app state (React Context, app-wide)
+
+Defined in `src/context/` and provided near the root in `App.tsx`:
+
+| Context | Hook | Responsibility |
+|---|---|---|
+| `DarkModeContext` | `useContext(DarkModeContext)` | Dark/light theme toggle, persisted to AsyncStorage |
+| `SeasonFilterContext` | `useSeasonFilter()` | Global season filter toggle, persisted to AsyncStorage |
+| `DefaultPersonsContext` | `useDefaultPersons()` | Default serving count setting, persisted to AsyncStorage |
+
+### Screen-scoped state (React Context, Recipe screen only)
+
+Provided by wrappers inside `src/screens/Recipe.tsx`:
+
+| Context | Hook | Responsibility |
+|---|---|---|
+| `RecipeFormContext` | `useRecipeForm()` | All form field values and setters for the active recipe; resets on navigation |
+| `RecipeDialogsContext` | `useRecipeDialogs()` | Dialog open/close state (validation, similarity, queue) scoped to the Recipe screen |
+
+These contexts are intentionally narrow. They exist to avoid prop-drilling across the several hooks (`useRecipeIngredients`, `useRecipeTags`, `useRecipePreparation`, `useRecipeOCR`, `useRecipeScraperValidation`) that all need access to form state from within a single screen.
+
+### Reactive database state (useSyncExternalStore, cross-component)
+
+Hooks that subscribe to `RecipeDatabase` slices:
+
+| Hook | Slice | What it exposes |
+|---|---|---|
+| `useRecipes` | `recipes` | CRUD for recipes, fuzzy search, scaling |
+| `useIngredients` | `ingredients` | Ingredient master data, CRUD |
+| `useTags` | `tags` | Tag CRUD and random tag suggestions |
+| `useMenu` | `menu`, `purchased` | Menu management and purchase state |
+| `useShopping` | `menu`, `purchased` | Derived shopping list (read-only, no mutations) |
+| `useImportHistory` | — | Import history records |
+
+---
+
+## 5. Navigation structure
+
+Navigation uses React Navigation v6. Types for screens and params are defined in `src/customTypes/ScreenTypes.tsx`.
+
+```
+NavigationContainer (App.tsx)
+└── RootNavigator (Stack)
+    ├── Tabs (BottomTabs)                   -- initial route
+    │   ├── Home                            -- recipe list + FAB for creation
+    │   ├── Search                          -- fuzzy search + filter UI
+    │   ├── Menu                            -- weekly cooking menu
+    │   ├── Shopping                        -- shopping list derived from menu
+    │   └── Parameters                      -- settings hub
+    ├── Recipe                              -- view / edit / create recipe
+    ├── LanguageSettings
+    ├── DefaultPersonsSettings
+    ├── IngredientsSettings
+    ├── TagsSettings
+    ├── BulkImportSettings
+    ├── BulkImportDiscovery
+    ├── BulkImportValidation
+    └── BugReport
+```
+
+All screens are header-less (`headerShown: false`). Navigation animations can be disabled globally via `EXPO_PUBLIC_DISABLE_ANIMATIONS=true` (used by E2E tests).
+
+The `Recipe` screen receives a typed `RecipePropType` parameter that describes the mode:
+
+- `readOnly` — view an existing recipe
+- `edit` — edit an existing recipe
+- `add` — create a new recipe from scratch
+- `addFromPic` — create from a photo (OCR pre-fills fields)
+- `addFromScrape` — create from scraped web data (pre-fills from scraper output)
+
+---
+
+## 6. Component hierarchy
+
+The project follows Atomic Design. Components live in `src/components/`:
+
+| Layer | Directory | Rule |
+|---|---|---|
+| Atomic | `components/atomic/` | Single-purpose building blocks with no business logic. No hooks that touch the DB. |
+| Molecules | `components/molecules/` | Combinations of atoms. May have local UI state. No DB hooks. |
+| Organisms | `components/organisms/` | Feature sections — may use hooks, may call DB hooks indirectly. |
+| Dialogs | `components/dialogs/` | Modal overlays. Receive state via props or context, not from DB directly. |
+| Templates | `components/templates/` | Layout wrappers (e.g. `ScreenWrapper`). |
+
+Use React Native Paper components (`Text`, `Button`, `Card`, etc.) before writing custom primitives. Theme colors come from `useTheme()` from `react-native-paper`.
+
+---
+
+## 7. Recipe form architecture
+
+The Recipe screen (`src/screens/Recipe.tsx`) supports read-only view, edit, and create modes in a single component. Form state is held in `RecipeFormContext`.
+
+### Context structure
+
+`RecipeFormContext` (see `src/context/RecipeFormContext.tsx`) exposes three objects:
+
+- `state` — current values for all form fields
+- `setters` — `Dispatch<SetStateAction<T>>` for each field
+- `actions` — `resetToOriginal()` and `createRecipeSnapshot()`
+
+`RecipeFormProvider` initialises state from navigation props: existing recipe data (edit mode), scraped data (web import), or blank defaults (new recipe).
+
+### Ingredient quantity scaling
+
+When `recipePersons` changes, a `useEffect` in `RecipeFormProvider` automatically scales all ingredient quantities proportionally using `scaleQuantityForPersons` from `src/utils/Quantity.ts`. This keeps ingredient quantities consistent with the displayed serving count throughout the editing session.
+
+### Field hooks
+
+Each field domain has its own hook that reads from and writes to `RecipeFormContext`:
+
+| Hook | Responsibility |
+|---|---|
+| `useRecipeIngredients` | Add, edit, delete, reorder ingredients; similarity detection |
+| `useRecipeTags` | Add, remove, suggest tags |
+| `useRecipePreparation` | Add, edit, delete, reorder preparation steps |
+| `useRecipeOCR` | Trigger OCR, parse results into form fields |
+| `useRecipeScraperValidation` | Validate and apply scraped recipe data |
+
+### Validation and save
+
+`validateRecipeData` in `src/utils/RecipeFormHelpers.tsx` checks required fields before saving. `createRecipeSnapshot()` assembles the current form state into a `recipeTableElement` ready for `useRecipes.addRecipe()` or `useRecipes.editRecipe()`.
+
+### Zod schemas
+
+Narrow Zod schemas exist in `src/schemas/` for sub-forms like the item dialog (`itemDialogSchema.ts`) and bug report (`bugReportSchema.ts`). These use `react-hook-form` with `@hookform/resolvers/zod`. The main recipe form still uses the custom `RecipeFormContext` approach.
+
+---
+
+## 8. Bulk import pipeline
+
+```
+User selects provider (HelloFresh, Quitoque)
+        |
+        v
+BulkImportSettings screen -- provider configuration
+        |
+        v
+BulkImportDiscovery screen
+  useDiscoveryWorkflow hook
+    BaseRecipeProvider.discoverRecipes()  -- fetches category pages, extracts URLs
+        |
+        v
+  useRecipeScraper hook
+    recipe-scraper native module          -- Python scraper extracts structured data
+        |
+        v
+BulkImportValidation screen
+  useValidationWorkflow hook
+    Phases: initializing → warning → reviewing → importing → complete
+    User maps unknown ingredients/tags to existing DB entries
+        |
+        v
+  useRecipes.addMultipleRecipes()         -- writes to DB
+```
+
+### Provider system
+
+`BaseRecipeProvider` (`src/providers/BaseRecipeProvider.ts`) is an abstract class implementing the `RecipeProvider` interface. Concrete providers (`HelloFreshProvider`, `QuitoqueProvider`) override URL discovery logic. All providers are registered in `ProviderRegistry.ts`.
+
+Providers are responsible only for discovering recipe URLs. Scraping (content extraction) is entirely handled by the `recipe-scraper` native module.
+
+### Validation workflow phases
+
+| Phase | Description |
+|---|---|
+| `initializing` | Analyzes discovered recipes, fuzzy-matches ingredients and tags against the existing DB |
+| `warning` | Shows pre-validation summary of skipped or unrecognized items |
+| `reviewing` | User manually maps unknown ingredients/tags one at a time |
+| `importing` | Writes all validated recipes to the DB in batch |
+| `complete` | Shows summary of imported recipes |
+| `error` | Something failed; user can retry |
+
+---
+
+## 9. Key invariants
+
+These must not be violated. Violating them causes subtle bugs or breaks CI.
+
+**Never call `RecipeDatabase.getInstance()` in a React component.** Use the focused hooks (`useRecipes`, `useIngredients`, etc.). Direct singleton calls bypass `useSyncExternalStore` subscriptions and produce stale UI.
+
+**Never add `useCallback`, `useMemo`, or `React.memo`.** React Compiler (enabled in `app.config.ts`) handles memoization automatically. Manual memoization interferes with the compiler's analysis and adds dead code.
+
+**Always use path aliases, never relative cross-feature imports.** Use `@utils/RecipeDatabase`, `@hooks/useRecipes`, `@components/organisms/RecipeImage`, etc. The aliases are defined in `tsconfig.json`. Relative imports like `../../utils/RecipeDatabase` are forbidden across feature boundaries.
+
+**Integration tests must not mock hooks, DB, or any in-app layer.** Mock only at irreducible native module boundaries (e.g. `@react-native-ml-kit/text-recognition`). This is what distinguishes integration tests from unit tests.
+
+**All user-facing strings must use i18n.** Use `useI18n()` and add keys to both `en/` and `fr/` translation files. Do not hardcode English strings in components.
+
+**All new utility functions outside React components must have unit tests and TypeDoc comments.** See `CLAUDE.md`.
+
+**Schema changes require a migration.** Adding a column without a `PRAGMA`-guarded `ALTER TABLE` in `init()` breaks existing app installs.
+
+---
+
+## 10. File naming conventions
+
+| Type | Convention | Example |
+|---|---|---|
+| React components | PascalCase `.tsx` | `RecipeCard.tsx` |
+| Hooks | camelCase, `use` prefix, `.ts` | `useRecipeIngredients.ts` |
+| Utilities | PascalCase `.tsx` or `.ts` | `RecipeDatabase.tsx`, `Quantity.ts` |
+| Context files | PascalCase, `Context` suffix, `.tsx` | `RecipeFormContext.tsx` |
+| Type files | PascalCase, `Types` suffix, `.tsx` | `DatabaseElementTypes.tsx`, `BulkImportTypes.tsx` |
+| Schemas | camelCase, `Schema` suffix, `.ts` | `itemDialogSchema.ts` |
+| Providers | PascalCase, `Provider` suffix, `.ts` | `HelloFreshProvider.ts` |
+| Test files | Mirror source path, `.test.ts(x)` | `tests/unit/utils/Quantity.test.ts` |
+| Translation files | feature-scoped, camelCase, `.ts` | `recipe.ts`, `bulkImport.ts` |
+
+Screens are PascalCase `.tsx` at `src/screens/` — no subdirectory nesting except for the recipe screen components.
+
+---
+
+## 11. Adding a new feature checklist
+
+Use this checklist when adding a non-trivial feature. Not every step applies to every feature — adjust as needed.
+
+**Types**
+- [ ] Define or extend types in `src/customTypes/`
+- [ ] Export the types; check nothing relies on the old shape
+
+**Database (if persisted data changes)**
+- [ ] Add/modify column in the encoded type and `*ColumnsEncoding` array
+- [ ] Add encoding/decoding logic in `RecipeDatabase`
+- [ ] Add a `PRAGMA`-guarded `ALTER TABLE` migration in `init()`
+- [ ] Expose the new data via a focused hook (or extend an existing one)
+
+**Business logic**
+- [ ] Add utility functions outside React components in `src/utils/`
+- [ ] Add TypeDoc comments to all exported functions
+- [ ] Add unit tests in `tests/unit/`
+
+**UI**
+- [ ] Build from the correct atomic layer (atomic → molecule → organism → screen)
+- [ ] Use React Native Paper components
+- [ ] Support both light and dark themes via `useTheme().colors`
+- [ ] Add i18n keys to `src/translations/en/` and `src/translations/fr/`
+
+**Navigation (if a new screen)**
+- [ ] Add screen name and params to `ScreenTypes.tsx`
+- [ ] Register the screen in `RootNavigator.tsx` or `BottomTabs.tsx`
+
+**Testing**
+- [ ] Unit tests for new utilities
+- [ ] Integration test if the feature involves a cross-module flow
+- [ ] E2E test (Maestro) if the feature has a user-visible workflow that has burned regressions before
+
+**Quality**
+- [ ] `npm run quality` passes
+- [ ] `npm run test:unit` passes
+- [ ] `npm run test:integration` passes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -456,7 +456,7 @@ We use labels to categorize issues:
 
 ### Performance
 
-- Use `React.memo` for expensive components
+- React Compiler handles memoization — do **not** add `React.memo`, `useMemo`, or `useCallback`
 - Optimize large lists with FlashList
 - Profile app performance regularly
 - Monitor bundle size
@@ -571,6 +571,23 @@ targetServings: number
 - **TypeScript Integration**: All types must be properly exported and documented
 - **Source Links**: Documentation includes direct links to GitHub source files
 - **Examples Required**: Complex components and utilities must include usage examples
+
+#### Keeping Documentation Current
+
+When submitting a PR, update the relevant docs alongside the code:
+
+| Change | What to update |
+|--------|----------------|
+| Add/modify exported function or type in `utils/` or `hooks/` | TSDoc block on that export; run `npm run docs:build` |
+| Add a new React Context provider | `ARCHITECTURE.md` — State management section |
+| Introduce a new architectural pattern or invariant | `ARCHITECTURE.md` — relevant section + Key Invariants |
+| Change navigation structure | `ARCHITECTURE.md` — Navigation section |
+| Add a workflow spanning multiple layers (new import pipeline, new form type) | New file in `guides/` |
+| Add a new dev setup requirement (env var, native dep) | `guides/installation.md` |
+
+Docs files live in:
+- `ARCHITECTURE.md` — system-level overview and invariants (root)
+- `guides/` — step-by-step guides for setup, testing, CI, FAQ
 
 #### Documentation Publishing
 

--- a/README.md
+++ b/README.md
@@ -100,16 +100,13 @@ src/
 
 ### For Users
 
-- [Installation Guide](docs/installation.md)
-- [User Manual](docs/user-guide.md)
-- [FAQ](docs/faq.md)
+- [Installation Guide](guides/installation.md)
+- [FAQ](guides/faq.md)
 
 ### For Developers
 
 - **[API Documentation](https://AntoC-dev.github.io/Recipedia/)** - Complete TypeScript API reference
 - [Contributing Guidelines](CONTRIBUTING.md)
-- [Testing Guide](docs/testing.md)
-- [CI/CD Setup](docs/ci-setup.md)
 
 ### API Documentation
 
@@ -268,7 +265,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📞 Support
 
-- **Documentation**: Check our [docs folder](docs/)
+- **Documentation**: Check our [guides folder](guides/)
 - **Issues**: [GitHub Issues](https://github.com/AntoC-dev/Recipedia/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/AntoC-dev/Recipedia/discussions)
 

--- a/guides/ci-setup.md
+++ b/guides/ci-setup.md
@@ -1,0 +1,290 @@
+# CI Setup Guide
+
+Recipedia uses GitHub Actions for all CI/CD. This guide covers every workflow, required secrets, the EAS build pipeline, quality gates, and how to debug failures.
+
+---
+
+## Workflows overview
+
+| File | Name | Triggers |
+|---|---|---|
+| `quality.yml` | Code Quality | push/PR to `main` |
+| `build-test.yml` | Build & Test Pipeline | push/PR to `main` |
+| `build-app.yml` | Build App (reusable) | `workflow_call` |
+| `e2e-maestro.yml` | E2E Maestro Tests (reusable) | `workflow_call` |
+| `performance.yml` | Performance Tests (Flashlight) | nightly cron, `workflow_dispatch`, PR with `perf-test` label |
+| `documentation.yml` | Documentation | push to `main` (src/README/jsdoc changes), `workflow_dispatch` |
+| `release.yml` | Release | push to `main`, `workflow_dispatch` |
+| `publication.yml` | Publication | after Build & Test Pipeline succeeds on `main`, `workflow_dispatch` |
+
+---
+
+## Code Quality (`quality.yml`)
+
+Runs on every push and PR to `main`. Jobs run in parallel after `install`:
+
+```
+commit-validation (PR only)
+    └── install
+            ├── lint           (ESLint)
+            ├── formatting     (Prettier)
+            ├── typescript     (tsc)
+            ├── expo-doctor    (Expo config check)
+            ├── security       (npm audit — critical level)
+            └── documentation  (TypeDoc build)
+```
+
+- **commit-validation**: Runs `commitlint` against all commits in the PR range. Conventional Commits format required.
+- **security**: Uses `oke-py/npm-audit-action`, fails only on `critical` severity, posts a PR comment if vulnerabilities are found.
+- **documentation**: Runs `npm run docs:build`. Fails the pipeline if TypeDoc exits with warnings.
+
+All jobs restore `node_modules` from cache keyed on `package-lock.json` hash.
+
+---
+
+## Build & Test Pipeline (`build-test.yml`)
+
+Runs on every push and PR to `main`. This is the main pipeline.
+
+### Job graph
+
+```
+install-and-doctor
+    ├── reassure-performance     (PR only — compares render benchmarks)
+    ├── unit-tests-and-coverage
+    ├── integration-tests
+    ├── build-android  ──────────── e2e-tests-android ──┐
+    ├── build-android-performance ─ e2e-tests-android-perf ┤
+    └── build-ios ───────────────── e2e-tests-ios ──────┤
+                                                         └── merge-test-artifacts
+                                                                  └── test-result-summary
+```
+
+### install-and-doctor
+
+Runs `npm ci` and caches `node_modules` by `package-lock.json` hash (key: `{os}-node_modules-{hash}`). All downstream jobs restore from this cache.
+
+### unit-tests-and-coverage
+
+- Runs `npm run test:unit:coverage`
+- Uploads `coverage/` artifact (30-day retention)
+- Posts per-file cobertura coverage comment on PRs (minimum 75%, does not block merge)
+- Uploads JUnit summary artifact
+
+### integration-tests
+
+- Runs `npm run test:integration`
+- Uploads JUnit summary artifact
+
+### reassure-performance
+
+- PR-only job
+- Checks out the base SHA, installs, runs `npm run test:perf:baseline`
+- Checks out the PR SHA, installs, runs `npm run test:perf`
+- Generates a compact diff with `.github/scripts/reassure-compact-summary.mjs`
+- Posts a sticky PR comment (header: `reassure`) via `marocchino/sticky-pull-request-comment`
+- Uploads `.reassure/` as artifact (7-day retention)
+
+### build-android / build-ios
+
+Both delegate to the reusable `build-app.yml` workflow with these profiles:
+
+| Job | Platform | Profile | Artifact |
+|---|---|---|---|
+| `build-android` | android | `test` | `build-apk` / `recipedia-maestro.apk` |
+| `build-android-performance` | android | `perf` | `build-apk-performance` / `recipedia-performance.apk` |
+| `build-ios` | ios | `test` | `build-ios-app` / `Recipedia.app` |
+
+The build-app workflow skips a fresh build if:
+- No relevant files changed (paths filter on `src/**`, platform dirs, `app.json`, `eas.json`, `package.json`, etc.)
+- The branch is not `main` and no release tag
+- A cached artifact from a previous run on the same branch is available
+
+On cache miss or `main`/tag push, it always builds fresh.
+
+### e2e-tests-android / e2e-tests-ios
+
+Delegates to the reusable `e2e-maestro.yml` workflow. Runs all suites in a parallel matrix (`fail-fast: false`):
+
+```
+app-init, bulk-import, duplicates-ingredient, duplicates-recipe, duplicates-tag,
+ingredient-dialog, ingredients-db, menu, ocr, recipe-create, recipe-readonly,
+recipe-edit, search, settings, shopping, tags-db, web, web-edge-cases
+```
+
+- Android: `ubuntu-latest`, API 34 Google APIs x86_64 emulator, KVM enabled, 4 GB RAM, 4 cores
+- iOS: `macos-15`, iPhone SE 3rd generation simulator, iOS 18.6, Xcode 26.2, hardware keyboard disabled, animations reduced
+
+Each suite uploads:
+- `maestro-logs-{platform}-{suite}.zip` — Maestro step logs + app logs
+- `junit-e2e-{platform}-{suite}` — JUnit XML report
+
+### merge-test-artifacts
+
+Runs `if: always()` after all E2E jobs. Merges per-suite JUnit reports with `jrm`, packages Maestro logs, deletes individual suite artifacts, re-uploads:
+- `e2e-junit-merged` — merged JUnit XML
+- `maestro-logs-android.zip`
+- `maestro-logs-ios.zip`
+
+### test-result-summary
+
+Runs `if: always()` after `merge-test-artifacts`. Combines unit and E2E summaries into a single sticky PR comment.
+
+---
+
+## EAS build pipeline (`build-app.yml`)
+
+The `build-app.yml` reusable workflow wraps EAS CLI local builds.
+
+### Build profiles
+
+Defined in `eas.json`:
+
+| Profile | Purpose | Dataset |
+|---|---|---|
+| `test` | E2E / Maestro testing | default |
+| `perf` | Flashlight + E2E performance testing | 150-recipe dataset (`EXPO_PUBLIC_DATASET_TYPE=performance`) |
+| `prod` | App Store / Play Store release | production |
+
+### Android setup
+
+Uses `.github/actions/setup-android-build` composite action:
+- Installs EAS CLI (`eas-version: '16.3.0'`)
+- Authenticates with `EXPO_TOKEN`
+- Sets up Android SDK
+
+### iOS setup
+
+Uses `.github/actions/setup-ios-build` composite action:
+- Requires `macos-15` runner
+- Selects Xcode 26.2 (`xcode-select -s /Applications/Xcode_26.2.app`)
+- Installs EAS CLI, authenticates
+
+### Artifact caching
+
+When source files have not changed and the branch is not `main`, the workflow searches previous runs on the same branch for a matching artifact using `.github/scripts/find-cached-artifact.sh`. If found, the artifact is downloaded directly, skipping the build entirely. This significantly reduces CI time for documentation-only or test-only PRs.
+
+---
+
+## Performance workflow (`performance.yml`)
+
+| Trigger | Condition |
+|---|---|
+| `schedule` (nightly 2 AM UTC) | Only runs if commits exist in the last 24 hours |
+| `workflow_dispatch` | Always runs |
+| PR with `perf-test` label | Always runs |
+
+Jobs:
+1. `build-performance-apk` — builds with `perf` profile
+2. `flashlight-test` — runs 5 Flashlight iterations against `cases/performance/1_full_flow.yaml`, duration 120s each; uploads HTML report (30-day retention)
+
+---
+
+## Documentation workflow (`documentation.yml`)
+
+Triggers on push to `main` when `src/**/*.ts`, `src/**/*.tsx`, `README.md`, `jsdoc.conf.json`, or the workflow file itself changes, plus `workflow_dispatch`.
+
+1. Runs `npm run docs:build` (TypeDoc → `docs/`)
+2. Deploys `docs/` to GitHub Pages
+
+Live docs: [https://AntoC-dev.github.io/Recipedia/](https://AntoC-dev.github.io/Recipedia/)
+
+---
+
+## Release workflow (`release.yml`)
+
+Triggers on push to `main` and `workflow_dispatch`. Runs `semantic-release` using `RELEASE_PAT` to create GitHub releases and bump `package.json` version.
+
+---
+
+## Publication workflow (`publication.yml`)
+
+Triggers after the Build & Test Pipeline completes successfully on `main`, or via `workflow_dispatch`.
+
+- Runs parallel matrix: `android` (`ubuntu-latest`) and `ios` (`macos-26`)
+- Builds with `prod` profile via EAS CLI
+- Submits to Play Store / App Store via `npm run submit:{platform}`
+- Requires the `production` environment to be configured (manual approval gate recommended)
+
+---
+
+## Required secrets
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `EXPO_TOKEN` | `build-app.yml`, `publication.yml`, `performance.yml` | EAS CLI authentication |
+| `RELEASE_PAT` | `release.yml` | GitHub PAT for semantic-release to push tags/releases |
+| `QUITOQUE_USERNAME` | `e2e-maestro.yml` | Quitoque bulk-import E2E test credentials |
+| `QUITOQUE_PASSWORD` | `e2e-maestro.yml` | Quitoque bulk-import E2E test credentials |
+| `GITHUB_TOKEN` | `quality.yml`, `build-test.yml` | Automatically provided; used for PR comments and coverage reports |
+
+All secrets except `GITHUB_TOKEN` must be configured in the repository settings under **Settings > Secrets and variables > Actions**.
+
+The `publication.yml` workflow uses a `production` GitHub environment — configure that environment with required reviewers to gate production deploys.
+
+---
+
+## Quality gates
+
+The following checks block merging (required status checks):
+
+| Check | Blocks merge |
+|---|---|
+| ESLint | Yes |
+| Prettier formatting | Yes |
+| TypeScript | Yes |
+| Expo Doctor | Yes |
+| Unit Tests & Coverage | Yes |
+| Integration Tests | Yes |
+| Build Android APK | Yes |
+| Build iOS App | Yes |
+| E2E Tests (all suites, both platforms) | Yes |
+| Commit message validation | Yes (PR only) |
+
+Non-blocking checks (informational):
+- Coverage threshold (75% on changed files — posts comment but `fail_below_threshold: false`)
+- Security audit — posts comment but does not block on `high`, only `critical`
+- Reassure performance diff — informational PR comment
+
+---
+
+## Debugging CI failures
+
+### Unit / integration test failures
+
+1. Download the `unit-test-summary` or `integration-test-summary` artifact from the Actions run
+2. Look for the failing test name in the JUnit XML
+3. Reproduce locally: `npm run test:unit` or `npm run test:integration`
+4. For coverage gaps: `npm run test:unit:coverage` then open `coverage/lcov-report/index.html`
+
+### E2E test failures
+
+1. Download `maestro-logs-android.zip` or `maestro-logs-ios.zip` from the run artifacts
+2. For Android, open `android-app-logs.txt` for logcat output
+3. For iOS, open `ios-app-logs.txt` for simulator logs
+4. Each suite has its own subdirectory with Maestro step logs
+5. Common causes: TestID changed in app, timing/animation race condition, OCR gallery ordering, simulator load (ANR)
+
+The CI retry mechanism (`maxRetries: 2` in `ci/` wrappers) handles infrastructure flakiness automatically. If a test fails all retries, it is a real failure.
+
+For a deeper E2E debugging guide see [tests/e2e/E2E_TESTING.md](../tests/e2e/E2E_TESTING.md#troubleshooting).
+
+### Build failures
+
+1. Download the `build-log-{platform}-{profile}` artifact
+2. Look for EAS CLI errors (missing credentials, SDK version mismatch, native module compile error)
+3. Verify `EXPO_TOKEN` is valid and has the correct permissions
+4. For iOS: confirm Xcode 26.2 is available on the runner (selected via `xcode-select`)
+
+### Quality failures
+
+- **ESLint**: run `npm run lint:fix` locally, commit the fixes
+- **Prettier**: run `npm run format` locally, commit the fixes
+- **TypeScript**: run `npm run typecheck` locally and fix all errors
+- **Expo Doctor**: run `npm run expo:doctor` locally; usually a dependency version mismatch
+- **Commit messages**: all commits on the PR branch must follow Conventional Commits — use `feat(scope): description` format
+- **Documentation**: run `npm run docs:build` locally; zero-warnings policy applies
+
+### Cache invalidation
+
+If node_modules cache causes issues, push a commit that changes `package-lock.json` (e.g. `npm install`) to bust the cache key.

--- a/guides/faq.md
+++ b/guides/faq.md
@@ -1,0 +1,150 @@
+# FAQ
+
+## Architecture and data
+
+### Where does local data live?
+
+All recipe data is stored in a SQLite database on the device via `expo-sqlite`. There is no cloud backend, no sync, and no external server. The database file is managed by the `RecipeDatabase` singleton (`src/utils/RecipeDatabase.tsx`) and lives in the app's private storage directory.
+
+User preferences (dark mode, default persons count, season filter) are stored separately via `@react-native-async-storage/async-storage`.
+
+### Why no `useCallback`, `useMemo`, or `React.memo`?
+
+The project has React Compiler enabled (`experiments.reactCompiler: true` in `app.config.ts`). The compiler automatically inserts memoization where it is beneficial. Manual memoization wrappers are redundant, add noise, and can interact badly with the compiler's own analysis. Do not add them.
+
+### Why can't I call `RecipeDatabase.getInstance()` directly in a component?
+
+The database singleton manages subscriptions via `useSyncExternalStore`. Components must subscribe through the focused hooks (`useRecipes`, `useIngredients`, `useTags`, `useMenu`, `useShopping`, `useImportHistory`) to receive reactive updates. Calling `getInstance()` directly in a component bypasses the subscription, so the component will not re-render when data changes. The one exception is non-React utility code (e.g. `datasetInitializer.ts`) that runs outside the component tree.
+
+---
+
+## Adding features
+
+### How do I add a new recipe field?
+
+A new field touches several layers:
+
+1. **Type** — Add the field to `recipeTableElement` in `src/customTypes/DatabaseElementTypes.tsx`. If it needs to be persisted, also add an entry to `encodedRecipeElement` and `recipeColumnsEncoding`.
+
+2. **Database** — Open `src/utils/RecipeDatabase.tsx`. Add encoding/decoding logic in the encode/decode methods and update the `addRecipe` / `editRecipe` SQL statements.
+
+3. **Schema migration** — If an existing database already exists on a device, the new column must be added via a migration in the `init()` method using `ALTER TABLE ... ADD COLUMN ...`. Without a migration, existing installs crash on startup.
+
+4. **Form state** — Add the field to `RecipeFormState` and `RecipeFormSetters` in `src/context/RecipeFormContext.tsx`, wire up the initial value logic, and add it to `createRecipeSnapshot()`.
+
+5. **UI** — Add the relevant organism or field component under `src/components/organisms/` and wire it into `src/screens/Recipe.tsx`.
+
+6. **Tests** — Add unit tests for the encoding/decoding functions and an integration test that round-trips the field through the full DB pipeline.
+
+### How do I add a new translation key?
+
+1. Add the key and English string to the appropriate file in `src/translations/en/` (e.g. `recipe.ts`, `common.ts`).
+2. Add the French translation to the matching file in `src/translations/fr/`.
+3. Use the key in a component via the `useI18n` hook:
+   ```typescript
+   const { t } = useI18n();
+   return <Text>{t('myNewKey')}</Text>;
+   ```
+
+To add an entirely new translation category file:
+
+1. Create `src/translations/en/myCategory.ts` and `src/translations/fr/myCategory.ts`.
+2. Export the object and merge it into `src/translations/en/index.ts` and the French equivalent.
+3. No changes to the i18n setup are needed — the barrel export handles it.
+
+See `src/translations/README.md` for full details and examples.
+
+### How do I add a new recipe source provider?
+
+1. Create a new class in `src/providers/` that extends `BaseRecipeProvider` (`src/providers/BaseRecipeProvider.ts`).
+2. Implement the abstract methods: `getId()`, `getName()`, `getBaseUrl()`, and the URL discovery methods as required.
+3. Register the provider in `src/providers/ProviderRegistry.ts`.
+4. The existing `useDiscoveryWorkflow` and `useRecipeScraper` hooks handle scraping and validation automatically for all registered providers.
+
+The scraper itself runs via the `modules/recipe-scraper` native module (Python embedded via Chaquopy on Android, BeeWare on iOS, Pyodide on web). Providers are responsible only for discovering recipe URLs — content extraction is handled by the scraper.
+
+---
+
+## Database
+
+### Why are my DB changes not reflected after a schema change?
+
+SQLite schemas are created once and not automatically updated. If you add a column to the schema definition but do not write a migration, existing app installs will keep the old schema.
+
+Migrations live in the `init()` method of `RecipeDatabase`. Use `ALTER TABLE` statements guarded by existence checks:
+
+```typescript
+// Check if column exists before adding it
+const columns = await db.getAllAsync(`PRAGMA table_info(${recipeTableName})`);
+const hasNewColumn = columns.some((col: { name: string }) => col.name === 'NEW_COLUMN');
+if (!hasNewColumn) {
+  await db.runAsync(`ALTER TABLE ${recipeTableName} ADD COLUMN NEW_COLUMN TEXT DEFAULT ''`);
+}
+```
+
+For development, the fastest workaround is to delete the app and reinstall — this creates a fresh database with the new schema.
+
+### How does the in-memory cache work?
+
+`RecipeDatabase` loads all rows from SQLite into memory at startup (`init()` populates `_recipes`, `_ingredients`, `_tags`, etc.). Read operations like `get_recipes()` return the in-memory array synchronously. Write operations (`addRecipe`, `editRecipe`, etc.) update both SQLite and the in-memory array, then call `notify('recipes')` to trigger `useSyncExternalStore` callbacks in subscribed hooks, causing components to re-render.
+
+---
+
+## Testing
+
+### How do I run only one test file?
+
+```bash
+# Run a specific file
+npx jest tests/unit/utils/RecipeDatabase.test.ts
+
+# Run all tests in a directory
+npx jest tests/unit/utils/
+
+# Run tests matching a name pattern
+npx jest -t "should add recipe"
+
+# Watch mode for a single file
+npx jest --watch tests/unit/utils/RecipeDatabase.test.ts
+```
+
+### What is the difference between unit tests and integration tests?
+
+**Unit tests** (`tests/unit/`) test a single component or function in isolation. External dependencies (e.g. SQLite, native modules) are mocked.
+
+**Integration tests** (`tests/integration/`) exercise the real pipeline end-to-end: actual hooks, the real `RecipeDatabase` running against `better-sqlite3` (the Node.js SQLite driver used in tests), the real fuzzy index, and the real form logic. The only things mocked are truly irreducible native boundaries like `@react-native-ml-kit/text-recognition`. Never mock hooks, utilities, or database layers in integration tests.
+
+### Where do mocks go?
+
+All mocks live in `tests/mocks/`. Never write inline mocks inside test files. Globally active mocks (e.g. `react-native-paper`) are registered in `jest.config.js`. Suite-specific mocks are imported by individual test files.
+
+---
+
+## Development workflow
+
+### How do I run quality checks before committing?
+
+```bash
+npm run quality
+# Runs: eslint + prettier check + tsc --noEmit + expo-doctor
+```
+
+Pre-commit hooks (Husky + lint-staged) run `prettier` and `eslint --fix` automatically on staged files. If a commit is blocked by a hook failure, fix the underlying issue rather than bypassing with `--no-verify`.
+
+### How do I check TypeScript errors only?
+
+```bash
+npm run typecheck
+```
+
+### The app has a copilot tutorial — how does it work?
+
+The onboarding tutorial uses `react-native-copilot`. The `useSafeCopilot` hook (`src/hooks/useSafeCopilot.tsx`) wraps copilot with error boundaries so a missing `CopilotProvider` does not crash the app. During the tutorial, bottom tab lazy loading is disabled (all tabs render immediately) so all copilot step registrations fire before the tutorial starts.
+
+### How do I regenerate the TypeDoc API documentation?
+
+```bash
+npm run docs:build
+```
+
+The output goes to `docs/`. Open `docs/index.html` locally, or view the published version at [https://AntoC-dev.github.io/Recipedia/](https://AntoC-dev.github.io/Recipedia/).

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -1,0 +1,189 @@
+# Installation Guide
+
+## Prerequisites
+
+### Required
+
+- **Node.js** v18 or higher — [nodejs.org](https://nodejs.org/)
+- **npm** v10 or higher (bundled with Node.js)
+- **Git** — [git-scm.com](https://git-scm.com/)
+- **Expo CLI** — installed globally or used via `npx`:
+  ```bash
+  npm install -g expo-cli
+  ```
+
+### For Android development
+
+- **Android Studio** with the Android SDK — [developer.android.com/studio](https://developer.android.com/studio)
+- Set the `ANDROID_HOME` environment variable to your SDK location
+- Add `$ANDROID_HOME/platform-tools` to your `PATH`
+- Create an Android Virtual Device (AVD) via Android Studio's AVD Manager, or connect a physical device with USB debugging enabled
+
+Minimum SDK version: **API level 23 (Android 6.0)**. Target SDK: **API level 36**.
+
+### For iOS development (macOS only)
+
+- **Xcode 15+** from the Mac App Store
+- Xcode Command Line Tools: `xcode-select --install`
+- An iOS simulator configured in Xcode, or a physical device with a developer certificate
+- **CocoaPods**: `sudo gem install cocoapods`
+
+Minimum deployment target: **iOS 18.0**.
+
+### For the recipe scraper module
+
+The web import feature embeds Python via a native module (`modules/recipe-scraper`). The native build handles this automatically — no manual Python installation is required.
+
+---
+
+## Clone and install
+
+```bash
+git clone https://github.com/AntoC-dev/Recipedia.git
+cd Recipedia
+npm install
+```
+
+`npm install` installs all JavaScript dependencies. No additional setup step is needed for most development tasks.
+
+---
+
+## Environment setup
+
+There are no required `.env` files for basic development. Optional environment variables:
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `EXPO_PUBLIC_DISABLE_ANIMATIONS` | Set to `"true"` to disable navigation animations (used in E2E tests) | unset |
+
+These are set inline when needed, e.g. `EXPO_PUBLIC_DISABLE_ANIMATIONS=true npm run dev:android`.
+
+---
+
+## Running the app
+
+### Start the development server
+
+```bash
+npm start
+```
+
+This starts the Expo Metro bundler. From the terminal menu you can open the app in a simulator/emulator or on a device via the Expo Go app.
+
+> Note: OCR, the recipe scraper, and several other native modules require a full native build and do not work inside Expo Go. Use `dev:android` or `dev:ios` instead.
+
+### Android emulator
+
+```bash
+npm run dev:android
+```
+
+Requires Android Studio with a configured AVD, or a physical device connected via USB with USB debugging enabled.
+
+### iOS simulator (macOS only)
+
+```bash
+npm run dev:ios
+```
+
+Requires Xcode and a booted simulator. To boot one manually:
+
+```bash
+npm run boot:ios-simulator
+# Boots iPhone SE (3rd generation) — the default E2E target
+```
+
+### Physical device
+
+Connect your device and run the same `dev:android` or `dev:ios` commands. For iOS, a paid Apple Developer account is required to install on a physical device.
+
+---
+
+## Building a standalone APK / IPA
+
+The project uses EAS Build. To build locally:
+
+```bash
+# Android APK (Maestro/testing profile)
+npm run build:test:android
+
+# iOS IPA
+npm run build:test:ios
+```
+
+Install the resulting artifact:
+
+```bash
+# Android
+npm run install:android   # runs: adb install *.apk
+
+# iOS
+npm run install:ios       # runs: xcrun simctl install booted *.app
+```
+
+---
+
+## Verifying the setup
+
+Run the quality checks to confirm the environment is correct:
+
+```bash
+npm run quality        # lint + format check + typecheck + expo:doctor
+npm run test:unit      # unit test suite
+```
+
+All checks should pass on a clean clone with no modifications.
+
+---
+
+## Common setup errors
+
+### `npm install` fails with peer dependency errors
+
+Run with `--legacy-peer-deps`:
+
+```bash
+npm install --legacy-peer-deps
+```
+
+### Metro bundler reports "Unable to resolve module"
+
+Clear the Metro cache:
+
+```bash
+npm run dev:clean   # expo start --clear
+```
+
+### Android build fails: "SDK location not found"
+
+Create a `local.properties` file in the `android/` directory:
+
+```
+sdk.dir=/Users/<your-username>/Library/Android/sdk
+```
+
+Alternatively, set the `ANDROID_HOME` environment variable.
+
+### iOS build fails: CocoaPods issues
+
+```bash
+cd ios
+pod install --repo-update
+cd ..
+```
+
+### `expo-doctor` reports outdated packages
+
+Run `npx expo install --fix` to align package versions with the current Expo SDK. Do not manually upgrade Expo SDK versions without following the [Expo upgrade guide](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/).
+
+### TypeScript errors after `npm install`
+
+```bash
+npm run typecheck
+```
+
+If errors appear only in `node_modules`, they are usually safe to ignore. If they appear in `src/`, check that you are on the correct Node version (`node --version` should be v18+).
+
+### App crashes immediately on Android
+
+Ensure you are using a device or emulator running **Android 6.0+ (API 23+)**. The app does not support lower versions.

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -1,0 +1,223 @@
+# Testing Guide
+
+Recipedia uses four complementary test layers. Each has a distinct scope, runner configuration, and set of rules.
+
+---
+
+## Testing philosophy
+
+| Layer | Scope | Mock boundary |
+|---|---|---|
+| Unit | Single component or utility in isolation | External packages, native modules, React Native Paper (globally) |
+| Integration | Cross-module pipeline end-to-end | Only irreducible native modules (e.g. `@react-native-ml-kit/text-recognition`) |
+| E2E | Full user flows on a real app build | None — real device/simulator |
+| Performance | React render benchmarks + device-level FPS/CPU/RAM | None |
+
+The goal is 100% statement coverage for everything under `src/` (excluding translations, assets, and navigation boilerplate — see `jest.config.js` `collectCoverageFrom`).
+
+---
+
+## Directory structure
+
+```
+tests/
+├── unit/            # Jest + RTL unit tests (mirrors src/ structure)
+│   ├── components/
+│   ├── context/
+│   ├── hooks/
+│   ├── screens/
+│   └── utils/
+├── integration/     # Cross-module pipeline tests (real DB, real hooks)
+│   ├── MenuAndShoppingPipeline.test.tsx
+│   ├── OCRIngredientQuantityBinding.test.tsx
+│   ├── RecipeFormIngredientsPipeline.test.tsx
+│   ├── RecipeFormTagsPipeline.test.tsx
+│   └── ValidationWorkflowRealDB.test.tsx
+├── e2e/             # Maestro YAML test suites
+│   └── E2E_TESTING.md   ← detailed E2E guide
+├── perf/            # Reassure render benchmarks (*.perf.tsx)
+├── mocks/           # All shared mocks (never inline mocks in test files)
+│   ├── deps/        # Third-party dependency mocks
+│   ├── components/
+│   ├── hooks/
+│   └── ...
+├── helpers/         # Shared test utilities
+├── data/            # Test fixtures and datasets
+├── setup.js         # Global test setup
+└── setup-community-mocks.js
+```
+
+---
+
+## Running tests
+
+### Unit tests
+
+```bash
+npm run test:unit                 # Run all unit tests (tests/unit/)
+npm run test:unit:watch           # Watch mode during development
+npm run test:unit:coverage        # Run with coverage report
+```
+
+Coverage output goes to `coverage/`. The CI threshold for changed files is 75% (cobertura check), with a project goal of 100%.
+
+### Integration tests
+
+```bash
+npm run test:integration          # Run all integration tests (tests/integration/)
+```
+
+Integration tests run in the same Jest process as unit tests. They are separated by directory match in `jest.config.js`:
+
+```js
+testMatch: [
+    '**/tests/unit/**/*.test.{js,jsx,ts,tsx}',
+    '**/tests/integration/**/*.test.{js,jsx,ts,tsx}',
+]
+```
+
+### E2E tests
+
+```bash
+# Build and run the full E2E suite on Android
+npm run workflow:build-test:android
+
+# Run a specific suite locally (from tests/e2e/)
+cd tests/e2e
+maestro test . --config=recipe-create.yaml
+
+# Run a single test case
+maestro test cases/settings/1_dark_mode.yaml
+```
+
+See [tests/e2e/E2E_TESTING.md](../tests/e2e/E2E_TESTING.md) for the complete E2E guide covering architecture, TestID conventions, reusable flows, OCR patterns, and troubleshooting.
+
+### Performance tests
+
+```bash
+npm run test:perf                 # Run Reassure benchmarks, compare to baseline
+npm run test:perf:baseline        # Record a new baseline (commit .reassure/)
+npm run build:perf:android        # Build the 150-recipe performance APK
+```
+
+---
+
+## Unit test conventions
+
+### Framework
+
+- Jest with `jest-expo` preset
+- React Native Testing Library (RTL) for component tests
+- Test files live under `tests/unit/` and mirror the `src/` tree
+
+### Mocking rules
+
+**Globally mocked packages** (active for all unit tests, configured in `jest.config.js` `moduleNameMapper`):
+- `react-native-paper` — renders props via Text/Button, no real Paper components
+- `@expo/vector-icons`
+- `expo-font`
+- `react-native-image-crop-picker`
+- `react-native-copilot`
+- `react-native-reanimated`
+- `expo-clipboard`
+- `react-native-webview`
+- `expo-mail-composer`
+- `expo-status-bar`
+- `expo-image-manipulator`
+- `@react-native-ml-kit/text-recognition`
+
+**Suite-level mocks**: Place in `tests/mocks/` as a standalone file and import it in the test. Never write inline mocks inside test files.
+
+**Do not mock** custom hooks, utility functions, `RecipeDatabase`, fuzzy index, or any internal app layer in unit tests unless there is an absolute reason. Use real implementations.
+
+### Mock component conventions (CLAUDE.local.md)
+
+When mocking a React component:
+- Render all props
+- Functional props: render in a `Button` where `onPress` calls the function
+- Other props: render in a `Text` component
+
+### Coverage
+
+- Target 100% on `src/**` (excluding translations, assets, navigation, index files)
+- Run `npm run test:unit:coverage` locally and check the `text` reporter output before pushing
+
+---
+
+## Integration test rules
+
+Integration tests exercise real pipelines: real hooks, real fuzzy index, real `RecipeDatabase`, real form context.
+
+**The only acceptable mock boundary** is a native module that cannot run in Node (e.g. `@react-native-ml-kit/text-recognition`).
+
+Rules:
+- Do not mock hooks
+- Do not mock utility modules or database layers
+- Do not mock `RecipeDatabase` or context providers
+- Tests must set up and tear down their own DB state
+- Each test file in `tests/integration/` represents a real cross-module scenario (e.g. OCR binding → ingredient quantity update, validation workflow with a real DB)
+
+Integration tests run as a separate CI job (`Integration Tests`) parallel to the unit test job.
+
+---
+
+## Maestro E2E
+
+E2E tests are YAML-based Maestro flows, organized into named suites. Each suite has a configuration file at `tests/e2e/{suite}.yaml` that controls test discovery and execution order.
+
+Available suites: `app-init`, `bulk-import`, `duplicates-ingredient`, `duplicates-recipe`, `duplicates-tag`, `ingredient-dialog`, `ingredients-db`, `menu`, `ocr`, `recipe-create`, `recipe-edit`, `recipe-readonly`, `search`, `settings`, `shopping`, `tags-db`, `web`, `web-edge-cases`, `performance`.
+
+CI runs every suite in a matrix job (fail-fast: false), on both Android (API 34) and iOS (iPhone SE 3rd gen, iOS 18.6). Each test case has a `ci/` wrapper that adds `retry: maxRetries: 2` for infrastructure flakiness without affecting local runs.
+
+For full architecture, TestID conventions, OCR patterns, and troubleshooting see [tests/e2e/E2E_TESTING.md](../tests/e2e/E2E_TESTING.md).
+
+---
+
+## Performance tests
+
+### Reassure (render benchmarks)
+
+Reassure measures React component render count and duration.
+
+- Test files: `tests/perf/*.perf.tsx`
+- Configuration: `reassure.config.js` (10% regression/improvement threshold, matches `tests/perf/**/*.perf.{js,jsx,ts,tsx}`)
+- Baseline stored in `.reassure/` (commit when intentionally changing)
+
+On PRs, CI runs Reassure against the base branch to generate a diff, then posts a compact comparison comment via Danger.js.
+
+```bash
+# Update baseline after a deliberate performance change
+npm run test:perf:baseline
+git add .reassure/
+```
+
+### App-level performance (Flashlight + E2E)
+
+The `performance` E2E suite loads the app with 150 real recipes (`EXPO_PUBLIC_DATASET_TYPE=performance`) and records FPS, CPU, and RAM via Flashlight.
+
+- Dataset: `src/assets/datasets/performance/`
+- Instrumentation: `src/utils/PerformanceMetrics.ts`
+- Maestro suite: `tests/e2e/performance.yaml`
+- Metrics are extracted from logcat in CI and tracked with `github-action-benchmark` (>150% degradation triggers an alert comment)
+
+---
+
+## CI test jobs
+
+All test jobs are defined in `.github/workflows/build-test.yml` and `.github/workflows/performance.yml`.
+
+| Job | Trigger | What it does |
+|---|---|---|
+| `unit-tests-and-coverage` | push/PR to main | `npm run test:unit:coverage`; uploads coverage artifact; posts per-file cobertura coverage on PRs |
+| `integration-tests` | push/PR to main | `npm run test:integration`; uploads JUnit summary |
+| `reassure-performance` | push/PR to main | Runs Reassure against base SHA; posts compact diff comment on PR |
+| `e2e-tests-android` | after APK build | Runs all suites in parallel matrix on Android API 34 emulator |
+| `e2e-tests-ios` | after iOS build | Runs all suites in parallel matrix on iOS simulator (macos-15) |
+| `e2e-tests-android-performance` | after perf APK build | Runs `performance` suite only |
+| `merge-test-artifacts` | always, after E2E | Merges per-suite JUnit reports and Maestro logs into single artifacts |
+| `test-result-summary` | always, after merge | Posts combined unit + E2E test summary comment on PRs |
+| Flashlight (`performance.yml`) | nightly 2 AM UTC, `workflow_dispatch`, PR with `perf-test` label | Builds perf APK, runs Flashlight 5 iterations, uploads HTML report |
+
+Logs for failed E2E tests are available in the `maestro-logs-android.zip` / `maestro-logs-ios.zip` artifacts:
+- Android: `android-app-logs.txt` (logcat)
+- iOS: `ios-app-logs.txt` (`xcrun simctl spawn`)

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,3 +1,10 @@
+/**
+ * Hooks that derive sorted, locale-aware category lists from the ingredient
+ * type enum and the non-ingredient filter constants.
+ *
+ * @module useCategories
+ */
+
 import { ingredientType } from '@customTypes/DatabaseElementTypes';
 import {
   nonIngredientFilters,
@@ -8,7 +15,21 @@ import { useI18n } from '@utils/i18n';
 
 /**
  * Returns all ingredient categories sorted by their translated display name.
- * Re-sorts automatically when the language changes.
+ *
+ * The sort is locale-sensitive and re-runs whenever the active language changes,
+ * so the list is always correctly ordered for the current locale without manual
+ * invalidation.
+ *
+ * @returns Array of every {@link TIngredientCategories} value in ascending
+ *   translated order for the current locale.
+ *
+ * @example
+ * ```tsx
+ * function ShoppingCategoryPicker() {
+ *   const categories = useShoppingCategories();
+ *   return categories.map(cat => <Text key={cat}>{t(cat)}</Text>);
+ * }
+ * ```
  */
 export function useShoppingCategories(): TIngredientCategories[] {
   const { t, getLocale } = useI18n();
@@ -18,8 +39,23 @@ export function useShoppingCategories(): TIngredientCategories[] {
 }
 
 /**
- * Returns all filter categories sorted by their translated display name.
- * Re-sorts automatically when the language changes.
+ * Returns the full list of recipe-list filter categories, combining
+ * non-ingredient filters (e.g. season, tags) with all ingredient type
+ * categories, both sorted by their translated display name.
+ *
+ * Delegates to {@link useShoppingCategories} for the ingredient portion,
+ * so the sort is always locale-sensitive and reactive to language changes.
+ *
+ * @returns Array of every {@link TListFilter} value — non-ingredient filters
+ *   first, then ingredient categories — all in ascending translated order.
+ *
+ * @example
+ * ```tsx
+ * function FilterChipRow() {
+ *   const filters = useFiltersCategories();
+ *   return filters.map(f => <Chip key={f}>{t(f)}</Chip>);
+ * }
+ * ```
  */
 export function useFiltersCategories(): TListFilter[] {
   const shoppingCategories = useShoppingCategories();

--- a/src/utils/DatasetLoader.ts
+++ b/src/utils/DatasetLoader.ts
@@ -1,3 +1,13 @@
+/**
+ * Utilities for loading the appropriate seed dataset based on the runtime environment.
+ *
+ * Supports three dataset types — `production`, `performance`, and `test` — selected
+ * via `EXPO_PUBLIC_DATASET_TYPE` or `NODE_ENV`. Production datasets are
+ * language-specific; performance and test datasets are language-agnostic.
+ *
+ * @module DatasetLoader
+ */
+
 import {
   ingredientTableElement,
   recipeTableElement,
@@ -20,12 +30,22 @@ import { performanceIngredients } from '@assets/datasets/performance/ingredients
 import { performanceTags } from '@assets/datasets/performance/tags';
 import { performanceRecipes } from '@assets/datasets/performance/recipes';
 
+/**
+ * A complete set of seed data for one dataset variant.
+ */
 export interface DatasetCollection {
   ingredients: ingredientTableElement[];
   tags: tagTableElement[];
   recipes: recipeTableElement[];
 }
 
+/**
+ * Identifies which seed dataset is active.
+ *
+ * - `production` — localised real-world data, language-specific
+ * - `performance` — large synthetic dataset for render benchmarks
+ * - `test` — minimal fixture data used in unit and integration tests
+ */
 export type DatasetType = 'test' | 'production' | 'performance';
 
 /**
@@ -77,11 +97,20 @@ function loadProductionDataset(language: SupportedLanguage): DatasetCollection {
 }
 
 /**
- * Determines the current dataset type based on EXPO_PUBLIC_DATASET_TYPE or NODE_ENV
+ * Determines the active dataset type from environment variables.
  *
- * Priority: EXPO_PUBLIC_DATASET_TYPE takes precedence if set, otherwise falls back to NODE_ENV
+ * `EXPO_PUBLIC_DATASET_TYPE` takes precedence over `NODE_ENV`. When neither
+ * variable resolves to `'production'` or `'performance'`, returns `'test'`.
  *
- * @returns 'production' if the active variable is 'production', 'performance' for performance testing, otherwise 'test'
+ * @returns The resolved {@link DatasetType} for the current environment.
+ *
+ * @example
+ * ```typescript
+ * // EXPO_PUBLIC_DATASET_TYPE=production → 'production'
+ * // NODE_ENV=production               → 'production'
+ * // NODE_ENV=test                     → 'test'
+ * const type = getDatasetType();
+ * ```
  */
 export function getDatasetType(): DatasetType {
   if (process.env.EXPO_PUBLIC_DATASET_TYPE !== undefined) {
@@ -97,6 +126,23 @@ export function getDatasetType(): DatasetType {
   return process.env.NODE_ENV === 'production' ? 'production' : 'test';
 }
 
+/**
+ * Loads the seed dataset appropriate for the current environment and language.
+ *
+ * Resolves the dataset type via {@link getDatasetType}, then returns the
+ * matching collection. On any load error, falls back to the test dataset and
+ * logs the failure.
+ *
+ * @param language - The active app language; used to select the correct
+ *   production dataset. Ignored for `test` and `performance` types.
+ * @returns The resolved {@link DatasetCollection}.
+ *
+ * @example
+ * ```typescript
+ * const { ingredients, tags, recipes } = getDataset('fr');
+ * await db.seedDatabase(ingredients, tags, recipes);
+ * ```
+ */
 export function getDataset(language: SupportedLanguage): DatasetCollection {
   try {
     const datasetType = getDatasetType();

--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -1,3 +1,14 @@
+/**
+ * Singleton SQLite database layer for the Recipedia app.
+ *
+ * Exposes all CRUD operations for recipes, ingredients, tags, menu items, and
+ * purchased-ingredient state. Maintains an in-memory cache of every table so
+ * that read operations are synchronous after initialization. Implements a
+ * slice-based pub/sub model (via {@link StoreSlice}) to integrate with
+ * `useSyncExternalStore` without requiring React Context or Redux.
+ *
+ * @module RecipeDatabase
+ */
 import * as SQLite from 'expo-sqlite';
 import {
   coreIngredientElement,
@@ -671,6 +682,16 @@ export class RecipeDatabase {
     await this.insertAndCacheRecipes(prepared);
   }
 
+  /**
+   * Updates an existing recipe in the database.
+   *
+   * Saves any temporary image to permanent storage before persisting the
+   * update, then refreshes the in-memory cache and notifies `recipes` subscribers.
+   *
+   * @param recipe - The recipe to update. Must have a valid `id`.
+   * @returns The updated recipe object (same reference as the input).
+   * @throws Error if `recipe.id` is undefined.
+   */
   public async editRecipe(recipe: recipeTableElement) {
     if (recipe.id === undefined) {
       throw new Error(`Cannot edit recipe without ID: ${recipe.title}`);
@@ -699,6 +720,16 @@ export class RecipeDatabase {
     return recipe;
   }
 
+  /**
+   * Updates an existing ingredient in the database.
+   *
+   * After a successful update the in-memory ingredients cache is refreshed and
+   * all recipes that reference this ingredient are reloaded from the database,
+   * then both the `ingredients` and `recipes` store slices are notified.
+   *
+   * @param ingredient - The ingredient to update. Must have a valid `id`.
+   * @returns `true` if the update succeeded, `false` otherwise.
+   */
   public async editIngredient(ingredient: ingredientTableElement) {
     if (ingredient.id === undefined) {
       databaseLogger.warn('Cannot edit ingredient - missing ID', {
@@ -722,6 +753,16 @@ export class RecipeDatabase {
     return success;
   }
 
+  /**
+   * Updates an existing tag in the database.
+   *
+   * After a successful update the in-memory tags cache is refreshed and all
+   * recipes that reference this tag are reloaded from the database, then both
+   * the `tags` and `recipes` store slices are notified.
+   *
+   * @param tag - The tag to update. Must have a valid `id`.
+   * @returns `true` if the update succeeded, `false` otherwise.
+   */
   public async editTag(tag: tagTableElement) {
     if (tag.id === undefined) {
       databaseLogger.warn('Cannot edit tag - missing ID', { tagName: tag.name });
@@ -739,6 +780,15 @@ export class RecipeDatabase {
     return success;
   }
 
+  /**
+   * Returns a random sample of tags from the local cache.
+   *
+   * If the cache contains fewer tags than requested, all available tags are
+   * returned. When the cache is empty an empty array is returned immediately.
+   *
+   * @param numOfElements - Number of distinct random tags to return.
+   * @returns Array of randomly selected tags, length ≤ `numOfElements`.
+   */
   public searchRandomlyTags(numOfElements: number): tagTableElement[] {
     if (this._tags.length === 0) {
       databaseLogger.error('Cannot get random tags - tag table is empty');
@@ -808,6 +858,17 @@ export class RecipeDatabase {
     return fisherYatesShuffle(this._tags, count);
   }
 
+  /**
+   * Deletes a recipe from the database and performs related cleanup.
+   *
+   * In addition to removing the recipe row, this method:
+   * - Deletes the associated image file if it is stored in permanent storage.
+   * - Removes any corresponding menu entry.
+   * - Removes the recipe URL from the seen-history if it originated from a provider.
+   *
+   * @param recipe - The recipe to delete. Matched by `id` if present, otherwise by title/description/image.
+   * @returns `true` if the recipe was deleted, `false` otherwise.
+   */
   public async deleteRecipe(recipe: recipeTableElement): Promise<boolean> {
     let recipeDeleted: boolean;
     if (recipe.id !== undefined) {
@@ -841,6 +902,16 @@ export class RecipeDatabase {
     return recipeDeleted;
   }
 
+  /**
+   * Deletes an ingredient from the database and removes it from all recipes.
+   *
+   * Any recipe that referenced the deleted ingredient is updated in-place to
+   * drop that ingredient, and both the `ingredients` and `recipes` store slices
+   * are notified after the operation completes.
+   *
+   * @param ingredient - The ingredient to delete. Matched by `id` if present, otherwise by name/unit/type.
+   * @returns `true` if the ingredient was deleted, `false` otherwise.
+   */
   public async deleteIngredient(ingredient: ingredientTableElement): Promise<boolean> {
     let ingredientDeleted: boolean;
     if (ingredient.id !== undefined) {
@@ -877,6 +948,16 @@ export class RecipeDatabase {
     return ingredientDeleted;
   }
 
+  /**
+   * Deletes a tag from the database and removes it from all recipes.
+   *
+   * Any recipe that referenced the deleted tag is updated in-place to drop
+   * that tag, and both the `tags` and `recipes` store slices are notified after
+   * the operation completes.
+   *
+   * @param tag - The tag to delete. Matched by `id` if present, otherwise by name.
+   * @returns `true` if the tag was deleted, `false` otherwise.
+   */
   public async deleteTag(tag: tagTableElement): Promise<boolean> {
     let tagDeleted: boolean;
     if (tag.id !== undefined) {
@@ -947,18 +1028,51 @@ export class RecipeDatabase {
     return this._tags;
   }
 
+  /**
+   * Appends a recipe to the in-memory cache without persisting to the database.
+   *
+   * Used internally after a successful database insert. Prefer {@link addRecipe}
+   * or {@link addMultipleRecipes} for full persistence.
+   *
+   * @param recipe - The recipe to append to the cache.
+   */
   public add_recipes(recipe: recipeTableElement) {
     this._recipes.push(recipe);
   }
 
+  /**
+   * Appends an ingredient to the in-memory cache without persisting to the database.
+   *
+   * Used internally after a successful database insert. Prefer {@link addIngredient}
+   * or {@link addMultipleIngredients} for full persistence.
+   *
+   * @param ingredient - The ingredient to append to the cache.
+   */
   public add_ingredient(ingredient: ingredientTableElement) {
     this._ingredients.push(ingredient);
   }
 
+  /**
+   * Appends a tag to the in-memory cache without persisting to the database.
+   *
+   * Used internally after a successful database insert. Prefer {@link addTag}
+   * or {@link addMultipleTags} for full persistence.
+   *
+   * @param tag - The tag to append to the cache.
+   */
   public add_tags(tag: tagTableElement) {
     this._tags.push(tag);
   }
 
+  /**
+   * Removes a recipe from the in-memory cache without touching the database.
+   *
+   * Matches by `id` when present, otherwise uses partial equality. Logs a warning
+   * if the recipe is not found in the cache. Prefer {@link deleteRecipe} for full
+   * persistence including cascaded cleanup.
+   *
+   * @param recipe - The recipe to remove from the cache.
+   */
   public remove_recipe(recipe: recipeTableElement) {
     const foundRecipe = this.find_recipe(recipe);
     if (foundRecipe !== undefined) {
@@ -970,6 +1084,14 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Removes an ingredient from the in-memory cache without touching the database.
+   *
+   * Matches by `id` when present, otherwise uses full equality. Logs a warning if
+   * the ingredient is not found. Prefer {@link deleteIngredient} for full persistence.
+   *
+   * @param ingredient - The ingredient to remove from the cache.
+   */
   public remove_ingredient(ingredient: ingredientTableElement) {
     const foundIngredient = this.find_ingredient(ingredient);
     if (foundIngredient !== undefined) {
@@ -981,6 +1103,14 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Removes a tag from the in-memory cache without touching the database.
+   *
+   * Matches by `id` when present, otherwise uses full equality. Logs a warning if
+   * the tag is not found. Prefer {@link deleteTag} for full persistence.
+   *
+   * @param tag - The tag to remove from the cache.
+   */
   public remove_tag(tag: tagTableElement) {
     const foundTag = this.find_tag(tag);
     if (foundTag !== undefined) {
@@ -990,6 +1120,12 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Replaces an existing recipe in the in-memory cache by `id` without touching
+   * the database. No-ops silently if the recipe is not found.
+   *
+   * @param newRecipe - The updated recipe. Matched by `id`.
+   */
   public update_recipe(newRecipe: recipeTableElement) {
     const foundRecipe = this._recipes.findIndex(recipe => recipe.id === newRecipe.id);
     if (foundRecipe !== -1) {
@@ -997,6 +1133,14 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Replaces multiple recipes in the in-memory cache in a single pass.
+   *
+   * Uses a pre-built id→index Map for O(n) performance. Logs a warning for
+   * any recipe in `updatedRecipes` whose `id` is not found in the current cache.
+   *
+   * @param updatedRecipes - Array of updated recipes. Each must have a valid `id`.
+   */
   public update_multiple_recipes(updatedRecipes: recipeTableElement[]) {
     const recipeMap = new Map(this._recipes.map((recipe, index) => [recipe.id, index]));
 
@@ -1013,6 +1157,12 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Replaces an existing ingredient in the in-memory cache by `id` without
+   * touching the database. No-ops silently if the ingredient is not found.
+   *
+   * @param newIngredient - The updated ingredient. Matched by `id`.
+   */
   public update_ingredient(newIngredient: ingredientTableElement) {
     const foundIngredient = this._ingredients.findIndex(
       ingredient => ingredient.id === newIngredient.id
@@ -1022,6 +1172,12 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Replaces an existing tag in the in-memory cache by `id` without touching
+   * the database. No-ops silently if the tag is not found.
+   *
+   * @param newTag - The updated tag. Matched by `id`.
+   */
   public update_tag(newTag: tagTableElement) {
     const foundTag = this._tags.findIndex(tag => tag.id === newTag.id);
     if (foundTag !== -1) {
@@ -1029,6 +1185,15 @@ export class RecipeDatabase {
     }
   }
 
+  /**
+   * Looks up a recipe in the in-memory cache.
+   *
+   * Uses strict `id` equality when the recipe has an `id`; falls back to
+   * partial structural equality ({@link isRecipePartiallyEqual}) otherwise.
+   *
+   * @param recipeToFind - Recipe to search for.
+   * @returns The matching cached recipe, or `undefined` if not found.
+   */
   public find_recipe(recipeToFind: recipeTableElement): recipeTableElement | undefined {
     let findFunc: (element: recipeTableElement) => boolean;
     if (recipeToFind.id !== undefined) {
@@ -1039,6 +1204,15 @@ export class RecipeDatabase {
     return this._recipes.find(element => findFunc(element));
   }
 
+  /**
+   * Looks up an ingredient in the in-memory cache.
+   *
+   * Uses strict `id` equality when the ingredient has an `id`; falls back to
+   * full structural equality ({@link isIngredientEqual}) otherwise.
+   *
+   * @param ingToFind - Ingredient to search for.
+   * @returns The matching cached ingredient, or `undefined` if not found.
+   */
   public find_ingredient(ingToFind: ingredientTableElement): ingredientTableElement | undefined {
     let findFunc: (element: ingredientTableElement) => boolean;
     if (ingToFind.id !== undefined) {
@@ -1049,6 +1223,15 @@ export class RecipeDatabase {
     return this._ingredients.find(element => findFunc(element));
   }
 
+  /**
+   * Looks up a tag in the in-memory cache.
+   *
+   * Uses strict `id` equality when the tag has an `id`; falls back to full
+   * structural equality ({@link isTagEqual}) otherwise.
+   *
+   * @param tagToSearch - Tag to search for.
+   * @returns The matching cached tag, or `undefined` if not found.
+   */
   public find_tag(tagToSearch: tagTableElement): tagTableElement | undefined {
     let findFunc: (element: tagTableElement) => boolean;
     if (tagToSearch.id !== undefined) {
@@ -1650,14 +1833,23 @@ export class RecipeDatabase {
   /* PRIVATE METHODS */
 
   /**
-   * Resets all internal state to empty values
+   * Fires all registered callbacks for the given store slice.
    *
-   * @private
+   * Called after every mutation so that `useSyncExternalStore` subscribers
+   * know to re-read the store snapshot.
+   *
+   * @param slice - The data slice whose listeners should be triggered.
    */
   private notify(slice: StoreSlice): void {
     this._listeners.get(slice)?.forEach(cb => cb());
   }
 
+  /**
+   * Resets all in-memory caches to their initial empty values.
+   *
+   * Does not touch the database — use {@link closeAndReset} for a full teardown
+   * that also closes the SQLite connection.
+   */
   private reset() {
     this._recipes = [];
     this._ingredients = [];

--- a/src/utils/RecipeValidationHelpers.ts
+++ b/src/utils/RecipeValidationHelpers.ts
@@ -1,3 +1,16 @@
+/**
+ * Pure helper functions for the recipe import validation pipeline.
+ *
+ * Covers ingredient and tag list manipulation (merging, deduplication, filtering,
+ * replacement) as well as the higher-level orchestration functions that split
+ * items into exact database matches and fuzzy-match queues requiring user review.
+ *
+ * All functions are side-effect-free and return new arrays; none mutate their
+ * inputs.
+ *
+ * @module RecipeValidationHelpers
+ */
+
 import {
   FormIngredientElement,
   ingredientTableElement,
@@ -6,6 +19,10 @@ import {
 import { IngredientWithSimilarity, TagWithSimilarity } from '@customTypes/ValidationTypes';
 import { namesMatch, normalizeKey } from '@utils/NutritionUtils';
 
+/**
+ * Mutable ingredient list that may contain a mix of fully validated database
+ * records and partial form entries produced by OCR or web scraping.
+ */
 export type IngredientState = (ingredientTableElement | FormIngredientElement)[];
 
 /**
@@ -312,6 +329,10 @@ export function deduplicateIngredientsByName<T extends FormIngredientElement>(
   return Array.from(seen.values());
 }
 
+/**
+ * Configuration object passed to the validation queue for tag items that
+ * require user review.
+ */
 interface TagQueueConfig {
   type: 'Tag';
   items: TagWithSimilarity[];
@@ -319,6 +340,10 @@ interface TagQueueConfig {
   onDismissed?: (tag: TagWithSimilarity) => void;
 }
 
+/**
+ * Configuration object passed to the validation queue for ingredient items
+ * that require user review.
+ */
 interface IngredientQueueConfig {
   type: 'Ingredient';
   items: IngredientWithSimilarity[];

--- a/src/utils/firstLaunch.ts
+++ b/src/utils/firstLaunch.ts
@@ -1,8 +1,28 @@
+/**
+ * Helpers for detecting and recording the app's first-launch state.
+ *
+ * A single AsyncStorage flag is used as the source of truth. Reading the flag
+ * before it has ever been written indicates a first launch; calling
+ * {@link markAsLaunched} writes the flag so subsequent launches are not treated
+ * as first launches.
+ *
+ * @module firstLaunch
+ */
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { appLogger } from '@utils/logger';
 
 const FIRST_LAUNCH_KEY = 'first_launch';
 
+/**
+ * Checks whether this is the first time the app has been launched.
+ *
+ * Returns `true` when the launch flag has never been written to AsyncStorage.
+ * Returns `false` on any storage error to avoid triggering first-launch flows
+ * unexpectedly.
+ *
+ * @returns `true` if the app has not been launched before, `false` otherwise.
+ */
 export async function isFirstLaunch(): Promise<boolean> {
   try {
     const hasLaunchedBefore = await AsyncStorage.getItem(FIRST_LAUNCH_KEY);
@@ -16,6 +36,13 @@ export async function isFirstLaunch(): Promise<boolean> {
   }
 }
 
+/**
+ * Persists the launch flag so that future calls to {@link isFirstLaunch} return `false`.
+ *
+ * Should be called once after all first-launch setup (onboarding, database
+ * seeding, etc.) has completed successfully. Errors are logged and swallowed
+ * so callers are not blocked if storage is unavailable.
+ */
 export async function markAsLaunched(): Promise<void> {
   try {
     await AsyncStorage.setItem(FIRST_LAUNCH_KEY, 'true');

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,3 +1,14 @@
+/**
+ * Internationalisation setup and React hook for the Recipedia app.
+ *
+ * Configures a dedicated i18next instance with dynamic backend loading and
+ * device-locale detection via `expo-localization`. Exports the singleton
+ * `i18n` instance, language metadata constants, and the {@link useI18n} hook
+ * for use in React components.
+ *
+ * @module i18n
+ */
+
 import { createInstance } from 'i18next';
 import { initReactI18next, useTranslation } from 'react-i18next';
 import * as Localization from 'expo-localization';
@@ -65,39 +76,35 @@ i18n
   });
 
 /**
- * Hook to use translations in React components
- * @returns Translation functions and utilities
+ * Hook providing translation utilities for React components.
+ *
+ * Wraps `react-i18next`'s `useTranslation` and exposes a stable API for
+ * reading and changing the active locale.
+ *
+ * @returns An object containing:
+ *   - `t` — the i18next translation function
+ *   - `setLocale(locale)` — changes the active language; resolves when loaded
+ *   - `getLocale()` — returns the current language code (e.g. `'en'`)
+ *   - `getAvailableLocales()` — returns all supported {@link SupportedLanguage} codes
+ *   - `getLocaleName(locale)` — returns the display name for a language code,
+ *     or the raw code if it is not in {@link SUPPORTED_LANGUAGES}
+ *
+ * @example
+ * ```tsx
+ * const { t, setLocale, getLocale } = useI18n();
+ * return <Button onPress={() => setLocale('fr')}>{t('settings.language')}</Button>;
+ * ```
  */
 export const useI18n = () => {
   const { t, i18n } = useTranslation();
 
   return {
     t,
-    /**
-     * Changes the current locale
-     * @param locale The locale to set (e.g., 'en', 'fr')
-     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setLocale: (locale: string): Promise<any> => i18n.changeLanguage(locale),
-
-    /**
-     * Gets the current locale
-     * @returns The current locale
-     */
     getLocale: (): string => i18n.language,
-
-    /**
-     * Gets all available locales
-     * @returns Array of available locale codes
-     */
     getAvailableLocales: (): SupportedLanguage[] =>
       Object.keys(SUPPORTED_LANGUAGES) as SupportedLanguage[],
-
-    /**
-     * Gets the locale name in its own language
-     * @param locale The locale code
-     * @returns The name of the language in its own language
-     */
     getLocaleName: (locale: string): string =>
       locale in SUPPORTED_LANGUAGES
         ? SUPPORTED_LANGUAGES[locale as SupportedLanguage].name

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,10 +1,24 @@
+/**
+ * Persistent app settings backed by AsyncStorage.
+ *
+ * Provides typed getters and setters for dark mode, default persons count,
+ * season filter, and language. On first use, each setting falls back to a
+ * device-derived or hardcoded default. `initSettings` should be called once
+ * during app startup to apply persisted values (e.g. the active language) to
+ * the running i18n instance.
+ *
+ * @module settings
+ */
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Localization from 'expo-localization';
 import { Appearance } from 'react-native';
 import i18n from './i18n';
 import { settingsLogger } from '@utils/logger';
 
-// Settings keys for AsyncStorage
+/**
+ * AsyncStorage keys used to persist each user setting.
+ */
 export const SETTINGS_KEYS = {
   DARK_MODE: 'settings_dark_mode',
   DEFAULT_PERSONS: 'settings_default_persons',
@@ -12,18 +26,25 @@ export const SETTINGS_KEYS = {
   LANGUAGE: 'settings_language',
 };
 
-// Default settings values
+/**
+ * Fallback values applied when a setting has not yet been written to storage.
+ * An empty string for `language` means the device locale will be used.
+ */
 export const DEFAULT_SETTINGS = {
   darkMode: false,
   defaultPersons: 4,
   seasonFilter: true,
-  language: '', // Empty string means use device locale
+  language: '',
 };
 
 /**
- * Get the dark mode setting
- * Uses system preference on first launch, then respects user choice
- * @returns Promise resolving to dark mode boolean
+ * Reads the dark mode preference from storage.
+ *
+ * On first launch (before the setting is written) falls back to the OS colour
+ * scheme reported by `Appearance`. On storage error, also falls back to the OS
+ * colour scheme.
+ *
+ * @returns `true` when dark mode should be enabled, `false` otherwise.
  */
 export const getDarkMode = async (): Promise<boolean> => {
   try {
@@ -39,9 +60,9 @@ export const getDarkMode = async (): Promise<boolean> => {
 };
 
 /**
- * Set the dark mode setting
- * @param value Dark mode boolean value
- * @returns Promise that resolves when setting is saved
+ * Persists the dark mode preference.
+ *
+ * @param value - `true` to enable dark mode, `false` to disable.
  */
 export const setDarkMode = async (value: boolean): Promise<void> => {
   try {
@@ -53,8 +74,12 @@ export const setDarkMode = async (value: boolean): Promise<void> => {
 };
 
 /**
- * Get the default persons setting
- * @returns Promise resolving to default persons number
+ * Reads the default serving-persons preference from storage.
+ *
+ * Falls back to {@link DEFAULT_SETTINGS}.`defaultPersons` when the value has
+ * not been set or storage fails.
+ *
+ * @returns The saved default number of persons, or `4` as the fallback.
  */
 export const getDefaultPersons = async (): Promise<number> => {
   try {
@@ -67,9 +92,9 @@ export const getDefaultPersons = async (): Promise<number> => {
 };
 
 /**
- * Set the default persons setting
- * @param value Default persons number
- * @returns Promise that resolves when setting is saved
+ * Persists the default serving-persons preference.
+ *
+ * @param value - The number of persons to use as default for recipe scaling.
  */
 export const setDefaultPersons = async (value: number): Promise<void> => {
   try {
@@ -81,8 +106,12 @@ export const setDefaultPersons = async (value: number): Promise<void> => {
 };
 
 /**
- * Get the season filter setting
- * @returns Promise resolving to season filter boolean
+ * Reads the season filter preference from storage.
+ *
+ * Returns `false` when the value has never been written; falls back to
+ * {@link DEFAULT_SETTINGS}.`seasonFilter` on storage error.
+ *
+ * @returns `true` when the season filter is enabled.
  */
 export const getSeasonFilter = async (): Promise<boolean> => {
   try {
@@ -95,9 +124,9 @@ export const getSeasonFilter = async (): Promise<boolean> => {
 };
 
 /**
- * Set the season filter setting
- * @param value Season filter boolean value
- * @returns Promise that resolves when setting is saved
+ * Persists the season filter preference.
+ *
+ * @param value - `true` to restrict recipe results to seasonal ingredients.
  */
 export const setSeasonFilter = async (value: boolean): Promise<void> => {
   try {
@@ -109,8 +138,9 @@ export const setSeasonFilter = async (value: boolean): Promise<void> => {
 };
 
 /**
- * Toggle the season filter setting
- * @returns Promise resolving to the new season filter value
+ * Flips the season filter preference and persists the new value.
+ *
+ * @returns The new season filter state after toggling.
  */
 export const toggleSeasonFilter = async (): Promise<boolean> => {
   const currentValue = await getSeasonFilter();
@@ -120,8 +150,12 @@ export const toggleSeasonFilter = async (): Promise<boolean> => {
 };
 
 /**
- * Get the language setting
- * @returns Promise resolving to language code
+ * Reads the language preference from storage.
+ *
+ * Falls back to the device locale (`expo-localization`) when no value has been
+ * saved, and to `'en'` if the device locale cannot be determined.
+ *
+ * @returns A BCP 47 language code (e.g. `'en'`, `'fr'`).
  */
 export const getLanguage = async (): Promise<string> => {
   try {
@@ -136,9 +170,9 @@ export const getLanguage = async (): Promise<string> => {
 };
 
 /**
- * Set the language setting
- * @param value Language code
- * @returns Promise that resolves when setting is saved
+ * Persists the language preference and applies it to the running i18n instance.
+ *
+ * @param value - A BCP 47 language code (e.g. `'en'`, `'fr'`).
  */
 export const setLanguage = async (value: string): Promise<void> => {
   try {
@@ -152,8 +186,11 @@ export const setLanguage = async (value: string): Promise<void> => {
 };
 
 /**
- * Initialize settings by loading from AsyncStorage
- * This should be called on app startup
+ * Applies persisted settings to the running app.
+ *
+ * Reads the saved language from storage and calls `i18n.changeLanguage` so
+ * the correct translation bundle is active before any component renders. Should
+ * be awaited during app startup before the root navigator mounts.
  */
 export const initSettings = async (): Promise<void> => {
   settingsLogger.debug('Initializing app settings');


### PR DESCRIPTION
## Summary

- Add TSDoc file-level headers and export documentation to 7 previously undocumented source files (`RecipeDatabase`, `DatasetLoader`, `firstLaunch`, `i18n`, `RecipeValidationHelpers`, `settings`, `useCategories`)
- Add `ARCHITECTURE.md` — system-level overview of data flow, patterns, key invariants, and a new-feature checklist aimed at AI agents and new engineers
- Add `guides/` directory with 4 developer guides: `installation.md`, `faq.md`, `testing.md`, `ci-setup.md`
- Update `CONTRIBUTING.md`: add "Keeping Documentation Current" maintenance table; fix incorrect `React.memo` advice
- Update `README.md`: fix broken `docs/*.md` links → `guides/*.md` (`docs/` is gitignored TypeDoc output)
- Update `AGENTS.md`: add "Documentation Rules" section so AI agents know when to update TSDoc, `ARCHITECTURE.md`, and `guides/`

## Test plan

- [ ] `npm run docs:build` — TypeDoc builds without warnings
- [ ] `npm run quality` — lint, format, typecheck pass
- [ ] Verify `guides/` files render correctly on GitHub
- [ ] Verify README links to `guides/*.md` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)