### PR TITLE
fix(shopping): aggregate quantities numerically

### DIFF
--- a/src/utils/ShoppingComputation.ts
+++ b/src/utils/ShoppingComputation.ts
@@ -14,7 +14,13 @@ import {
   menuTableElement,
   recipeTableElement,
 } from '@customTypes/DatabaseElementTypes';
-import { sumNumberInString } from '@utils/TypeCheckingFunctions';
+import { parseQuantity } from '@utils/Quantity';
+
+type ShoppingAggregate = {
+  item: ComputedShoppingItem;
+  total: number;
+  hasQuantity: boolean;
+};
 
 /**
  * Computes a flat shopping list from the current menu, recipes and purchase state.
@@ -22,8 +28,10 @@ import { sumNumberInString } from '@utils/TypeCheckingFunctions';
  * Iterates over non-cooked menu items, looks up each recipe and accumulates
  * ingredient quantities (multiplied by the menu item count). Duplicate
  * ingredient names across recipes are merged into a single entry. Quantities
- * are summed using `sumNumberInString` to preserve locale-aware decimal
- * separators.
+ * are parsed to numbers via `parseQuantity`, summed numerically and formatted
+ * once at the end (rounded to six decimals to avoid binary floating point
+ * artifacts). Ingredients that never carry a quantity keep an empty string
+ * rather than `"0"`.
  *
  * @param menu - All current menu items (cooked items are excluded)
  * @param recipes - Full recipe catalogue used to resolve `menu[].recipeId`
@@ -36,7 +44,7 @@ export function computeShoppingList(
   purchasedIngredients: Map<string, boolean>
 ): ComputedShoppingItem[] {
   const toCookItems = menu.filter(item => !item.isCooked);
-  const shoppingIngredientMap = new Map<string, ComputedShoppingItem>();
+  const aggregates = new Map<string, ShoppingAggregate>();
   const recipeById = new Map(recipes.map(r => [r.id, r]));
 
   for (const menuItem of toCookItems) {
@@ -47,34 +55,36 @@ export function computeShoppingList(
 
     const count = menuItem.count ?? 1;
     for (const ingredient of recipe.ingredients) {
-      const existing = shoppingIngredientMap.get(ingredient.name);
-      const ingredientQuantity = ingredient.quantity ?? '';
+      const parsed = parseQuantity(ingredient.quantity);
+      const hasQuantity = parsed !== '';
+      const quantityToAdd = hasQuantity ? Number(parsed) * count : 0;
 
-      let quantityToAdd = ingredientQuantity;
-      for (let i = 1; i < count; i++) {
-        quantityToAdd = sumNumberInString(quantityToAdd, ingredientQuantity);
-      }
-
+      const existing = aggregates.get(ingredient.name);
       if (existing) {
-        shoppingIngredientMap.set(ingredient.name, {
-          ...existing,
-          quantity: sumNumberInString(existing.quantity, quantityToAdd),
-          recipeTitles: existing.recipeTitles.includes(recipe.title)
-            ? existing.recipeTitles
-            : [...existing.recipeTitles, recipe.title],
-        });
+        existing.total += quantityToAdd;
+        existing.hasQuantity = existing.hasQuantity || hasQuantity;
+        if (!existing.item.recipeTitles.includes(recipe.title)) {
+          existing.item.recipeTitles.push(recipe.title);
+        }
       } else {
-        shoppingIngredientMap.set(ingredient.name, {
-          name: ingredient.name,
-          type: ingredient.type,
-          quantity: quantityToAdd,
-          unit: ingredient.unit ?? '',
-          recipeTitles: [recipe.title],
-          purchased: purchasedIngredients.get(ingredient.name) ?? false,
+        aggregates.set(ingredient.name, {
+          item: {
+            name: ingredient.name,
+            type: ingredient.type,
+            quantity: '',
+            unit: ingredient.unit ?? '',
+            recipeTitles: [recipe.title],
+            purchased: purchasedIngredients.get(ingredient.name) ?? false,
+          },
+          total: quantityToAdd,
+          hasQuantity,
         });
       }
     }
   }
 
-  return Array.from(shoppingIngredientMap.values());
+  return Array.from(aggregates.values()).map(({ item, total, hasQuantity }) => ({
+    ...item,
+    quantity: hasQuantity ? (Math.round(total * 1e6) / 1e6).toString() : '',
+  }));
 }

--- a/src/utils/TypeCheckingFunctions.tsx
+++ b/src/utils/TypeCheckingFunctions.tsx
@@ -1,12 +1,9 @@
 /**
  * TypeCheckingFunctions - Utility functions for runtime type validation and string arithmetic
  *
- * This module provides type checking utilities for validating data at runtime and
- * performing arithmetic operations on strings containing numbers. Used primarily
- * for validating user input and processing recipe quantity strings.
+ * This module provides type checking utilities for validating data at runtime.
+ * Used primarily for validating user input and database records.
  */
-
-import { separateNumbersFromStr } from '@styles/typography';
 
 /**
  * Checks if a value is a string
@@ -147,92 +144,4 @@ export function hasSameKeysAs<T>(val: unknown, keys: (keyof T)[]): boolean {
 
   const valKeys = Object.keys(val);
   return valKeys.length === keys.length && keys.every(key => valKeys.includes(key as string));
-}
-
-/**
- * Adds numbers contained in two strings
- *
- * Performs addition on strings that contain numeric values. Handles both pure numbers
- * and strings with mixed content (e.g., "2 cups" + "1 cup" = "3 cups").
- *
- * @param lhs - Left-hand side string
- * @param rhs - Right-hand side string
- * @returns String containing the sum
- *
- * @example
- * ```typescript
- * sumNumberInString("2", "3") // "5"
- * sumNumberInString("2 cups", "1 cup") // "3 cups"
- * ```
- */
-export function sumNumberInString(lhs: string, rhs: string) {
-  return operatorNumberInString(lhs, rhs, '+');
-}
-
-/**
- * Subtracts numbers contained in two strings
- *
- * Performs subtraction on strings that contain numeric values. Handles both pure numbers
- * and strings with mixed content (e.g., "5 cups" - "2 cups" = "3 cups").
- *
- * @param lhs - Left-hand side string (minuend)
- * @param rhs - Right-hand side string (subtrahend)
- * @returns String containing the difference
- *
- * @example
- * ```typescript
- * subtractNumberInString("5", "2") // "3"
- * subtractNumberInString("5 cups", "2 cups") // "3 cups"
- * ```
- */
-export function subtractNumberInString(lhs: string, rhs: string) {
-  return operatorNumberInString(lhs, rhs, '-');
-}
-
-/**
- * Performs arithmetic operations on strings containing numbers
- *
- * Internal helper function that handles the logic for both addition and subtraction
- * on strings. When both strings are pure numbers the operation is applied directly.
- * Otherwise both strings are tokenized into number/non-number runs and combined
- * position by position: paired numbers are summed/subtracted, a number paired with
- * an empty slot (e.g. `"100"` vs `"200 g"`) keeps its value and reattaches the unit,
- * and matching text runs are kept once.
- *
- * @param lhs - Left-hand side string
- * @param rhs - Right-hand side string
- * @param operator - The arithmetic operator ('+' or '-')
- * @returns String containing the result of the operation
- */
-function operatorNumberInString(lhs: string, rhs: string, operator: '+' | '-') {
-  const applyOp = (lhs: number, rhs: number): number => {
-    switch (operator) {
-      case '+':
-        return lhs + rhs;
-      case '-':
-        return lhs - rhs;
-    }
-  };
-
-  if (isNumber(lhs) && isNumber(rhs)) {
-    return applyOp(Number(lhs), Number(rhs)).toString();
-  }
-
-  const tokens1 = lhs.match(separateNumbersFromStr) || [];
-  const tokens2 = rhs.match(separateNumbersFromStr) || [];
-  const length = Math.max(tokens1.length, tokens2.length);
-
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    const token = tokens1[i] ?? '';
-    const other = tokens2[i] ?? '';
-    if (token !== '' && other !== '' && isNumber(token) && isNumber(other)) {
-      result += applyOp(Number(token), Number(other)).toString();
-    } else if (token === '' || other === '') {
-      result += token + other;
-    } else {
-      result += token === other ? token : token + other;
-    }
-  }
-  return result;
 }

--- a/src/utils/TypeCheckingFunctions.tsx
+++ b/src/utils/TypeCheckingFunctions.tsx
@@ -7,7 +7,6 @@
  */
 
 import { separateNumbersFromStr } from '@styles/typography';
-import { validationLogger } from '@utils/logger';
 
 /**
  * Checks if a value is a string
@@ -194,10 +193,11 @@ export function subtractNumberInString(lhs: string, rhs: string) {
  * Performs arithmetic operations on strings containing numbers
  *
  * Internal helper function that handles the logic for both addition and subtraction
- * on strings. Supports three cases:
- * 1. Both strings are pure numbers
- * 2. Both strings contain mixed content (numbers + text)
- * 3. Mixed case (one number, one mixed) - logs error and concatenates
+ * on strings. When both strings are pure numbers the operation is applied directly.
+ * Otherwise both strings are tokenized into number/non-number runs and combined
+ * position by position: paired numbers are summed/subtracted, a number paired with
+ * an empty slot (e.g. `"100"` vs `"200 g"`) keeps its value and reattaches the unit,
+ * and matching text runs are kept once.
  *
  * @param lhs - Left-hand side string
  * @param rhs - Right-hand side string
@@ -214,31 +214,25 @@ function operatorNumberInString(lhs: string, rhs: string, operator: '+' | '-') {
     }
   };
 
-  const lhsIsNumber = isNumber(lhs);
-  const rhsIsNumber = isNumber(rhs);
-  if (lhsIsNumber && rhsIsNumber) {
+  if (isNumber(lhs) && isNumber(rhs)) {
     return applyOp(Number(lhs), Number(rhs)).toString();
-  } else if (!lhsIsNumber && !rhsIsNumber) {
-    const tokens1 = lhs.match(separateNumbersFromStr) || [];
-    const tokens2 = rhs.match(separateNumbersFromStr) || [];
-
-    return tokens1
-      .map((token, i) => {
-        const other = tokens2[i] ?? '';
-        if (isNumber(token) && isNumber(other)) {
-          return applyOp(Number(token), Number(other)).toString();
-        }
-        if (token === other) return token;
-        return token + other;
-      })
-      .join('');
-  } else {
-    validationLogger.error(
-      "Can't have one which can be a number and other which cannot be: ",
-      lhs,
-      ' ',
-      rhs
-    );
-    return lhs + rhs;
   }
+
+  const tokens1 = lhs.match(separateNumbersFromStr) || [];
+  const tokens2 = rhs.match(separateNumbersFromStr) || [];
+  const length = Math.max(tokens1.length, tokens2.length);
+
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    const token = tokens1[i] ?? '';
+    const other = tokens2[i] ?? '';
+    if (token !== '' && other !== '' && isNumber(token) && isNumber(other)) {
+      result += applyOp(Number(token), Number(other)).toString();
+    } else if (token === '' || other === '') {
+      result += token + other;
+    } else {
+      result += token === other ? token : token + other;
+    }
+  }
+  return result;
 }

--- a/tests/unit/utils/ShoppingComputation.test.ts
+++ b/tests/unit/utils/ShoppingComputation.test.ts
@@ -117,6 +117,59 @@ describe('computeShoppingList', () => {
     expect(result[0].quantity).toBe('350');
   });
 
+  test('sums same ingredient across recipes when quantity formats are mixed', () => {
+    const recipe1 = makeRecipe(1, 'Pasta', [makeIngredient('flour', '100', 'g')]);
+    const recipe2 = makeRecipe(2, 'Cake', [makeIngredient('flour', '200 g', 'g')]);
+    const result = computeShoppingList(
+      [makeMenuItem(1), makeMenuItem(2)],
+      [recipe1, recipe2],
+      noPurchased
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].quantity).toBe('300');
+    expect(result[0].unit).toBe('g');
+  });
+
+  test('multiplies a numeric quantity parsed from mixed input by count', () => {
+    const recipe = makeRecipe(1, 'Pasta', [makeIngredient('flour', '100 g', 'g')]);
+    const result = computeShoppingList([makeMenuItem(1, { count: 3 })], [recipe], noPurchased);
+
+    expect(result[0].quantity).toBe('300');
+  });
+
+  test('keeps quantity empty when same ingredient lacks quantity in two recipes', () => {
+    const recipe1 = makeRecipe(1, 'Soup', [makeIngredient('salt', '', 'pinch')]);
+    const recipe2 = makeRecipe(2, 'Stew', [makeIngredient('salt', '', 'pinch')]);
+    const result = computeShoppingList(
+      [makeMenuItem(1), makeMenuItem(2)],
+      [recipe1, recipe2],
+      noPurchased
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].quantity).toBe('');
+  });
+
+  test('keeps quantity empty when an unquantified ingredient has count greater than one', () => {
+    const recipe = makeRecipe(1, 'Soup', [makeIngredient('salt', '', 'pinch')]);
+    const result = computeShoppingList([makeMenuItem(1, { count: 3 })], [recipe], noPurchased);
+
+    expect(result[0].quantity).toBe('');
+  });
+
+  test('sums decimal quantities without floating point artifacts', () => {
+    const recipe1 = makeRecipe(1, 'Cake', [makeIngredient('oil', '0.1', 'l')]);
+    const recipe2 = makeRecipe(2, 'Bread', [makeIngredient('oil', '0.2', 'l')]);
+    const result = computeShoppingList(
+      [makeMenuItem(1), makeMenuItem(2)],
+      [recipe1, recipe2],
+      noPurchased
+    );
+
+    expect(result[0].quantity).toBe('0.3');
+  });
+
   test('accumulates both recipe titles when ingredient appears in two recipes', () => {
     const recipe1 = makeRecipe(1, 'Pasta', [makeIngredient('flour', '200', 'g')]);
     const recipe2 = makeRecipe(2, 'Cake', [makeIngredient('flour', '150', 'g')]);

--- a/tests/unit/utils/TypeCheckingFunctions.test.tsx
+++ b/tests/unit/utils/TypeCheckingFunctions.test.tsx
@@ -7,8 +7,6 @@ import {
   isNumber,
   isOfType,
   isString,
-  subtractNumberInString,
-  sumNumberInString,
 } from '@utils/TypeCheckingFunctions';
 
 describe('Type Checking Functions', () => {
@@ -47,6 +45,16 @@ describe('Type Checking Functions', () => {
       expect(hasAtLeastKeys<{ a: any; b: any }>({ a: 1, b: 2, c: 3 }, ['a', 'b'])).toBe(true);
     });
 
+    test('hasAtLeastKeys should reject null and non-objects', () => {
+      expect(hasAtLeastKeys<{ a: any }>(null, ['a'])).toBe(false);
+      expect(hasAtLeastKeys<{ a: any }>('not an object', ['a'])).toBe(false);
+    });
+
+    test('hasSameKeysAs should reject null and non-objects', () => {
+      expect(hasSameKeysAs<{ a: any }>(null, ['a'])).toBe(false);
+      expect(hasSameKeysAs<{ a: any }>(42, ['a'])).toBe(false);
+    });
+
     test('isOfType should confirm object has required keys (allows extra keys)', () => {
       expect(isOfType<{ name: string }>({ name: 'Alice' }, ['name'])).toBe(true);
       expect(isOfType<{ name: string }>({ name: 'Alice', age: 30 }, ['name'])).toBe(true);
@@ -56,60 +64,6 @@ describe('Type Checking Functions', () => {
     test('isArrayOfType should confirm array of structured objects', () => {
       const array = [{ id: 1 }, { id: 2 }];
       expect(isArrayOfType<{ id: number }>(array, ['id'])).toBe(true);
-    });
-  });
-
-  describe('sumNumberInString', () => {
-    test('adds plain numbers', () => {
-      expect(sumNumberInString('10', '5')).toBe('15');
-    });
-
-    test('adds embedded numbers in strings', () => {
-      expect(sumNumberInString('2x3y', '4x7y')).toBe('6x10y');
-      expect(sumNumberInString('1and3', '1and3')).toBe('2and6');
-    });
-
-    test('adds text intelligently', () => {
-      expect(sumNumberInString('a5b', 'a2b')).toBe('a7b');
-      expect(sumNumberInString('abc1', 'abc2')).toBe('abc3');
-    });
-
-    test('logs error when mixing number and non-number strings', () => {
-      expect(sumNumberInString('42', 'abc')).toBe('42abc');
-      // Should handle mixed types gracefully
-    });
-
-    test('sums a pure number with a number-and-unit string and reattaches the unit', () => {
-      expect(sumNumberInString('100', '200 g')).toBe('300 g');
-      expect(sumNumberInString('200 g', '100')).toBe('300 g');
-    });
-
-    test('sums two number-and-unit strings sharing the same unit', () => {
-      expect(sumNumberInString('2 cups', '1 cups')).toBe('3 cups');
-    });
-  });
-
-  describe('subtractNumberInString', () => {
-    test('subtracts plain numbers', () => {
-      expect(subtractNumberInString('10', '4')).toBe('6');
-    });
-
-    test('subtracts embedded numbers', () => {
-      expect(subtractNumberInString('5x8y', '2x3y')).toBe('3x5y');
-    });
-
-    test('subtracts text-number combos safely', () => {
-      expect(subtractNumberInString('a9b', 'a2b')).toBe('a7b');
-    });
-
-    test('logs error when mixing types', () => {
-      expect(subtractNumberInString('oops', '123')).toBe('oops123');
-      // Should handle mixed types gracefully
-    });
-
-    test('subtracts a pure number from a number-and-unit string and reattaches the unit', () => {
-      expect(subtractNumberInString('200 g', '50')).toBe('150 g');
-      expect(subtractNumberInString('200', '50 g')).toBe('150 g');
     });
   });
 });

--- a/tests/unit/utils/TypeCheckingFunctions.test.tsx
+++ b/tests/unit/utils/TypeCheckingFunctions.test.tsx
@@ -78,6 +78,15 @@ describe('Type Checking Functions', () => {
       expect(sumNumberInString('42', 'abc')).toBe('42abc');
       // Should handle mixed types gracefully
     });
+
+    test('sums a pure number with a number-and-unit string and reattaches the unit', () => {
+      expect(sumNumberInString('100', '200 g')).toBe('300 g');
+      expect(sumNumberInString('200 g', '100')).toBe('300 g');
+    });
+
+    test('sums two number-and-unit strings sharing the same unit', () => {
+      expect(sumNumberInString('2 cups', '1 cups')).toBe('3 cups');
+    });
   });
 
   describe('subtractNumberInString', () => {
@@ -96,6 +105,11 @@ describe('Type Checking Functions', () => {
     test('logs error when mixing types', () => {
       expect(subtractNumberInString('oops', '123')).toBe('oops123');
       // Should handle mixed types gracefully
+    });
+
+    test('subtracts a pure number from a number-and-unit string and reattaches the unit', () => {
+      expect(subtractNumberInString('200 g', '50')).toBe('150 g');
+      expect(subtractNumberInString('200', '50 g')).toBe('150 g');
     });
   });
 });


### PR DESCRIPTION
## Summary

Reworks shopping-list quantity aggregation to operate on numbers instead of strings, fixing two reachable bugs and removing the now-dead string-arithmetic helpers.

Investigation of #359: the reported `"100200 g"` concatenation is unreachable today — `quantity` and `unit` are separate fields and every entry point normalizes `quantity` via `parseQuantity`, so `computeShoppingList` only ever receives pure-number/empty strings. But probing the live `sumNumberInString` path surfaced two bugs that **are** reachable:

- **Empty + empty → `"0"`** — same ingredient with no quantity in two recipes (or `count > 1`) showed `"0"` instead of `""`.
- **Float artifacts** — `0.1 + 0.2` produced `"0.30000000000000004"`, accumulating across sums.

## Commits

- `fix(shopping): aggregate quantities numerically` — `computeShoppingList` now parses each quantity once with `parseQuantity`, sums numerically (× menu count), rounds to 6 decimals, formats once. Empty-quantity ingredients keep `""`. Also removes the O(count) repeated re-summation.
- `refactor(utils): drop unused string-arithmetic helpers` — `subtractNumberInString` (0 callers) and `sumNumberInString` (unused after the rework) removed, along with the shared `operatorNumberInString` tokenizer and the dead `separateNumbersFromStr` import. `TypeCheckingFunctions` keeps only the runtime type guards.

## Testing

- `ShoppingComputation.ts` + `TypeCheckingFunctions.tsx`: **100%** stmts/branch/func/line
- New regression tests: empty→`""`, decimal float, mixed-input numeric parse, count multiply
- typecheck ✓, eslint ✓, docs:build ✓ (no warnings)
- Full unit suite green (`Home.test.tsx` is a pre-existing timer flake under parallel load — passes isolated, untouched by this diff)

Closes #359 (as not-reproducible per current model; fixes the real reachable bugs found in the same path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)