### PR TITLE
chore(deps): align dependabot config with Expo SDK management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  # Enable version updates for npm dependencies
+  # npm dependencies. Expo SDK pins the React Native / React / Expo / Babel /
+  # Metro toolchain — those are bumped via `expo install` / SDK upgrades, never
+  # by Dependabot. Dependabot only handles standalone JS libs and dev tooling,
+  # minor + patch only. Major bumps are a deliberate human action.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -11,14 +14,8 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - "AntoC"
-    assignees:
-      - "dependabot"
-    # Pull request configuration
     pull-request-branch-name:
       separator: "/"
-    allow:
-      - dependency-type: "direct"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
@@ -26,49 +23,52 @@ updates:
     labels:
       - "dependencies"
       - "automated"
-    # Group React Native related packages together
+    allow:
+      - dependency-type: "direct"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
-      expo:
-        patterns:
-          - "expo*"
-          - "@expo*"
       testing:
         patterns:
           - "*jest*"
-          - "babel-jest"
           - "reassure"
       linting:
         patterns:
           - "eslint*"
           - "@typescript-eslint/*"
           - "prettier*"
-      build-tools:
+      semantic-release:
         patterns:
-          - "typescript"
-          - "webpack*"
-          - "babel*"
-          - "@babel/*"
+          - "semantic-release"
+          - "@semantic-release/*"
+          - "conventional-changelog-*"
+      commitlint:
+        patterns:
+          - "@commitlint/*"
     ignore:
-      # Expo SDK versions should be updated manually
-      - dependency-name: "expo"
-      # React Native versions should be updated carefully
-      - dependency-name: "react-native"
-      # All React Native related packages should be updated manually
-      - dependency-name: "react-native*"
-      - dependency-name: "@react-native*"
-      # All Expo related packages should be updated manually
+      # Expo / React Native / React — managed by Expo SDK, bump via `expo install`
       - dependency-name: "expo*"
       - dependency-name: "@expo*"
-      # React versions must track Expo SDK — update manually
+      - dependency-name: "react-native*"
+      - dependency-name: "@react-native*"
       - dependency-name: "react"
       - dependency-name: "react-dom"
       - dependency-name: "react-compiler-runtime"
+      - dependency-name: "babel-plugin-react-compiler"
+      - dependency-name: "eslint-plugin-react-compiler"
       - dependency-name: "@types/react*"
-      # React Navigation is tightly coupled to React Native version
       - dependency-name: "@react-navigation/*"
-      # React Native Testing Library must match React Native version
       - dependency-name: "@testing-library/react-native"
-      # Node.js types often have issues with automatic updates
+      - dependency-name: "@shopify/flash-list"
+      # Expo-SDK-versioned, not matched by the wildcards above
+      - dependency-name: "jest-expo"
+      - dependency-name: "eslint-config-expo"
+      # Babel / Metro — pinned by babel-preset-expo / jest-expo / metro
+      - dependency-name: "@babel/*"
+      - dependency-name: "babel-*"
+      - dependency-name: "metro-*"
+      # Node types — avoid disruptive majors
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
 
@@ -82,9 +82,6 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "AntoC"
-    assignees:
-      - "dependabot"
-    # Pull request configuration
     pull-request-branch-name:
       separator: "/"
     commit-message:


### PR DESCRIPTION
## Summary

Audited the Dependabot config against Expo SDK 55 + standard Dependabot best practices (via sub-agent). The config had contradictions, dead groups, and leaked SDK-managed bumps.

**Principle:** Expo SDK pins the RN / React / Expo / Babel / Metro version matrix — those must be bumped via `expo install` / SDK upgrades, never independently by Dependabot. Dependabot now scoped to standalone JS libs + dev tooling, minor/patch only.

## Changes

- **Restrict to semver minor + patch** — drop auto major bumps (breakage/noise on an Expo project)
- **Ignore SDK/compiler-version-aligned packages** that previously leaked through: `@babel/*`, `babel-*`, `metro-*`, `@shopify/flash-list`, `jest-expo`, `eslint-config-expo`, `eslint-plugin-react-compiler`, `babel-plugin-react-compiler`
- **Delete dead config**: `expo` group (matched only ignored `expo*`/`@expo*`), `webpack*`/`babel*` patterns in `build-tools` (no webpack; babel is SDK-managed)
- **Add groups**: `semantic-release`, `commitlint`
- **Remove** meaningless `assignees: [dependabot]` (assigned PRs to the bot itself)
- **Drop** redundant standalone `expo` / `react-native` ignores (covered by wildcards)

## Audit findings fixed

| Sev | Issue |
|-----|-------|
| HIGH | `allow` permitted `semver-major` |
| HIGH | Dead `expo` group + `webpack*`/babel patterns in `build-tools` |
| HIGH | Babel/Metro, flash-list, jest-expo, eslint-config-expo not ignored → leaked SDK bumps |
| MED | `assignees: [dependabot]` meaningless |
| LOW | Redundant `expo`/`react-native` ignores |

🤖 Generated with [Claude Code](https://claude.com/claude-code)