### PR TITLE
fix(tutorial): copilot spotlight alignment, navigation & reduced-motion

### DIFF
--- a/src/components/atomic/FilterToggleButton.tsx
+++ b/src/components/atomic/FilterToggleButton.tsx
@@ -1,0 +1,48 @@
+import React, { forwardRef } from 'react';
+import { View } from 'react-native';
+import { Button } from 'react-native-paper';
+import { Icons } from '@assets/Icons';
+import { useI18n } from '@utils/i18n';
+import { padding } from '@styles/spacing';
+
+/**
+ * Props for {@link FilterToggleButton}
+ */
+export type FilterToggleButtonProps = {
+  /** testID for the underlying button */
+  testID: string;
+  /** Whether filter-adding mode is active (controls the label and icon) */
+  addingFilterMode: boolean;
+  /** Fired when the button is pressed */
+  onToggle: () => void;
+};
+
+/**
+ * Toggle button switching between filter selection and results view.
+ *
+ * Ref-forwarded to its root View so callers (e.g. the tutorial spotlight) can
+ * measure its on-screen position.
+ *
+ * @param props - {@link FilterToggleButtonProps}
+ * @returns The filter mode toggle button
+ */
+export const FilterToggleButton = forwardRef<View, FilterToggleButtonProps>(
+  function FilterToggleButton({ testID, addingFilterMode, onToggle }, ref) {
+    const { t } = useI18n();
+    return (
+      <View ref={ref} style={{ alignSelf: 'flex-start' }}>
+        <Button
+          testID={testID}
+          mode={'contained'}
+          onPress={onToggle}
+          icon={addingFilterMode ? Icons.removeFilterIcon : Icons.addFilterIcon}
+          style={{ margin: padding.medium, alignSelf: 'flex-start', borderRadius: 20 }}
+        >
+          {t(addingFilterMode ? 'seeFilterResult' : 'addFilter')}
+        </Button>
+      </View>
+    );
+  }
+);
+
+export default FilterToggleButton;

--- a/src/components/dialogs/Alert.tsx
+++ b/src/components/dialogs/Alert.tsx
@@ -67,6 +67,8 @@ export type AlertProps = {
   onConfirm?: () => void;
   /** Optional callback fired when cancel button is pressed */
   onCancel?: () => void;
+  /** Optional style applied to the dialog surface (e.g. to offset its position) */
+  style?: StyleProp<ViewStyle>;
 };
 
 /**
@@ -85,6 +87,7 @@ export function Alert({
   onClose,
   onConfirm,
   onCancel,
+  style,
 }: AlertProps) {
   const handleDismiss = () => {
     onClose();
@@ -114,7 +117,7 @@ export function Alert({
 
   return (
     <Portal>
-      <Dialog visible={isVisible} onDismiss={handleDismiss}>
+      <Dialog visible={isVisible} onDismiss={handleDismiss} style={style}>
         <Dialog.Title testID={dialogTestId + '::Title'}>{title}</Dialog.Title>
         <Dialog.Content>
           <Text testID={dialogTestId + '::Content'} variant={'bodyMedium'}>

--- a/src/components/molecules/TutorialTooltip.tsx
+++ b/src/components/molecules/TutorialTooltip.tsx
@@ -5,7 +5,13 @@ import { useNavigation } from '@react-navigation/native';
 import { useSafeCopilot } from '@hooks/useSafeCopilot';
 import { useI18n } from '@utils/i18n';
 import { TabScreenNavigation } from '@customTypes/ScreenTypes';
-import { TUTORIAL_STEPS } from '@utils/Constants';
+import {
+  getNextTutorialScreen,
+  getPreviousTutorialScreen,
+  isFirstTutorialStep,
+  isLastTutorialStep,
+  SELF_ADVANCING_TUTORIAL_SCREEN,
+} from '@utils/Tutorial';
 import { padding } from '@styles/spacing';
 
 /**
@@ -32,97 +38,41 @@ export function TutorialTooltip() {
     return null;
   }
 
-  const { isLastStep, goToNext, goToPrev, stop, currentStep } = copilotData;
-
-  /**
-   * Helper function to find tutorial step configuration by order number
-   *
-   * @param order - The order number of the tutorial step to find
-   * @returns Tutorial step configuration object
-   * @throws Error if step with given order is not found
-   */
-  const findStepByOrder = (order: number) => {
-    const screens = Object.values(TUTORIAL_STEPS);
-    const step = screens.find(step => step.order === order);
-    if (!step) {
-      throw new Error(
-        `Tutorial step with order ${order} not found. Check TUTORIAL_STEPS configuration.`
-      );
-    }
-    return step;
-  };
-
-  /**
-   * Gets the screen name for the next tutorial step
-   *
-   * @param currentOrder - Current step order number
-   * @returns Screen name for the next step
-   */
-  const getNextScreen = (currentOrder: number) => {
-    return findStepByOrder(currentOrder + 1).name;
-  };
-
-  /**
-   * Gets the screen name for the previous tutorial step
-   *
-   * @param currentOrder - Current step order number
-   * @returns Screen name for the previous step
-   */
-  const getPreviousScreen = (currentOrder: number) => {
-    return findStepByOrder(currentOrder - 1).name;
-  };
+  const { goToNext, goToPrev, stop, currentStep } = copilotData;
 
   // Don't render if no current step
   if (!currentStep) {
     return null;
   }
 
-  // Calculate isFirstStep from order, not library's broken calculation
-  const isFirstStep = currentStep.order === 1;
+  const isFirstStep = isFirstTutorialStep(currentStep.order);
+  const isLastStep = isLastTutorialStep(currentStep.order);
 
   /**
-   * Handles advancing to the next tutorial step
+   * Navigates to a tutorial screen, then moves the copilot step. The Search
+   * screen is the exception: its spotlight target is measured at runtime and is
+   * only correct once focused, so it advances the step itself once ready (see
+   * Search screen). Every other screen uses a stable proxy, safe to move now.
    *
-   * Navigates to the next screen in the tutorial sequence and sets up
-   * step advancement to occur after navigation completes. Uses deferred
-   * execution to ensure proper timing with navigation state changes.
+   * @param screen - Destination screen, or undefined at a sequence boundary
+   * @param moveStep - Copilot step mover (goToNext / goToPrev)
    */
-  const handleNext = async () => {
-    if (!currentStep) {
+  const navigateToStep = (
+    screen: ReturnType<typeof getNextTutorialScreen>,
+    moveStep: () => void
+  ) => {
+    if (!screen) {
       return;
     }
-
-    const nextScreen = getNextScreen(currentStep.order);
-    if (!nextScreen) {
-      return;
+    navigation.navigate(screen);
+    if (screen !== SELF_ADVANCING_TUTORIAL_SCREEN) {
+      moveStep();
     }
-
-    goToNext().then(() => {
-      navigation.navigate(nextScreen);
-    });
   };
 
-  /**
-   * Handles going back to the previous tutorial step
-   *
-   * Navigates to the previous screen in the tutorial sequence and sets up
-   * step regression to occur after navigation completes. Uses deferred
-   * execution to ensure proper timing with navigation state changes.
-   */
-  const handlePrevious = async () => {
-    if (!currentStep) {
-      return;
-    }
-
-    const previousScreen = getPreviousScreen(currentStep.order);
-    if (!previousScreen) {
-      return;
-    }
-
-    goToPrev().then(() => {
-      navigation.navigate(previousScreen);
-    });
-  };
+  const handleNext = () => navigateToStep(getNextTutorialScreen(currentStep.order), goToNext);
+  const handlePrevious = () =>
+    navigateToStep(getPreviousTutorialScreen(currentStep.order), goToPrev);
 
   // From copilot source files, see that they add 15 padding to tooltip
   const paddingOfCopilot = 15;
@@ -141,8 +91,13 @@ export function TutorialTooltip() {
       }}
     >
       <Card.Content>
-        <Text testID={testId + '::Text'} variant='bodyMedium'>
-          {currentStep?.text}
+        <Text
+          testID={testId + '::Text'}
+          variant='bodyMedium'
+          accessible
+          accessibilityLiveRegion='polite'
+        >
+          {currentStep.text}
         </Text>
       </Card.Content>
 

--- a/src/components/organisms/FiltersSelection.tsx
+++ b/src/components/organisms/FiltersSelection.tsx
@@ -42,16 +42,19 @@
 
 import React, { useEffect, useRef } from 'react';
 import { TagButton } from '@components/atomic/TagButton';
+import { FilterToggleButton } from '@components/atomic/FilterToggleButton';
 import { Icons } from '@assets/Icons';
 import { useI18n } from '@utils/i18n';
 import { TUTORIAL_DEMO_INTERVAL, TUTORIAL_STEPS } from '@utils/Constants';
 import { FlatList, View } from 'react-native';
 import { padding } from '@styles/spacing';
-import { Button } from 'react-native-paper';
-import { CopilotStep, walkthroughable } from 'react-native-copilot';
 import { useSafeCopilot } from '@hooks/useSafeCopilot';
+import { useReducedMotion } from '@hooks/useReducedMotion';
 import { CopilotStepData } from '@customTypes/TutorialTypes';
 import { listFilter, prepTimeValues } from '@customTypes/RecipeFiltersTypes';
+
+/** Frame cap for the spotlight measure-until-stable loop, so it cannot spin forever */
+const MAX_MEASURE_ATTEMPTS = 30;
 
 /**
  * Props for the FiltersSelection component
@@ -67,6 +70,10 @@ export type FiltersSelectionProps = {
   setAddingAFilter: React.Dispatch<React.SetStateAction<boolean>>;
   /** Callback fired when a filter is removed */
   onRemoveFilter: (filter: string) => void;
+  /** Reports the window-space top (px) of the filter toggle button when it lays out */
+  onToggleButtonTop?: (windowTop: number) => void;
+  /** Whether the host screen is focused; re-measures the toggle button on focus */
+  screenFocused?: boolean;
 };
 
 /**
@@ -75,14 +82,14 @@ export type FiltersSelectionProps = {
  * @param props - The component props with filter state and management functions
  * @returns JSX element representing active filters with toggle functionality
  */
-const CopilotView = walkthroughable(View);
-
 export function FiltersSelection({
   testId,
   filters,
   addingFilterMode,
   setAddingAFilter,
   onRemoveFilter,
+  onToggleButtonTop,
+  screenFocused,
 }: FiltersSelectionProps) {
   const { t } = useI18n();
   const copilotData = useSafeCopilot();
@@ -90,6 +97,8 @@ export function FiltersSelection({
   const currentStep = copilotData?.currentStep;
 
   const demoIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const toggleButtonRef = useRef<View>(null);
+  const reducedMotion = useReducedMotion();
 
   const stepOrder = TUTORIAL_STEPS.Search.order;
   const selectionTestID = testId + '::FiltersSelection';
@@ -105,34 +114,15 @@ export function FiltersSelection({
     setAddingAFilter(prev => !prev);
   };
 
-  /**
-   * Filter Toggle Button - Internal component for filter mode switching
-   *
-   * Renders the toggle button that switches between filter selection and results view.
-   * Clean separation of concerns:
-   * - Button handles only its main responsibility (toggling mode)
-   * - Demo system manages itself through dedicated trigger function
-   */
-  function FilterToggleButton() {
-    return (
-      <Button
-        testID={testId + '::FiltersToggleButtons'}
-        mode={'contained'}
-        onPress={triggerToggle}
-        icon={addingFilterMode ? Icons.removeFilterIcon : Icons.addFilterIcon}
-        style={{ margin: padding.medium, alignSelf: 'flex-start', borderRadius: 20 }}
-      >
-        {t(addingFilterMode ? 'seeFilterResult' : 'addFilter')}
-      </Button>
-    );
-  }
-
   useEffect(() => {
     if (!copilotData || !copilotEvents) {
       return;
     }
 
     const startDemo = () => {
+      if (reducedMotion) {
+        return;
+      }
       if (demoIntervalRef.current) {
         clearInterval(demoIntervalRef.current);
       }
@@ -170,7 +160,39 @@ export function FiltersSelection({
       copilotEvents.off('stop', stopDemo);
       stopDemo();
     };
-  }, [currentStep, copilotData, copilotEvents, stepOrder, setAddingAFilter]);
+  }, [currentStep, copilotData, copilotEvents, reducedMotion, stepOrder, setAddingAFilter]);
+
+  // On focus during the tutorial, the screen is still mid-transition (the
+  // spotlight target moves as the safe area settles), so a single measurement
+  // can be stale. Measure each frame until the window position stops changing,
+  // then report the settled value. Deterministic (ends when layout is stable),
+  // capped so it cannot spin forever, and only runs while the tutorial is active.
+  useEffect(() => {
+    if (!screenFocused || !copilotData) {
+      return;
+    }
+    let cancelled = false;
+    let previousTop: number | null = null;
+    let attempts = 0;
+    let frame = requestAnimationFrame(function measureUntilStable() {
+      toggleButtonRef.current?.measureInWindow((_x, y) => {
+        if (cancelled) {
+          return;
+        }
+        if ((previousTop !== null && y === previousTop) || attempts >= MAX_MEASURE_ATTEMPTS) {
+          onToggleButtonTop?.(y);
+        } else {
+          previousTop = y;
+          attempts += 1;
+          frame = requestAnimationFrame(measureUntilStable);
+        }
+      });
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
+  }, [screenFocused, copilotData, onToggleButtonTop]);
 
   return (
     <>
@@ -196,17 +218,12 @@ export function FiltersSelection({
         )}
       />
 
-      {copilotData ? (
-        <View>
-          <CopilotStep text={t('tutorial.search.description')} order={stepOrder} name={'Search'}>
-            <CopilotView testID={selectionTestID + '::Tutorial'}>
-              <FilterToggleButton />
-            </CopilotView>
-          </CopilotStep>
-        </View>
-      ) : (
-        <FilterToggleButton />
-      )}
+      <FilterToggleButton
+        ref={toggleButtonRef}
+        testID={testId + '::FiltersToggleButtons'}
+        addingFilterMode={addingFilterMode}
+        onToggle={triggerToggle}
+      />
     </>
   );
 }

--- a/src/components/organisms/TutorialController.tsx
+++ b/src/components/organisms/TutorialController.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { StatusBar } from 'react-native';
 import { CopilotProvider, useCopilot } from 'react-native-copilot';
 import { useNavigation } from '@react-navigation/native';
 import { tutorialLogger } from '@utils/logger';
@@ -6,7 +7,7 @@ import { TabScreenNavigation } from '@customTypes/ScreenTypes';
 import { CopilotStepData } from '@customTypes/TutorialTypes';
 import { TutorialTooltip } from '@components/molecules/TutorialTooltip';
 import { TutorialStepNumber } from '@components/molecules/TutorialStepNumber';
-import { TUTORIAL_VERTICAL_OFFSET } from '@utils/Constants';
+import { TUTORIAL_AUTO_START_DELAY, TUTORIAL_SPOTLIGHT_MARGIN } from '@utils/Constants';
 
 export type TutorialProviderProps = {
   children: React.ReactNode;
@@ -25,6 +26,9 @@ export type TutorialProviderProps = {
 function TutorialManager({ onComplete }: Pick<TutorialProviderProps, 'onComplete'>) {
   const navigation = useNavigation<TabScreenNavigation>();
   const { start, copilotEvents, visible } = useCopilot();
+  const hasAutoStartedRef = useRef(false);
+  const startRef = useRef(start);
+  startRef.current = start;
 
   /**
    * Handles tutorial start event
@@ -53,15 +57,24 @@ function TutorialManager({ onComplete }: Pick<TutorialProviderProps, 'onComplete
     }
   };
 
-  // Auto-start tutorial when copilot is ready
+  // Auto-start tutorial once when copilot is ready. `start` is read through a
+  // ref and kept out of the deps: the library returns a new `start` each render,
+  // and depending on it would re-run this effect and cancel the pending timer.
   useEffect(() => {
-    if (copilotEvents && !visible) {
-      tutorialLogger.info('Starting tutorial on next tick');
-      setTimeout(() => {
-        start();
-      }, 300);
+    if (!copilotEvents || visible || hasAutoStartedRef.current) {
+      return;
     }
-  }, [copilotEvents, visible, start]);
+
+    hasAutoStartedRef.current = true;
+    tutorialLogger.info('Starting tutorial on next tick');
+    const timer = setTimeout(() => {
+      startRef.current();
+    }, TUTORIAL_AUTO_START_DELAY);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [copilotEvents, visible]);
 
   // Setup event listeners
   useEffect(() => {
@@ -115,14 +128,21 @@ export function TutorialProvider({ children, onComplete }: TutorialProviderProps
     padding: 0,
   };
 
+  // With androidStatusBarVisible set, copilot measures targets a status-bar
+  // height higher than the overlay draws, so push the spotlight down by that
+  // exact amount. StatusBar.currentHeight is Android-only (undefined on iOS).
+  const verticalOffset = StatusBar.currentHeight ?? 0;
+
   return (
     <CopilotProvider
-      overlay='view'
+      overlay='svg'
       animated={true}
+      androidStatusBarVisible={true}
+      margin={TUTORIAL_SPOTLIGHT_MARGIN}
       tooltipComponent={TutorialTooltip}
       stepNumberComponent={TutorialStepNumber}
       tooltipStyle={tooltipStyle}
-      verticalOffset={TUTORIAL_VERTICAL_OFFSET}
+      verticalOffset={verticalOffset}
     >
       {children}
       <TutorialManager onComplete={onComplete} />

--- a/src/components/organisms/VerticalBottomButtons.tsx
+++ b/src/components/organisms/VerticalBottomButtons.tsx
@@ -32,6 +32,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { View } from 'react-native';
 import { CopilotStep, walkthroughable } from 'react-native-copilot';
 import { useSafeCopilot } from '@hooks/useSafeCopilot';
+import { useReducedMotion } from '@hooks/useReducedMotion';
 import { useRecipeScraper } from '@hooks/useRecipeScraper';
 import { CopilotStepData } from '@customTypes/TutorialTypes';
 import { useI18n } from '@utils/i18n';
@@ -41,7 +42,7 @@ import { Icons } from '@assets/Icons';
 import { StackScreenNavigation } from '@customTypes/ScreenTypes';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
 import { FAB, Portal, useTheme } from 'react-native-paper';
-import { padding, screenHeight, screenWidth } from '@styles/spacing';
+import { padding, screenHeight } from '@styles/spacing';
 import { UrlInputDialog } from '@components/dialogs/UrlInputDialog';
 import { AuthenticationDialog } from '@components/dialogs/AuthenticationDialog';
 
@@ -79,10 +80,11 @@ function VerticalBottomButtons() {
   const insets = useSafeAreaInsets();
 
   const tabBarHeight = screenHeight / 9 + insets.bottom;
-  const copilotWidth = screenWidth * 0.62;
   const copilotHeight =
-    MAIN_FAB_SIZE + (ACTION_BUTTON_SIZE + ACTION_BUTTON_SPACING) * ACTION_BUTTON_COUNT;
-  const copilotBottom = tabBarHeight - (ACTION_BUTTON_SIZE + 2 * ACTION_BUTTON_SPACING);
+    MAIN_FAB_SIZE +
+    (ACTION_BUTTON_SIZE + ACTION_BUTTON_SPACING) * ACTION_BUTTON_COUNT +
+    ACTION_BUTTON_SPACING;
+  const copilotBottom = tabBarHeight - MAIN_FAB_SIZE;
 
   const copilotData = useSafeCopilot();
   const copilotEvents = copilotData?.copilotEvents;
@@ -93,6 +95,7 @@ function VerticalBottomButtons() {
   const [authDialogVisible, setAuthDialogVisible] = useState(false);
   const demoIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isFocused = useIsFocused();
+  const reducedMotion = useReducedMotion();
 
   const {
     scrapeAndPrepare,
@@ -112,6 +115,9 @@ function VerticalBottomButtons() {
     }
 
     function startDemo() {
+      if (reducedMotion) {
+        return;
+      }
       if (demoIntervalRef.current) {
         clearInterval(demoIntervalRef.current);
       }
@@ -148,7 +154,7 @@ function VerticalBottomButtons() {
       copilotEvents.off('stop', stopDemo);
       stopDemo();
     };
-  }, [isFocused, copilotData, copilotEvents, currentStep, stepOrder]);
+  }, [isFocused, copilotData, copilotEvents, currentStep, reducedMotion, stepOrder]);
 
   useEffect(() => {
     if (authRequired) {
@@ -156,10 +162,6 @@ function VerticalBottomButtons() {
       setAuthDialogVisible(true);
     }
   }, [authRequired]);
-
-  if (!isFocused) {
-    return null;
-  }
 
   async function takePhotoAndOpenNewRecipe() {
     openRecipeWithUri(await takePhoto(colors));
@@ -230,8 +232,8 @@ function VerticalBottomButtons() {
               style={{
                 position: 'absolute',
                 bottom: copilotBottom,
+                left: padding.small,
                 right: padding.small,
-                width: copilotWidth,
                 height: copilotHeight,
                 pointerEvents: 'none',
               }}
@@ -239,73 +241,77 @@ function VerticalBottomButtons() {
           </CopilotStep>
         </View>
       )}
-      <Portal>
-        <FAB.Group
-          open={open}
-          visible
-          icon={open ? Icons.minusIcon : Icons.plusIcon}
-          {...fabTestProps(open ? FAB_TEST_IDS.reduce : FAB_TEST_IDS.expand)}
-          actions={[
-            {
-              icon: Icons.pencilIcon,
-              label: t('fab.addManually'),
-              onPress: () => navigate('Recipe', { mode: 'addManually' }),
-              ...fabTestProps(FAB_TEST_IDS.edit),
-              style: { borderRadius: 999 },
-              size: 'medium',
-            },
-            {
-              icon: Icons.webIcon,
-              label: t('fab.addFromUrl'),
-              onPress: handleOpenUrlDialog,
-              ...fabTestProps(FAB_TEST_IDS.url),
-              style: { borderRadius: 999 },
-              size: 'medium',
-            },
-            {
-              icon: Icons.galleryIcon,
-              label: t('fab.pickFromGallery'),
-              onPress: () => pickImageAndOpenNewRecipe(),
-              ...fabTestProps(FAB_TEST_IDS.gallery),
-              style: { borderRadius: 999 },
-              size: 'medium',
-            },
-            {
-              icon: Icons.cameraIcon,
-              label: t('fab.takePhoto'),
-              onPress: () => takePhotoAndOpenNewRecipe(),
-              ...fabTestProps(FAB_TEST_IDS.camera),
-              style: { borderRadius: 999 },
-              size: 'medium',
-            },
-          ]}
-          onStateChange={({ open: isOpen }) => setOpen(isOpen)}
-          fabStyle={{
-            marginBottom: tabBarHeight,
-            marginRight: padding.small,
-            backgroundColor: colors.primaryContainer,
-            borderRadius: 999,
-          }}
-          color={colors.onPrimaryContainer}
-        />
-      </Portal>
-      <UrlInputDialog
-        testId={testID}
-        isVisible={urlDialogVisible}
-        onClose={handleCloseUrlDialog}
-        onSubmit={handleUrlSubmit}
-        isLoading={isScrapingLoading}
-        error={scrapingError}
-      />
-      <AuthenticationDialog
-        testId={testID}
-        isVisible={authDialogVisible}
-        host={authRequired?.host ?? ''}
-        onClose={handleCloseAuthDialog}
-        onSubmit={handleAuthSubmit}
-        isLoading={isScrapingLoading}
-        error={scrapingError}
-      />
+      {isFocused && (
+        <>
+          <Portal>
+            <FAB.Group
+              open={open}
+              visible
+              icon={open ? Icons.minusIcon : Icons.plusIcon}
+              {...fabTestProps(open ? FAB_TEST_IDS.reduce : FAB_TEST_IDS.expand)}
+              actions={[
+                {
+                  icon: Icons.pencilIcon,
+                  label: t('fab.addManually'),
+                  onPress: () => navigate('Recipe', { mode: 'addManually' }),
+                  ...fabTestProps(FAB_TEST_IDS.edit),
+                  style: { borderRadius: 999 },
+                  size: 'medium',
+                },
+                {
+                  icon: Icons.webIcon,
+                  label: t('fab.addFromUrl'),
+                  onPress: handleOpenUrlDialog,
+                  ...fabTestProps(FAB_TEST_IDS.url),
+                  style: { borderRadius: 999 },
+                  size: 'medium',
+                },
+                {
+                  icon: Icons.galleryIcon,
+                  label: t('fab.pickFromGallery'),
+                  onPress: () => pickImageAndOpenNewRecipe(),
+                  ...fabTestProps(FAB_TEST_IDS.gallery),
+                  style: { borderRadius: 999 },
+                  size: 'medium',
+                },
+                {
+                  icon: Icons.cameraIcon,
+                  label: t('fab.takePhoto'),
+                  onPress: () => takePhotoAndOpenNewRecipe(),
+                  ...fabTestProps(FAB_TEST_IDS.camera),
+                  style: { borderRadius: 999 },
+                  size: 'medium',
+                },
+              ]}
+              onStateChange={({ open: isOpen }) => setOpen(isOpen)}
+              fabStyle={{
+                marginBottom: tabBarHeight,
+                marginRight: padding.small,
+                backgroundColor: colors.primaryContainer,
+                borderRadius: 999,
+              }}
+              color={colors.onPrimaryContainer}
+            />
+          </Portal>
+          <UrlInputDialog
+            testId={testID}
+            isVisible={urlDialogVisible}
+            onClose={handleCloseUrlDialog}
+            onSubmit={handleUrlSubmit}
+            isLoading={isScrapingLoading}
+            error={scrapingError}
+          />
+          <AuthenticationDialog
+            testId={testID}
+            isVisible={authDialogVisible}
+            host={authRequired?.host ?? ''}
+            onClose={handleCloseAuthDialog}
+            onSubmit={handleAuthSubmit}
+            isLoading={isScrapingLoading}
+            error={scrapingError}
+          />
+        </>
+      )}
     </View>
   );
 }

--- a/src/hooks/useReducedMotion.tsx
+++ b/src/hooks/useReducedMotion.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+/**
+ * Tracks the OS "reduce motion" accessibility setting.
+ *
+ * Returns the current preference and keeps it in sync with system changes.
+ * Used to suppress non-essential animations such as the tutorial auto-demos.
+ *
+ * @returns True when the user has requested reduced motion
+ */
+export function useReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    AccessibilityInfo.isReduceMotionEnabled().then(enabled => {
+      if (mounted) {
+        setReducedMotion(enabled);
+      }
+    });
+
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      setReducedMotion
+    );
+
+    return () => {
+      mounted = false;
+      subscription.remove();
+    };
+  }, []);
+
+  return reducedMotion;
+}

--- a/src/screens/Menu.tsx
+++ b/src/screens/Menu.tsx
@@ -109,7 +109,7 @@ export function Menu() {
           <CopilotView
             style={{
               position: 'absolute',
-              top: '5%',
+              top: '3%',
               left: padding.small,
               right: padding.small,
               height: '70%',

--- a/src/screens/Search.tsx
+++ b/src/screens/Search.tsx
@@ -25,6 +25,12 @@ import { FilterAccordion } from '@components/organisms/FilterAccordion';
 import { useSeasonFilter } from '@context/SeasonFilterContext';
 import { useRecipes } from '@hooks/useRecipes';
 import { getRecipeKey } from '@utils/listUtils';
+import { CopilotStep, walkthroughable } from 'react-native-copilot';
+import { useIsFocused } from '@react-navigation/native';
+import { useSafeCopilot } from '@hooks/useSafeCopilot';
+import { TUTORIAL_STEPS } from '@utils/Constants';
+
+const CopilotView = walkthroughable(View);
 
 /**
  * Search screen component - Advanced recipe search with filtering
@@ -36,10 +42,42 @@ export function Search() {
 
   const { seasonFilter } = useSeasonFilter();
   const { recipes } = useRecipes();
+  const copilotData = useSafeCopilot();
+  const stepOrder = TUTORIAL_STEPS.Search.order;
+  const screenFocused = useIsFocused();
+  const [toggleButtonTop, setToggleButtonTop] = useState<number | null>(null);
 
   // Refs
   const flashListRef = useRef<FlashListRef<recipeTableElement>>(null);
   const searchBarClearRef = useRef<SearchBarHandle>(null);
+  const hasSelfAdvancedRef = useRef(false);
+
+  // Advance the tutorial to this step once the screen is focused and its
+  // spotlight target has been measured. The toggle button is in-flow, so its
+  // position is only correct after focus; advancing here (rather than from the
+  // tooltip) guarantees the spotlight is measured against the focused position.
+  const currentStepOrder = copilotData?.currentStep?.order;
+  useEffect(() => {
+    if (!screenFocused) {
+      hasSelfAdvancedRef.current = false;
+      return;
+    }
+    if (
+      !copilotData ||
+      toggleButtonTop == null ||
+      hasSelfAdvancedRef.current ||
+      currentStepOrder == null ||
+      currentStepOrder === stepOrder
+    ) {
+      return;
+    }
+    hasSelfAdvancedRef.current = true;
+    if (currentStepOrder < stepOrder) {
+      copilotData.goToNext();
+    } else {
+      copilotData.goToPrev();
+    }
+  }, [copilotData, screenFocused, toggleButtonTop, currentStepOrder, stepOrder]);
 
   // Core state
   const [filtersState, setFiltersState] = useState(new Map<TListFilter, string[]>());
@@ -180,6 +218,8 @@ export function Search() {
                   addingFilterMode={addingFilterMode}
                   setAddingAFilter={setAddingFilterMode}
                   onRemoveFilter={findFilterStringAndRemove}
+                  onToggleButtonTop={setToggleButtonTop}
+                  screenFocused={screenFocused}
                 />
 
                 <Divider testID={screenId + '::Divider'} />
@@ -225,6 +265,30 @@ export function Search() {
           />
         )}
       />
+
+      {copilotData && (
+        <CopilotStep text={t('tutorial.search.description')} order={stepOrder} name={'Search'}>
+          {/*
+            Unlike the other tutorial screens (which can hardcode a percentage
+            top), the toggle button sits below the search bar and a variable
+            filter-chip row, and its focused window position differs from its
+            unfocused one by the status-bar height. A static percentage left a
+            visible vertical offset, so the top is driven by the measured
+            (settled, focused) button position, falling back to '15%' until measured.
+          */}
+          <CopilotView
+            testID={screenId + '::Tutorial'}
+            style={{
+              position: 'absolute',
+              top: toggleButtonTop ?? '15%',
+              left: padding.small,
+              right: padding.small,
+              height: '40%',
+              pointerEvents: 'none',
+            }}
+          />
+        </CopilotStep>
+      )}
     </ScreenWrapper>
   );
 }

--- a/src/screens/Shopping.tsx
+++ b/src/screens/Shopping.tsx
@@ -48,12 +48,13 @@
  */
 
 import { ComputedShoppingItem } from '@customTypes/DatabaseElementTypes';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { SectionList, StyleProp, TextStyle, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
 import { CopilotStep, walkthroughable } from 'react-native-copilot';
 import { useSafeCopilot } from '@hooks/useSafeCopilot';
+import { useReducedMotion } from '@hooks/useReducedMotion';
 import { CopilotStepData } from '@customTypes/TutorialTypes';
 import { Checkbox, Divider, List, Text, useTheme } from 'react-native-paper';
 import { useI18n } from '@utils/i18n';
@@ -92,6 +93,9 @@ export function Shopping() {
 
   const demoIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isDialogOpenRef = useRef(false);
+  const reducedMotion = useReducedMotion();
+  const shoppingListRef = useRef(shoppingList);
+  shoppingListRef.current = shoppingList;
 
   const stepOrder = TUTORIAL_STEPS.Shopping.order;
 
@@ -103,58 +107,58 @@ export function Shopping() {
 
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false);
 
-  const toggleDemoDialog = useCallback(() => {
-    if (isDialogOpenRef.current) {
-      setIsDialogOpen(false);
-      setIngredientDataForDialog({ name: '', recipeTitles: [] });
-      isDialogOpenRef.current = false;
-    } else if (shoppingList.length > 2) {
-      setIngredientDataForDialog(shoppingList[2]);
-      setIsDialogOpen(true);
-      isDialogOpenRef.current = true;
-    }
-  }, [shoppingList]);
-
-  const closingDialogInDemo = () => {
-    setIsDialogOpen(false);
-    setIngredientDataForDialog({ name: '', recipeTitles: [] });
-    isDialogOpenRef.current = false;
-  };
-
-  const stopDemo = useCallback(() => {
-    if (demoIntervalRef.current) {
-      clearInterval(demoIntervalRef.current);
-      demoIntervalRef.current = null;
-    }
-    closingDialogInDemo();
-  }, []);
-
-  const startDemo = useCallback(() => {
-    if (demoIntervalRef.current) {
-      clearInterval(demoIntervalRef.current);
-      demoIntervalRef.current = null;
-    }
-
-    demoIntervalRef.current = setInterval(toggleDemoDialog, TUTORIAL_DEMO_INTERVAL);
-  }, [toggleDemoDialog]);
-
-  const handleStepChange = useCallback(
-    (step: CopilotStepData | undefined) => {
-      if (step?.order === stepOrder) {
-        startDemo();
-      } else {
-        stopDemo();
-      }
-    },
-    [stepOrder, startDemo, stopDemo]
-  );
-
   useEffect(() => {
     if (!copilotData || !copilotEvents) {
       return;
     }
 
-    // Start demo if we're already on our step when component mounts
+    function closeDialog() {
+      if (!isDialogOpenRef.current) {
+        return;
+      }
+      setIsDialogOpen(false);
+      setIngredientDataForDialog({ name: '', recipeTitles: [] });
+      isDialogOpenRef.current = false;
+    }
+
+    function toggleDemoDialog() {
+      const list = shoppingListRef.current;
+      if (isDialogOpenRef.current) {
+        closeDialog();
+      } else if (list.length > 2) {
+        setIngredientDataForDialog(list[2]);
+        setIsDialogOpen(true);
+        isDialogOpenRef.current = true;
+      }
+    }
+
+    function startDemo() {
+      if (reducedMotion) {
+        return;
+      }
+      if (demoIntervalRef.current) {
+        clearInterval(demoIntervalRef.current);
+        demoIntervalRef.current = null;
+      }
+      demoIntervalRef.current = setInterval(toggleDemoDialog, TUTORIAL_DEMO_INTERVAL);
+    }
+
+    function stopDemo() {
+      if (demoIntervalRef.current) {
+        clearInterval(demoIntervalRef.current);
+        demoIntervalRef.current = null;
+      }
+      closeDialog();
+    }
+
+    function handleStepChange(step: CopilotStepData | undefined) {
+      if (step?.order === stepOrder) {
+        startDemo();
+      } else {
+        stopDemo();
+      }
+    }
+
     if (currentStep?.order === stepOrder) {
       startDemo();
     }
@@ -167,7 +171,7 @@ export function Shopping() {
       copilotEvents.off('stop', stopDemo);
       stopDemo();
     };
-  }, [currentStep, copilotData, copilotEvents, handleStepChange, startDemo, stepOrder, stopDemo]);
+  }, [currentStep, copilotData, copilotEvents, reducedMotion, stepOrder]);
 
   const sections = shoppingCategories
     .map(category => ({
@@ -319,6 +323,9 @@ export function Shopping() {
         content={createDialogContent()}
         testId={screenId}
         title={createDialogTitle()}
+        // During the tutorial the demo dialog is pushed down so its top clears
+        // the tutorial tooltip anchored above the highlighted list.
+        style={copilotData ? { marginTop: '25%' } : undefined}
         onClose={() => {
           setIsDialogOpen(false);
           setIngredientDataForDialog({ name: '', recipeTitles: [] });

--- a/src/utils/Constants.tsx
+++ b/src/utils/Constants.tsx
@@ -47,11 +47,15 @@ export const TUTORIAL_STEPS = {
   Parameters: { order: 5, name: 'Parameters' },
 } as const;
 
+/** Delay before auto-starting the tutorial, letting screens lay out first (ms) */
+export const TUTORIAL_AUTO_START_DELAY = 300;
+
 /**
- * Tutorial spotlight vertical offset in pixels
- * Applied to all tutorial steps for consistent positioning
+ * Tutorial spotlight padding in pixels around each highlighted target
+ * Applied by the SVG overlay to keep a consistent breathing space between
+ * the spotlight edge and the highlighted element
  */
-export const TUTORIAL_VERTICAL_OFFSET = 20;
+export const TUTORIAL_SPOTLIGHT_MARGIN = 8;
 
 /**
  * Array of test recipe images used in development and testing

--- a/src/utils/Tutorial.ts
+++ b/src/utils/Tutorial.ts
@@ -1,0 +1,78 @@
+/**
+ * Tutorial - Step ordering helpers for the guided tour
+ *
+ * Single source of truth for tutorial step sequencing. The tour screens and
+ * the tooltip navigation both derive next/previous/first/last from these
+ * helpers (backed by {@link TUTORIAL_STEPS}) instead of the copilot library's
+ * registered-step calculations, which only reflect steps already mounted.
+ */
+
+import { TUTORIAL_STEPS } from '@utils/Constants';
+
+/** Configuration of a single tutorial step (order + screen name) */
+export type TutorialStepConfig = (typeof TUTORIAL_STEPS)[keyof typeof TUTORIAL_STEPS];
+
+/** Screen name of a tutorial step */
+export type TutorialScreenName = TutorialStepConfig['name'];
+
+/**
+ * Tutorial screen whose spotlight target is measured at runtime and is only
+ * correct once the screen is focused. It advances the copilot step itself once
+ * its target is ready, so the tooltip must not advance the step when navigating
+ * to it. Every other screen uses a stable proxy and is advanced by the tooltip.
+ */
+export const SELF_ADVANCING_TUTORIAL_SCREEN: TutorialScreenName = 'Search';
+
+const orderedTutorialSteps: readonly TutorialStepConfig[] = Object.values(TUTORIAL_STEPS)
+  .slice()
+  .sort((a, b) => a.order - b.order);
+
+/**
+ * Whether the given order is the first tutorial step.
+ *
+ * @param order - Step order to check
+ * @returns True when order matches the first step
+ */
+export function isFirstTutorialStep(order: number): boolean {
+  return order === orderedTutorialSteps[0].order;
+}
+
+/**
+ * Whether the given order is the last tutorial step.
+ *
+ * @param order - Step order to check
+ * @returns True when order matches the last step
+ */
+export function isLastTutorialStep(order: number): boolean {
+  return order === orderedTutorialSteps[orderedTutorialSteps.length - 1].order;
+}
+
+/**
+ * Screen name of the tutorial step at the given order.
+ *
+ * @param order - Step order to resolve
+ * @returns Screen name, or undefined when no step has that order
+ */
+export function getTutorialScreenByOrder(order: number): TutorialScreenName | undefined {
+  return orderedTutorialSteps.find(step => step.order === order)?.name;
+}
+
+/**
+ * Screen name of the step following the given order.
+ *
+ * @param order - Current step order
+ * @returns Next screen name, or undefined when already on the last step
+ */
+export function getNextTutorialScreen(order: number): TutorialScreenName | undefined {
+  return getTutorialScreenByOrder(order + 1);
+}
+
+/**
+ * Screen name of the step preceding the given order.
+ *
+ * @param order - Current step order
+ * @returns Previous screen name, or undefined when already on the first step
+ */
+export function getPreviousTutorialScreen(order: number): TutorialScreenName | undefined {
+  return getTutorialScreenByOrder(order - 1);
+}

--- a/tests/mocks/components/organisms/FiltersSelection-mock.tsx
+++ b/tests/mocks/components/organisms/FiltersSelection-mock.tsx
@@ -29,12 +29,13 @@ export function mapToObject(map: Map<any, any>) {
   return obj;
 }
 
-export function filtersSelectionMock({
+function FiltersSelectionMock({
   testId,
-  filters,
   addingFilterMode,
   onRemoveFilter,
   setAddingAFilter,
+  onToggleButtonTop,
+  screenFocused,
 }: FiltersSelectionProps) {
   const [localFilters, setLocalFilters] = useState<string[]>([...globalCurrentFilters]);
 
@@ -82,6 +83,14 @@ export function filtersSelectionMock({
         onPress={() => setAddingAFilter(!addingFilterMode)}
         title='Toggle Filter Mode'
       />
+      <Text testID={testId + '::ScreenFocused'}>{String(screenFocused)}</Text>
+      <Button
+        testID={testId + '::ReportToggleTop'}
+        onPress={() => onToggleButtonTop?.(88)}
+        title='Report Toggle Top'
+      />
     </View>
   );
 }
+
+export const filtersSelectionMock = FiltersSelectionMock;

--- a/tests/mocks/hooks/useReducedMotion-mock.tsx
+++ b/tests/mocks/hooks/useReducedMotion-mock.tsx
@@ -1,0 +1,5 @@
+export const mockUseReducedMotion = jest.fn(() => false);
+
+export const useReducedMotionMock = () => ({
+  useReducedMotion: mockUseReducedMotion,
+});

--- a/tests/unit/components/atomic/FilterToggleButton.test.tsx
+++ b/tests/unit/components/atomic/FilterToggleButton.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { FilterToggleButton } from '@components/atomic/FilterToggleButton';
+
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
+describe('FilterToggleButton', () => {
+  const testID = 'FilterToggleButton';
+
+  test('shows the add-filter label when not adding a filter', () => {
+    const { getByTestId } = render(
+      <FilterToggleButton testID={testID} addingFilterMode={false} onToggle={jest.fn()} />
+    );
+
+    expect(getByTestId(testID)).toHaveTextContent('addFilter');
+  });
+
+  test('shows the see-results label when adding a filter', () => {
+    const { getByTestId } = render(
+      <FilterToggleButton testID={testID} addingFilterMode={true} onToggle={jest.fn()} />
+    );
+
+    expect(getByTestId(testID)).toHaveTextContent('seeFilterResult');
+  });
+
+  test('calls onToggle when pressed', () => {
+    const onToggle = jest.fn();
+    const { getByTestId } = render(
+      <FilterToggleButton testID={testID} addingFilterMode={false} onToggle={onToggle} />
+    );
+
+    fireEvent.press(getByTestId(testID));
+
+    expect(onToggle).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/molecules/TutorialTooltip.test.tsx
+++ b/tests/unit/components/molecules/TutorialTooltip.test.tsx
@@ -14,6 +14,7 @@ describe('TutorialTooltip Component', () => {
   const mockHomeStep = { order: 1, name: 'Home', text: 'First step' };
   const mockSearchStep = { order: 2, name: 'Search', text: 'Middle step' };
   const mockShoppingStep = { order: 3, name: 'Shopping', text: 'Last step' };
+  const mockLastStep = { order: 5, name: 'Parameters', text: 'Last step' };
 
   const defaultMockFirstStepData = {
     currentStep: mockHomeStep,
@@ -131,8 +132,7 @@ describe('TutorialTooltip Component', () => {
     const mockStop = jest.fn();
     useCopilot.mockReturnValue({
       ...defaultMockData,
-      isLastStep: true,
-      currentStep: mockShoppingStep,
+      currentStep: mockLastStep,
       stop: mockStop,
     });
 
@@ -162,15 +162,36 @@ describe('TutorialTooltip Component', () => {
     expect(mockNavigate).toHaveBeenCalledWith('Home');
   });
 
-  test('calls goToNext when next is pressed', async () => {
+  test('advances the step when moving to a non-self-advancing screen', () => {
     const mockGoToNext = jest.fn().mockResolvedValue(undefined);
-    useCopilot.mockReturnValue({ ...defaultMockData, goToNext: mockGoToNext });
+    useCopilot.mockReturnValue({
+      ...defaultMockData,
+      currentStep: mockSearchStep,
+      goToNext: mockGoToNext,
+    });
 
     const { getByTestId } = render(<TutorialTooltip />);
 
     fireEvent.press(getByTestId('TutorialTooltip::Next'));
 
+    expect(mockNavigate).toHaveBeenCalledWith('Menu');
     expect(mockGoToNext).toHaveBeenCalled();
+  });
+
+  test('does not advance the step when navigating to the self-advancing Search screen', () => {
+    const mockGoToNext = jest.fn().mockResolvedValue(undefined);
+    useCopilot.mockReturnValue({
+      ...defaultMockData,
+      currentStep: mockHomeStep,
+      goToNext: mockGoToNext,
+    });
+
+    const { getByTestId } = render(<TutorialTooltip />);
+
+    fireEvent.press(getByTestId('TutorialTooltip::Next'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Search');
+    expect(mockGoToNext).not.toHaveBeenCalled();
   });
 
   test('renders correctly with valid step order', () => {

--- a/tests/unit/components/organisms/FiltersSelection.test.tsx
+++ b/tests/unit/components/organisms/FiltersSelection.test.tsx
@@ -8,9 +8,14 @@ import {
   triggerStepChangeEvent,
   triggerStopEvent,
 } from '@mocks/deps/react-native-copilot-mock';
+import { mockUseReducedMotion } from '@mocks/hooks/useReducedMotion-mock';
 import { TUTORIAL_DEMO_INTERVAL, TUTORIAL_STEPS } from '@utils/Constants';
 
 jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
+jest.mock('@hooks/useReducedMotion', () =>
+  require('@mocks/hooks/useReducedMotion-mock').useReducedMotionMock()
+);
 
 describe('FiltersSelection Component', () => {
   const mockSetAddingAFilter = jest.fn();
@@ -105,6 +110,7 @@ describe('FiltersSelection Component', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       resetMockCopilot();
+      mockUseReducedMotion.mockReturnValue(false);
       jest.useFakeTimers();
     });
 
@@ -112,25 +118,37 @@ describe('FiltersSelection Component', () => {
       jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
-    test('renders with tutorial wrapper when copilot is available', () => {
+
+    test('does not run the demo when reduced motion is enabled', () => {
+      mockUseReducedMotion.mockReturnValue(true);
       setMockCopilotState({
         isActive: true,
-        currentStep: { order: 1, name: 'Home', text: 'Test step' },
+        currentStep: { order: TUTORIAL_STEPS.Search.order, name: 'Search', text: 'Search step' },
       });
-      const { getByTestId } = render(<FiltersSelection {...defaultProps} />);
 
-      expect(getByTestId('FiltersSelection::FiltersSelection::Tutorial')).toBeTruthy();
-      expect(getByTestId('CopilotStep::Search')).toBeTruthy();
+      render(<FiltersSelection {...defaultProps} />);
+
+      jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL * 2);
+
+      expect(mockSetAddingAFilter).not.toHaveBeenCalled();
+    });
+
+    test('renders the toggle button without owning a copilot step when copilot is available', () => {
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: TUTORIAL_STEPS.Search.order, name: 'Search', text: 'Search step' },
+      });
+      const { getByTestId, queryByTestId } = render(<FiltersSelection {...defaultProps} />);
+
+      expect(queryByTestId('CopilotStep::Search')).toBeNull();
       expect(getByTestId('FiltersSelection::FiltersToggleButtons')).toBeTruthy();
       expect(getByTestId('FiltersSelection::FiltersToggleButtons')).toHaveTextContent('addFilter');
     });
-    test('renders without tutorial wrapper when copilot is not available', () => {
+    test('renders the toggle button when copilot is not available', () => {
       setMockCopilotState({ isActive: false });
 
-      const { getByTestId, queryByTestId } = render(<FiltersSelection {...defaultProps} />);
+      const { getByTestId } = render(<FiltersSelection {...defaultProps} />);
 
-      expect(queryByTestId('FiltersSelection::FiltersSelection::Tutorial')).toBeNull();
-      expect(queryByTestId('CopilotStep::Search')).toBeNull();
       expect(getByTestId('FiltersSelection::FiltersToggleButtons')).toBeTruthy();
       expect(getByTestId('FiltersSelection::FiltersToggleButtons')).toHaveTextContent('addFilter');
     });

--- a/tests/unit/components/organisms/TutorialController.test.tsx
+++ b/tests/unit/components/organisms/TutorialController.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StatusBar } from 'react-native';
 import { act, render } from '@testing-library/react-native';
 import { TutorialProvider } from '@components/organisms/TutorialController';
 import {
@@ -6,11 +7,12 @@ import {
   getMockCopilotMethods,
   resetMockCopilot,
   setMockCopilotState,
+  triggerStartEvent,
   triggerStepChangeEvent,
   triggerStopEvent,
 } from '@mocks/deps/react-native-copilot-mock';
 import { mockNavigate } from '@mocks/deps/react-navigation-mock';
-import { TUTORIAL_VERTICAL_OFFSET } from '@utils/Constants';
+import { TUTORIAL_SPOTLIGHT_MARGIN } from '@utils/Constants';
 
 jest.mock('@react-navigation/native', () =>
   require('@mocks/deps/react-navigation-mock').reactNavigationMock()
@@ -85,6 +87,68 @@ describe('TutorialController Component', () => {
     jest.useRealTimers();
   });
 
+  test('auto-starts only once across re-renders', () => {
+    const mockMethods = getMockCopilotMethods();
+    setMockCopilotState({ isActive: true, visible: false });
+    const { View } = require('react-native');
+
+    jest.useFakeTimers();
+    const { rerender } = render(
+      <TutorialProvider onComplete={mockOnComplete}>
+        <View testID='test-child' />
+      </TutorialProvider>
+    );
+    act(() => jest.advanceTimersByTime(300));
+
+    rerender(
+      <TutorialProvider onComplete={mockOnComplete}>
+        <View testID='test-child' />
+      </TutorialProvider>
+    );
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(mockMethods.start).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  test('auto-starts with the latest start when its identity changes before the delay', () => {
+    const { useCopilot } = require('react-native-copilot');
+    const originalImpl = useCopilot.getMockImplementation();
+    const start1 = jest.fn();
+    const start2 = jest.fn();
+    let currentStart = start1;
+    useCopilot.mockImplementation(() => ({
+      start: currentStart,
+      stop: jest.fn(),
+      copilotEvents: getMockCopilotEvents(),
+      visible: false,
+      currentStep: undefined,
+    }));
+    const { View } = require('react-native');
+
+    jest.useFakeTimers();
+    const { rerender } = render(
+      <TutorialProvider onComplete={mockOnComplete}>
+        <View testID='test-child' />
+      </TutorialProvider>
+    );
+
+    currentStart = start2;
+    rerender(
+      <TutorialProvider onComplete={mockOnComplete}>
+        <View testID='test-child' />
+      </TutorialProvider>
+    );
+
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(start1).not.toHaveBeenCalled();
+    expect(start2).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+    useCopilot.mockImplementation(originalImpl);
+  });
+
   test('does not auto-start when tutorial is already visible', async () => {
     const mockMethods = getMockCopilotMethods();
     setMockCopilotState({
@@ -131,6 +195,14 @@ describe('TutorialController Component', () => {
     triggerStepChangeEvent(mockStep);
   });
 
+  test('handles start event without throwing', async () => {
+    setMockCopilotState({ isActive: true });
+
+    await renderTutorialProvider();
+
+    expect(() => triggerStartEvent()).not.toThrow();
+  });
+
   test('cleans up event listeners on unmount', async () => {
     const mockEvents = getMockCopilotEvents();
     setMockCopilotState({ isActive: true });
@@ -162,9 +234,11 @@ describe('TutorialController Component', () => {
     const { getByTestId } = await renderTutorialProvider();
 
     const copilotProvider = getByTestId('CopilotProvider');
-    expect(copilotProvider.props.overlay).toBe('view');
+    expect(copilotProvider.props.overlay).toBe('svg');
     expect(copilotProvider.props.animated).toBe(true);
-    expect(copilotProvider.props.verticalOffset).toBe(TUTORIAL_VERTICAL_OFFSET);
+    expect(copilotProvider.props.androidStatusBarVisible).toBe(true);
+    expect(copilotProvider.props.margin).toBe(TUTORIAL_SPOTLIGHT_MARGIN);
+    expect(copilotProvider.props.verticalOffset).toBe(StatusBar.currentHeight ?? 0);
     expect(copilotProvider.props.tooltipStyle).toEqual({
       margin: 0,
       padding: 0,

--- a/tests/unit/components/organisms/VerticalBottomButtons.test.tsx
+++ b/tests/unit/components/organisms/VerticalBottomButtons.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import VerticalBottomButtons from '@components/organisms/VerticalBottomButtons';
 import { mockNavigate } from '@mocks/deps/react-navigation-mock';
 import { RecipePropType } from '@customTypes/RecipeNavigationTypes';
@@ -8,9 +8,15 @@ import {
   resetMockCopilot,
   setMockCopilotState,
 } from '@mocks/deps/react-native-copilot-mock';
+import { mockUseReducedMotion } from '@mocks/hooks/useReducedMotion-mock';
+import { TUTORIAL_DEMO_INTERVAL } from '@utils/Constants';
 import { DefaultPersonsProvider } from '@context/DefaultPersonsContext';
 
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
+
+jest.mock('@hooks/useReducedMotion', () =>
+  require('@mocks/hooks/useReducedMotion-mock').useReducedMotionMock()
+);
 
 jest.mock('@react-navigation/native', () =>
   require('@mocks/deps/react-navigation-mock').reactNavigationMock()
@@ -145,12 +151,45 @@ describe('VerticalBottomButtons Component', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       resetMockCopilot();
+      mockUseReducedMotion.mockReturnValue(false);
       jest.useFakeTimers();
     });
 
     afterEach(() => {
       jest.runOnlyPendingTimers();
       jest.useRealTimers();
+    });
+
+    test('auto-opens the FAB during the demo', () => {
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: 1, name: 'Home', text: 'Home step' },
+      });
+
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      act(() => {
+        jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL);
+      });
+
+      expect(getByTestId('ReduceButton')).toBeTruthy();
+    });
+
+    test('does not auto-run the demo when reduced motion is enabled', () => {
+      mockUseReducedMotion.mockReturnValue(true);
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: 1, name: 'Home', text: 'Home step' },
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      act(() => {
+        jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL * 2);
+      });
+
+      expect(getByTestId('ExpandButton')).toBeTruthy();
+      expect(queryByTestId('ReduceButton')).toBeNull();
     });
 
     test('renders with tutorial wrapper when copilot is available', () => {

--- a/tests/unit/hooks/useReducedMotion.test.tsx
+++ b/tests/unit/hooks/useReducedMotion.test.tsx
@@ -1,0 +1,45 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { AccessibilityInfo } from 'react-native';
+import { useReducedMotion } from '@hooks/useReducedMotion';
+
+describe('useReducedMotion', () => {
+  let changeHandler: (enabled: boolean) => void;
+  const remove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(false);
+    const addListener = jest.spyOn(AccessibilityInfo, 'addEventListener') as unknown as jest.Mock;
+    addListener.mockImplementation((_event: string, handler: (enabled: boolean) => void) => {
+      changeHandler = handler;
+      return { remove };
+    });
+  });
+
+  test('reflects the initial system preference', async () => {
+    (AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockResolvedValue(true);
+
+    const { result } = renderHook(() => useReducedMotion());
+
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  test('updates when the preference changes', async () => {
+    const { result } = renderHook(() => useReducedMotion());
+
+    await waitFor(() => expect(result.current).toBe(false));
+
+    act(() => changeHandler(true));
+
+    expect(result.current).toBe(true);
+  });
+
+  test('removes the subscription on unmount', () => {
+    const { unmount } = renderHook(() => useReducedMotion());
+
+    unmount();
+
+    expect(remove).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/screens/Search.test.tsx
+++ b/tests/unit/screens/Search.test.tsx
@@ -35,6 +35,11 @@ jest.mock('@components/organisms/FilterAccordion', () => ({
 jest.mock('@components/molecules/RecipeCard', () => ({
   RecipeCard: require('@mocks/components/molecules/RecipeCard-mock').recipeCardMock,
 }));
+jest.mock('@hooks/useSafeCopilot', () =>
+  require('@mocks/hooks/useSafeCopilot-mock').useSafeCopilotMock()
+);
+
+const { mockUseSafeCopilot } = require('@mocks/hooks/useSafeCopilot-mock');
 
 const Stack = createStackNavigator();
 
@@ -110,6 +115,74 @@ describe('Search Screen', () => {
 
   afterEach(async () => {
     await database.closeAndReset();
+    mockUseSafeCopilot.mockReturnValue(null);
+  });
+
+  test('renders the tutorial spotlight proxy when copilot is available', async () => {
+    mockUseSafeCopilot.mockReturnValue({
+      copilotEvents: {},
+      currentStep: { order: 2, name: 'Search', text: 'Search step' },
+      isActive: true,
+    });
+
+    const { getByTestId } = await renderSearchComponent();
+
+    expect(getByTestId('CopilotStep::Search')).toBeTruthy();
+    expect(getByTestId('SearchScreen::Tutorial')).toBeTruthy();
+  });
+
+  test('advances to the search step once its target is measured from an earlier step', async () => {
+    const goToNext = jest.fn();
+    const goToPrev = jest.fn();
+    mockUseSafeCopilot.mockReturnValue({
+      copilotEvents: {},
+      currentStep: { order: 1, name: 'Home', text: 'Home step' },
+      isActive: true,
+      goToNext,
+      goToPrev,
+    });
+
+    const { getByTestId } = await renderSearchComponent();
+    fireEvent.press(getByTestId('SearchScreen::ReportToggleTop'));
+
+    expect(goToNext).toHaveBeenCalled();
+    expect(goToPrev).not.toHaveBeenCalled();
+  });
+
+  test('regresses to the search step once its target is measured from a later step', async () => {
+    const goToNext = jest.fn();
+    const goToPrev = jest.fn();
+    mockUseSafeCopilot.mockReturnValue({
+      copilotEvents: {},
+      currentStep: { order: 3, name: 'Menu', text: 'Menu step' },
+      isActive: true,
+      goToNext,
+      goToPrev,
+    });
+
+    const { getByTestId } = await renderSearchComponent();
+    fireEvent.press(getByTestId('SearchScreen::ReportToggleTop'));
+
+    expect(goToPrev).toHaveBeenCalled();
+    expect(goToNext).not.toHaveBeenCalled();
+  });
+
+  test('does not change step when already on the search step', async () => {
+    const goToNext = jest.fn();
+    const goToPrev = jest.fn();
+    mockUseSafeCopilot.mockReturnValue({
+      copilotEvents: {},
+      currentStep: { order: 2, name: 'Search', text: 'Search step' },
+      isActive: true,
+      goToNext,
+      goToPrev,
+    });
+
+    const { getByTestId } = await renderSearchComponent();
+    fireEvent.press(getByTestId('SearchScreen::ReportToggleTop'));
+
+    expect(goToNext).not.toHaveBeenCalled();
+    expect(goToPrev).not.toHaveBeenCalled();
   });
 
   test('initializes with database recipes', async () => {

--- a/tests/unit/screens/Shopping.test.tsx
+++ b/tests/unit/screens/Shopping.test.tsx
@@ -24,6 +24,12 @@ jest.mock('@hooks/useSafeCopilot', () =>
   require('@mocks/hooks/useSafeCopilot-mock').useSafeCopilotMock()
 );
 
+jest.mock('@hooks/useReducedMotion', () =>
+  require('@mocks/hooks/useReducedMotion-mock').useReducedMotionMock()
+);
+
+const { mockUseReducedMotion } = require('@mocks/hooks/useReducedMotion-mock');
+
 jest.mock('@react-navigation/native', () => ({
   ...require('@mocks/deps/react-navigation-mock').reactNavigationMock(),
   useFocusEffect: jest.fn(callback => {
@@ -247,6 +253,7 @@ describe('Shopping Screen', () => {
       jest.useFakeTimers();
       resetMockCopilot();
       mockUseSafeCopilot.mockReturnValue(null);
+      mockUseReducedMotion.mockReturnValue(false);
     });
 
     afterEach(() => {
@@ -275,6 +282,17 @@ describe('Shopping Screen', () => {
       expect(queryByTestId('CopilotStep::Shopping')).toBeNull();
       expect(getByTestId('ShoppingScreen::ClearShoppingListButton::RoundButton')).toBeTruthy();
       expect(getByTestId('ShoppingScreen::Alert::IsVisible')).toBeTruthy();
+      expect(getByTestId('ShoppingScreen::Alert::IsVisible').props.children).toBe(false);
+    });
+
+    test('does not run the demo when reduced motion is enabled', async () => {
+      mockUseReducedMotion.mockReturnValue(true);
+      mockUseSafeCopilot.mockReturnValue(defaultMockValue);
+
+      const { getByTestId } = await renderShoppingAndWaitForButtons();
+
+      jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL * 2);
+
       expect(getByTestId('ShoppingScreen::Alert::IsVisible').props.children).toBe(false);
     });
 

--- a/tests/unit/utils/Tutorial.test.ts
+++ b/tests/unit/utils/Tutorial.test.ts
@@ -1,0 +1,42 @@
+import {
+  getNextTutorialScreen,
+  getPreviousTutorialScreen,
+  getTutorialScreenByOrder,
+  isFirstTutorialStep,
+  isLastTutorialStep,
+} from '@utils/Tutorial';
+
+describe('Tutorial step helpers', () => {
+  test('identifies the first step', () => {
+    expect(isFirstTutorialStep(1)).toBe(true);
+    expect(isFirstTutorialStep(2)).toBe(false);
+  });
+
+  test('identifies the last step', () => {
+    expect(isLastTutorialStep(5)).toBe(true);
+    expect(isLastTutorialStep(4)).toBe(false);
+  });
+
+  test('resolves screen name by order', () => {
+    expect(getTutorialScreenByOrder(1)).toBe('Home');
+    expect(getTutorialScreenByOrder(3)).toBe('Menu');
+    expect(getTutorialScreenByOrder(5)).toBe('Parameters');
+  });
+
+  test('returns undefined for an unknown order', () => {
+    expect(getTutorialScreenByOrder(0)).toBeUndefined();
+    expect(getTutorialScreenByOrder(6)).toBeUndefined();
+  });
+
+  test('resolves the next screen and stops after the last step', () => {
+    expect(getNextTutorialScreen(1)).toBe('Search');
+    expect(getNextTutorialScreen(4)).toBe('Parameters');
+    expect(getNextTutorialScreen(5)).toBeUndefined();
+  });
+
+  test('resolves the previous screen and stops before the first step', () => {
+    expect(getPreviousTutorialScreen(5)).toBe('Shopping');
+    expect(getPreviousTutorialScreen(2)).toBe('Home');
+    expect(getPreviousTutorialScreen(1)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Overhauls the react-native-copilot guided tour so the spotlights land on their targets, navigation is consistent forward/backward, and the demos respect accessibility settings.

### Highlights
- **Home FAB spotlight** spans the full expanded menu (was a too-narrow fixed-width box — the original report).
- **SVG overlay + spotlight margin**; status-bar-aware vertical offset (`StatusBar.currentHeight`) so spotlights aren't shifted up by a status-bar height.
- **Search highlight** reworked: the in-flow toggle button's focused position differs from its unfocused one (it moves as the safe area settles mid-transition). Search now measures the button **until its position is stable** and self-advances the step off that settled value — deterministic, no timers — fixing the forward-vs-previous vertical offset.
- **Home FAB target stays mounted while unfocused** so copilot can always measure it (fixes a "thin band" / never-measured spotlight, and a SIGABRT remount loop from a per-render nested component).
- **Single source of step ordering** (`Tutorial.ts`) for next/previous/first/last.
- **Auto-start fires exactly once**; demos are skipped under OS reduce-motion.
- **Shopping demo dialog** drops below the tooltip during the tour so it isn't clipped.

### Commits
- `feat(tutorial): add useReducedMotion accessibility hook`
- `refactor(tutorial): centralize step ordering in Tutorial helpers`
- `refactor(search): extract FilterToggleButton into its own component`
- `fix(tutorial): align copilot spotlights, nav and reduced-motion demos`

### Tests / quality
- New unit suites: `useReducedMotion`, `Tutorial` helpers, `FilterToggleButton` (100% each); added Search self-advance, tooltip nav, and TutorialController start-event coverage.
- `lint`, `format:check`, `typecheck` all green; affected unit suites pass. `expo:doctor` reports pre-existing dependency-version drift, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)