### PR TITLE
ci(quality): drop npm audit PR comments, gate via check status

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   commit-validation:
@@ -136,12 +135,7 @@ jobs:
         with:
           node-version: '24'
       - name: Security audit
-        uses: oke-py/npm-audit-action@v4
-        with:
-          audit_level: critical
-          create_issues: false
-          create_pr_comments: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: npm audit --audit-level=critical
 
   documentation:
     name: Documentation Build


### PR DESCRIPTION
## Why

`github-actions` bot posted verbose npm audit output as a PR comment on every run via `oke-py/npm-audit-action` — pure noise. PR check status already signals pass/fail.

## What

- Replace `oke-py/npm-audit-action` with plain `npm audit --audit-level=critical`
- Audit still gates: fails job on critical vuln, surfaces in PR checks list
- Remove now-unused `pull-requests: write` permission (no job writes comments anymore)

## Notes

Not standard to post audit results as PR comments — convention is check status + dedicated tooling (Dependabot / Security tab) for vuln detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)