### PR TITLE
Add missing French vegetable oil match

### DIFF
--- a/src/translations/fr/recipe.ts
+++ b/src/translations/fr/recipe.ts
@@ -140,6 +140,7 @@ export default {
       'poivre et sel',
       "huile d'olive",
       'huile de cuisson',
+      'huile végétale',
       'beurre',
     ],
     stepTitle: 'Étape {{number}}',


### PR DESCRIPTION
Fixes #357.

Adds huile végétale to the French scraper ignored exact-match list so it stays aligned with the English vegetable oil entry. This keeps fallback ingredient filtering consistent across English and French.

Checked locally:
- npm exec --yes --package=prettier@3.6.2 -- prettier --check src/translations/fr/recipe.ts
- npx eslint src/translations/fr/recipe.ts
- npm run typecheck