### PR TITLE
fix(build): resolve store iOS bundle id for local production builds

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -20,25 +20,42 @@ function versionToCode(version: string): number {
     return major * 10000 + minor * 100 + patch;
 }
 
+/**
+ * Resolves the iOS bundle identifier for a build.
+ *
+ * iOS is republished under a new App Store identity, so only the store build
+ * uses the suffixed id (`<baseAppId>.ios`); every other build (Maestro E2E, dev,
+ * simulator) keeps the plain `baseAppId`, identical to Android, so the E2E flows
+ * can launch a single shared bundle id.
+ *
+ * The store build is detected via `EXPO_PUBLIC_DATASET_TYPE === 'production'`,
+ * which only the `production` EAS profile sets in its `env` block. This is used
+ * instead of `EAS_BUILD_PROFILE` because EAS only injects `EAS_BUILD_PROFILE`
+ * into the build job, whereas the bundle id is resolved earlier, when `eas build`
+ * evaluates this config to set up credentials — before the job env exists. A
+ * build-profile `env` var is applied at config-evaluation time, so it resolves
+ * the same bundle id for both local (`eas build --local`) and cloud builds.
+ *
+ * @param baseAppId - The platform-agnostic application id (e.g. `com.recipedia`).
+ * @param env - Environment variables to read the dataset type from. Defaults to
+ *   `process.env`.
+ * @returns The store bundle id (`<baseAppId>.ios`) for production builds,
+ *   otherwise `baseAppId`.
+ */
+export function resolveIosBundleId(
+    baseAppId: string,
+    env: Record<string, string | undefined> = process.env,
+): string {
+    const isStoreBuild = env.EXPO_PUBLIC_DATASET_TYPE === 'production';
+    return isStoreBuild ? `${baseAppId}.ios` : baseAppId;
+}
+
 const configuredName = toSlug(pkg.name);
 const appId = `com.${toIdentifierSegment(pkg.name)}`;
 
-// iOS is being republished under a new App Store identity, so the store build
-// uses a distinct bundle id (`<appId>.ios`). Only the `production` EAS profile
-// gets that id; every other build (Maestro E2E, dev, simulator) keeps the plain
-// `appId`, identical to Android.
-//
-// Why: Maestro identifies the app solely by bundle id and the E2E flows hardcode
-// a single `appId: 'com.recipedia'` shared across both platforms. If the iOS test
-// build also carried the `.ios` suffix, Maestro would try to launch a bundle id
-// that isn't installed and every iOS suite would fail. Gating the suffix to store
-// builds keeps the test bundle id aligned with Android, so the flows stay
-// platform-agnostic and any single flow can be run directly without extra env.
-//
-// Test builds are simulator-only and never submitted, so reusing `com.recipedia`
-// for them cannot collide with the published `com.recipedia.ios` App Store app.
-const isStoreBuild = process.env.EAS_BUILD_PROFILE === 'production';
-const iosAppId = isStoreBuild ? `${appId}.ios` : appId;
+// Maestro E2E flows hardcode a single `com.recipedia` shared across platforms,
+// so only the store build carries the `.ios` suffix. See `resolveIosBundleId`.
+const iosAppId = resolveIosBundleId(appId);
 
 const primaryColorLight = '#006D38';
 const primaryColorDark = '#79DB95';

--- a/eas.json
+++ b/eas.json
@@ -60,9 +60,6 @@
           "android/build"
         ]
       },
-      "env": {
-        "NODE_OPTIONS": "--max-old-space-size=4096"
-      },
       "android": {
         "buildType": "app-bundle",
         "image": "latest"
@@ -71,6 +68,7 @@
         "buildConfiguration": "Release"
       },
       "env": {
+        "NODE_OPTIONS": "--max-old-space-size=4096",
         "EXPO_PUBLIC_DATASET_TYPE": "production"
       }
     }

--- a/tests/unit/app.config.test.ts
+++ b/tests/unit/app.config.test.ts
@@ -1,0 +1,41 @@
+import { resolveIosBundleId } from '@app/app.config';
+
+describe('resolveIosBundleId', () => {
+  const baseAppId = 'com.recipedia';
+
+  it('appends the .ios suffix for production store builds', () => {
+    expect(resolveIosBundleId(baseAppId, { EXPO_PUBLIC_DATASET_TYPE: 'production' })).toBe(
+      'com.recipedia.ios'
+    );
+  });
+
+  it('keeps the plain id for the test dataset', () => {
+    expect(resolveIosBundleId(baseAppId, { EXPO_PUBLIC_DATASET_TYPE: 'test' })).toBe(
+      'com.recipedia'
+    );
+  });
+
+  it('keeps the plain id for the performance dataset', () => {
+    expect(resolveIosBundleId(baseAppId, { EXPO_PUBLIC_DATASET_TYPE: 'performance' })).toBe(
+      'com.recipedia'
+    );
+  });
+
+  it('keeps the plain id when the dataset type is unset', () => {
+    expect(resolveIosBundleId(baseAppId, {})).toBe('com.recipedia');
+  });
+
+  it('reads from process.env when no env is provided', () => {
+    const previous = process.env.EXPO_PUBLIC_DATASET_TYPE;
+    process.env.EXPO_PUBLIC_DATASET_TYPE = 'production';
+    try {
+      expect(resolveIosBundleId(baseAppId)).toBe('com.recipedia.ios');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.EXPO_PUBLIC_DATASET_TYPE;
+      } else {
+        process.env.EXPO_PUBLIC_DATASET_TYPE = previous;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The iOS **production** build could not produce a submittable binary. The store bundle id (`com.recipedia.ios`) was gated on `EAS_BUILD_PROFILE === 'production'`, but EAS only injects `EAS_BUILD_PROFILE` into the **build job** — not into the earlier config evaluation that resolves the bundle id for credential setup.

`npm run build:prod:ios` runs `eas build --local`, which evaluates the config before that job env exists. So local production builds silently fell back to `com.recipedia` and could **not** be submitted to the new App Store app (`com.recipedia.ios`, `ascAppId 6781367970`).

> Note: this was **not** a missing-credentials issue — the `com.recipedia.ios` distribution cert + provisioning profile already exist on EAS.

A secondary bug: the `production` profile had a **duplicate `env` key**, so the later one silently dropped `NODE_OPTIONS` (lowering the build's heap limit).

## Fix

- Gate the store bundle id on `EXPO_PUBLIC_DATASET_TYPE === 'production'`, which is set in the production profile's `env` block and is therefore applied at **config-evaluation time** for both local (`eas build --local`) and cloud builds.
- Extract the gating logic into an exported `resolveIosBundleId` helper with TSDoc, and cover both branches with unit tests so the regression cannot recur.
- Merge the duplicate `env` block in the `production` profile (restores `NODE_OPTIONS`).

## Verification

- `expo config`: production → `com.recipedia.ios`, default → `com.recipedia`.
- Unit tests: 5/5 pass.
- **Full local production build succeeded** end-to-end → signed `.ipa` (42.2 MB) with the `com.recipedia.ios` provisioning profile, `Build successful`.

## Commits

- `184c9e76` fix(build): resolve store iOS bundle id for local production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)