### PR TITLE
chore(ios): new bundle id and ASC app id for republication

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -22,6 +22,7 @@ function versionToCode(version: string): number {
 
 const configuredName = toSlug(pkg.name);
 const appId = `com.${toIdentifierSegment(pkg.name)}`;
+const iosAppId = `${appId}.ios`;
 
 const primaryColorLight = '#006D38';
 const primaryColorDark = '#79DB95';
@@ -48,7 +49,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
         },
         ios: {
             supportsTablet: true,
-            bundleIdentifier: appId,
+            bundleIdentifier: iosAppId,
             buildNumber: pkg.version,
             infoPlist: {
                 "ITSAppUsesNonExemptEncryption": false,

--- a/app.config.ts
+++ b/app.config.ts
@@ -22,7 +22,23 @@ function versionToCode(version: string): number {
 
 const configuredName = toSlug(pkg.name);
 const appId = `com.${toIdentifierSegment(pkg.name)}`;
-const iosAppId = `${appId}.ios`;
+
+// iOS is being republished under a new App Store identity, so the store build
+// uses a distinct bundle id (`<appId>.ios`). Only the `production` EAS profile
+// gets that id; every other build (Maestro E2E, dev, simulator) keeps the plain
+// `appId`, identical to Android.
+//
+// Why: Maestro identifies the app solely by bundle id and the E2E flows hardcode
+// a single `appId: 'com.recipedia'` shared across both platforms. If the iOS test
+// build also carried the `.ios` suffix, Maestro would try to launch a bundle id
+// that isn't installed and every iOS suite would fail. Gating the suffix to store
+// builds keeps the test bundle id aligned with Android, so the flows stay
+// platform-agnostic and any single flow can be run directly without extra env.
+//
+// Test builds are simulator-only and never submitted, so reusing `com.recipedia`
+// for them cannot collide with the published `com.recipedia.ios` App Store app.
+const isStoreBuild = process.env.EAS_BUILD_PROFILE === 'production';
+const iosAppId = isStoreBuild ? `${appId}.ios` : appId;
 
 const primaryColorLight = '#006D38';
 const primaryColorDark = '#79DB95';

--- a/eas.json
+++ b/eas.json
@@ -78,7 +78,7 @@
   "submit": {
     "production": {
       "ios": {
-        "ascAppId": "6761325557"
+        "ascAppId": "6781367970"
       }
     }
   }

--- a/modules/recipe-scraper/.gitignore
+++ b/modules/recipe-scraper/.gitignore
@@ -1,3 +1,8 @@
 # Generated Pyodide assets (regenerated at build time)
 assets/pyodide-bundle.html
 assets/pyodide-download/
+
+# Local Python venv — must not be copied into EAS build (its certifi cacert.pem
+# is stripped by the root *.pem ignore, breaking pip's truststore at prebuild).
+# Build falls back to system python3 instead (matches CI).
+python/.venv/

--- a/tests/e2e/E2E_TESTING.md
+++ b/tests/e2e/E2E_TESTING.md
@@ -108,6 +108,28 @@ tests/e2e/
 9. **Platform Awareness**: Android and iOS implementations are conditionally
    executed
 
+## Bundle ID (`appId`)
+
+Every flow declares `appId: 'com.recipedia'`. This is shared across **iOS and
+Android** on purpose, and it is **not** the iOS App Store bundle id.
+
+iOS is published under a distinct store identity, `com.recipedia.ios`. That
+suffix is applied **only to the `production` EAS build profile** — see the
+`isStoreBuild` gate in `app.config.ts`. Every non-store build (Maestro E2E, dev,
+simulator) keeps the plain `com.recipedia`, identical to Android.
+
+Why it matters for tests:
+
+- Maestro launches the app **solely by bundle id**. There is no per-platform
+  `appId` in a flow, so the test build must carry the same id on both platforms.
+- If the iOS test build also used `com.recipedia.ios`, Maestro would try to
+  launch a bundle id that isn't installed and **every iOS suite would fail**
+  with `Failed to get app binary directory for bundle com.recipedia`.
+- Keeping the suffix gated to store builds means the flows stay
+  platform-agnostic and any single flow runs directly
+  (`maestro test path/to/flow.yaml`) with no extra env. Do **not** change
+  `appId` to the `.ios` id in flow files.
+
 ## Directory Structure
 
 ### Suite Configuration Files (Root Level)


### PR DESCRIPTION
## Summary

Prepare iOS for a fresh App Store Connect publication and fix the local EAS prod build along the way.

## Commits

- **chore(ios): set new bundle id and ASC app id for republication** — iOS `bundleIdentifier` → `com.recipedia.ios`, `eas.json` `ascAppId` → new app. Android `package` (`com.recipedia`) intentionally unchanged.
- **fix(build): exclude local venv from EAS copy to fix iOS prebuild** — EAS local build copies the project respecting `.gitignore`; the root `*.pem` rule strips `certifi/cacert.pem` from the copied venv, so pip's truststore fails with `FileNotFoundError` at prebuild. Ignoring `python/.venv/` keeps it out of the copy; `setup-pyodide.sh` then falls back to system `python3`, matching CI.

## Notes

- iOS-only change. Android build path untouched.
- No CI impact: CI has no local `.venv`, so the ignore rule is a no-op there.
- Verified: `npm run build:prod:ios` succeeds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)