### PR TITLE
fix(db): verify tags/ingredients in editRecipe, throw on unresolved encode

### DIFF
--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -685,21 +685,23 @@ export class RecipeDatabase {
   /**
    * Updates an existing recipe in the database.
    *
-   * Saves any temporary image to permanent storage before persisting the
-   * update, then refreshes the in-memory cache and notifies `recipes` subscribers.
+   * Verifies all tags and ingredients exist in the database and saves any
+   * temporary image to permanent storage before persisting the update, then
+   * refreshes the in-memory cache and notifies `recipes` subscribers.
    *
    * @param recipe - The recipe to update. Must have a valid `id`.
-   * @returns The updated recipe object (same reference as the input).
+   * @returns The prepared recipe object with verified tags and ingredients.
    * @throws Error if `recipe.id` is undefined.
+   * @throws Error if any tags or ingredients are not found in the database.
    */
   public async editRecipe(recipe: recipeTableElement) {
     if (recipe.id === undefined) {
       throw new Error(`Cannot edit recipe without ID: ${recipe.title}`);
     }
 
-    recipe.image_Source = await this.prepareRecipeImage(recipe.image_Source, recipe.title);
+    const preparedRecipe = await this.prepareRecipe(recipe);
 
-    const updateMap = this.constructUpdateRecipeStructure(this.encodeRecipe(recipe));
+    const updateMap = this.constructUpdateRecipeStructure(this.encodeRecipe(preparedRecipe));
     databaseLogger.debug('Editing recipe', { recipeId: recipe.id, recipeTitle: recipe.title });
     const success = await this._recipesTable.editElementById(
       recipe.id,
@@ -707,7 +709,7 @@ export class RecipeDatabase {
       this._dbConnection
     );
     if (success) {
-      this.update_recipe(recipe);
+      this.update_recipe(preparedRecipe);
       this._recipes = [...this._recipes];
       this.notify('recipes');
       databaseLogger.debug('Recipe edited successfully', { recipeId: recipe.id });
@@ -717,7 +719,7 @@ export class RecipeDatabase {
         recipeTitle: recipe.title,
       });
     }
-    return recipe;
+    return preparedRecipe;
   }
 
   /**
@@ -2223,7 +2225,8 @@ export class RecipeDatabase {
    *
    * @private
    * @param ingredientToEncode - The ingredient object to encode
-   * @returns Encoded string, or empty string if ingredient not found in database
+   * @returns Encoded string representation of the ingredient
+   * @throws Error if the ingredient cannot be resolved in the database
    *
    * @example
    * // Without note
@@ -2235,19 +2238,18 @@ export class RecipeDatabase {
   private encodeIngredient(ingredientToEncode: ingredientTableElement): string {
     const quantity = ingredientToEncode.quantity ? ingredientToEncode.quantity.toString() : '';
     const note = ingredientToEncode.note || '';
-    let idForEncoding: number;
-    if (ingredientToEncode.id === undefined) {
+    let idForEncoding = ingredientToEncode.id;
+    if (idForEncoding === undefined) {
       const foundIngredient = this.find_ingredient(ingredientToEncode);
-      if (foundIngredient === undefined || foundIngredient.id === undefined) {
-        databaseLogger.warn('Cannot encode ingredient - not found in database', {
+      if (foundIngredient?.id === undefined) {
+        databaseLogger.error('Cannot encode ingredient - not found in database', {
           ingredientName: ingredientToEncode.name,
         });
-        return '';
-      } else {
-        idForEncoding = foundIngredient.id;
+        throw new Error(
+          `Cannot encode recipe: ingredient not found in database: ${ingredientToEncode.name}`
+        );
       }
-    } else {
-      idForEncoding = ingredientToEncode.id;
+      idForEncoding = foundIngredient.id;
     }
     const baseEncoding = idForEncoding + textSeparator + quantity;
     return note ? baseEncoding + noteSeparator + note : baseEncoding;
@@ -2442,19 +2444,19 @@ export class RecipeDatabase {
    *
    * @private
    * @param tag - The tag object to encode
-   * @returns String representation of the tag's database ID, or error message if not found
+   * @returns String representation of the tag's database ID
+   * @throws Error if the tag cannot be resolved in the database
    */
   private encodeTagForRecipe(tag: tagTableElement): string {
-    if (tag.id === undefined) {
-      const foundedTag = this.find_tag(tag);
-      if (foundedTag && foundedTag.id) {
-        return foundedTag.id.toString();
-      } else {
-        return 'ERROR : tag not found';
-      }
-    } else {
+    if (tag.id !== undefined) {
       return tag.id.toString();
     }
+    const foundedTag = this.find_tag(tag);
+    if (foundedTag?.id) {
+      return foundedTag.id.toString();
+    }
+    databaseLogger.error('Cannot encode tag - not found in database', { tagName: tag.name });
+    throw new Error(`Cannot encode recipe: tag not found in database: ${tag.name}`);
   }
 
   /**

--- a/tests/unit/context/RecipeDatabaseContext.test.tsx
+++ b/tests/unit/context/RecipeDatabaseContext.test.tsx
@@ -111,6 +111,27 @@ describe('focused database hooks', () => {
       });
     });
 
+    test('swallows a scaleAndUpdateRecipe rejection and clears progress', async () => {
+      const { result } = renderHook(() => useAllHooks());
+
+      await waitFor(() => {
+        expect(result.current.recipes.length).toBeGreaterThan(0);
+      });
+
+      const scaleSpy = jest
+        .spyOn(database, 'scaleAndUpdateRecipe')
+        .mockRejectedValue(new Error('Cannot encode recipe: tag not found in database: Ghost'));
+
+      await expect(result.current.scaleAllRecipesForNewDefaultPersons(6)).resolves.toBeUndefined();
+      expect(scaleSpy).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(result.current.scalingProgress).toBeUndefined();
+      });
+
+      scaleSpy.mockRestore();
+    });
+
     test('does nothing when no recipes need scaling', async () => {
       const { result } = renderHook(() => useAllHooks());
 

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -733,6 +733,49 @@ describe('RecipeDatabase', () => {
         expect(updated?.persons).toBe(4);
         expect(updated?.ingredients).toEqual([]);
       });
+
+      test('rejects and leaves the recipe untouched when a tag is unresolved', async () => {
+        const originalRecipe = db.get_recipes()[0];
+        const scaledRecipe = RecipeDatabase.scaleRecipeToPersons(originalRecipe, 6);
+        const scaledWithUnresolvedTag = {
+          ...scaledRecipe,
+          tags: [...scaledRecipe.tags, { name: 'Unresolved Tag' }],
+        };
+
+        await expect(db.scaleAndUpdateRecipe(scaledWithUnresolvedTag)).rejects.toThrow(
+          /tag not found/i
+        );
+
+        const reloaded = db.get_recipes().find(r => r.id === originalRecipe.id);
+        expect(reloaded?.tags).toEqual(originalRecipe.tags);
+        expect(reloaded?.persons).toBe(originalRecipe.persons);
+      });
+
+      test('rejects and leaves the recipe untouched when an ingredient is unresolved', async () => {
+        const originalRecipe = db.get_recipes()[0];
+        const scaledRecipe = RecipeDatabase.scaleRecipeToPersons(originalRecipe, 6);
+        const scaledWithUnresolvedIngredient = {
+          ...scaledRecipe,
+          ingredients: [
+            ...scaledRecipe.ingredients,
+            {
+              name: 'Unresolved Ingredient',
+              unit: 'g',
+              type: ingredientType.vegetable,
+              season: ['1'],
+              quantity: '100',
+            },
+          ],
+        };
+
+        await expect(db.scaleAndUpdateRecipe(scaledWithUnresolvedIngredient)).rejects.toThrow(
+          /ingredient not found/i
+        );
+
+        const reloaded = db.get_recipes().find(r => r.id === originalRecipe.id);
+        expect(reloaded?.ingredients).toEqual(originalRecipe.ingredients);
+        expect(reloaded?.persons).toBe(originalRecipe.persons);
+      });
     });
 
     // TODO found a test where the insertion fails
@@ -1704,6 +1747,131 @@ describe('RecipeDatabase', () => {
       await db.addMultipleRecipes(recipesWithNoIngredients);
 
       expect(db.get_recipes().length).toBe(0);
+    });
+  });
+
+  describe('editRecipe verification behavior', () => {
+    const db = RecipeDatabase.getInstance();
+
+    beforeEach(async () => {
+      await db.init();
+      await db.addMultipleIngredients(testIngredients);
+      await db.addMultipleTags(testTags);
+      await db.addMultipleRecipes(testRecipes);
+    });
+
+    afterEach(async () => {
+      await db.closeAndReset();
+    });
+
+    test('throws when an edited recipe contains an unpersisted tag', async () => {
+      const existing = db.get_recipes()[0];
+      const edited = {
+        ...existing,
+        tags: [...existing.tags, { id: -1, name: 'Unpersisted Tag' }],
+      };
+
+      await expect(db.editRecipe(edited)).rejects.toThrow(/Tags not found in database:/);
+
+      const reloaded = db.get_recipes().find(r => r.id === existing.id);
+      expect(reloaded?.tags).toEqual(existing.tags);
+    });
+
+    test('throws when an edited recipe contains an unpersisted ingredient', async () => {
+      const existing = db.get_recipes()[0];
+      const edited = {
+        ...existing,
+        ingredients: [
+          ...existing.ingredients,
+          {
+            id: -1,
+            name: 'Unpersisted Ingredient',
+            unit: 'g',
+            type: ingredientType.vegetable,
+            season: ['1'],
+            quantity: '100',
+          },
+        ],
+      };
+
+      await expect(db.editRecipe(edited)).rejects.toThrow(/Ingredients not found in database:/);
+
+      const reloaded = db.get_recipes().find(r => r.id === existing.id);
+      expect(reloaded?.ingredients).toEqual(existing.ingredients);
+    });
+
+    test('edits successfully when all tags and ingredients are persisted', async () => {
+      const existing = db.get_recipes()[0];
+      const edited = { ...existing, title: 'Verified Edit' };
+
+      await expect(db.editRecipe(edited)).resolves.toMatchObject({ title: 'Verified Edit' });
+
+      const reloaded = db.get_recipes().find(r => r.id === existing.id);
+      expect(reloaded?.title).toBe('Verified Edit');
+      expect(reloaded?.tags).toEqual(existing.tags);
+      expect(reloaded?.ingredients).toEqual(existing.ingredients);
+    });
+  });
+
+  describe('encoder error handling', () => {
+    const db = RecipeDatabase.getInstance();
+
+    beforeEach(async () => {
+      await db.init();
+    });
+
+    afterEach(async () => {
+      await db.closeAndReset();
+    });
+
+    const getEncodeTagForRecipe = () =>
+      (
+        db as unknown as { encodeTagForRecipe: (tag: tagTableElement) => string }
+      ).encodeTagForRecipe.bind(db);
+    const getEncodeIngredient = () =>
+      (
+        db as unknown as { encodeIngredient: (ing: ingredientTableElement) => string }
+      ).encodeIngredient.bind(db);
+
+    test('encodeTagForRecipe throws when the tag cannot be resolved', () => {
+      expect(() => getEncodeTagForRecipe()({ name: 'Ghost Tag' })).toThrow(/tag not found/i);
+    });
+
+    test('encodeTagForRecipe resolves an id-less tag by name', async () => {
+      await db.addMultipleTags(testTags);
+      const persisted = db.get_tags()[0];
+
+      expect(getEncodeTagForRecipe()({ name: persisted.name })).toBe(persisted.id?.toString());
+    });
+
+    test('encodeIngredient throws when the ingredient cannot be resolved', () => {
+      expect(() =>
+        getEncodeIngredient()({
+          name: 'Ghost Ingredient',
+          unit: 'g',
+          type: ingredientType.vegetable,
+          season: ['1'],
+          quantity: '100',
+        })
+      ).toThrow(/ingredient not found/i);
+    });
+
+    test('encodeIngredient resolves an id-less ingredient by name', async () => {
+      await db.addMultipleIngredients(testIngredients);
+      const persisted = db.get_ingredients()[0];
+
+      expect(getEncodeIngredient()({ ...persisted, id: undefined, quantity: '200' })).toBe(
+        `${persisted.id}--200`
+      );
+    });
+
+    test('encodeIngredient appends a note to the resolved encoding', async () => {
+      await db.addMultipleIngredients(testIngredients);
+      const persisted = db.get_ingredients()[0];
+
+      expect(
+        getEncodeIngredient()({ ...persisted, id: undefined, quantity: '200', note: 'For sauce' })
+      ).toBe(`${persisted.id}--200%%For sauce`);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #358 — `editRecipe` corrupted the DB when a recipe gained new (unpersisted) tags or ingredients.

`editRecipe` called `encodeRecipe` directly, skipping the `verifyTagsExist` / `verifyIngredientsExist` guards that `addRecipe` runs via `prepareRecipe`. New tags/ingredients (`id: -1`) silently corrupted the `TAGS` / `INGREDIENTS` columns and vanished on the next load.

## Changes

- **`editRecipe` now routes through `prepareRecipe`** — all tags and ingredients are verified before encoding, matching the `addRecipe` path. The returned recipe is now the prepared (DB-resolved) copy.
- **Encoders throw instead of returning sentinels** — `encodeIngredient` (`''`) and `encodeTagForRecipe` (`'ERROR : tag not found'`) now `throw`, so an unresolved entity surfaces as a visible error rather than corrupt data. Flattened their nested branches to guard clauses.

## Tests

- `editRecipe` rejects + leaves the recipe untouched on an unpersisted tag/ingredient.
- Encoder unit tests: throw on unresolved, resolve id-less entities by name (+ note variant).
- `scaleAndUpdateRecipe` (the only write-path without pre-verify) rejects + no corruption on unresolved entities.
- Hook-level: `scaleAllRecipesForNewDefaultPersons` swallows the rejection and clears `scalingProgress`.

All caller paths confirmed to catch the new throw. 178 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)