### PR TITLE
ci: run build and E2E on fork PRs without secrets

### DIFF
--- a/.github/scripts/merge-maestro-logs.sh
+++ b/.github/scripts/merge-maestro-logs.sh
@@ -25,8 +25,8 @@ for suite_dir in "$INPUT_DIR"/*/; do
 done
 
 if [ $SUITE_COUNT -eq 0 ]; then
-  echo "No suite directories found to merge"
-  exit 1
+  echo "No suite directories found to merge (nothing to package)"
+  exit 0
 fi
 
 mkdir -p "$OUTPUT_DIR"

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,5 +1,9 @@
 name: Build App
 
+# Uses an EAS signed build when EXPO_TOKEN is set (push / same-repo PRs), and
+# falls back to a secret-free local build (gradlew / xcodebuild simulator) on
+# fork PRs, which never receive secrets.
+
 on:
   workflow_call:
     inputs:
@@ -21,12 +25,14 @@ on:
         type: string
     secrets:
       EXPO_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:
     name: Build ${{ inputs.platform == 'ios' && 'iOS App' || 'APK' }} (${{ inputs.build-profile }})
     runs-on: ${{ inputs.platform == 'ios' && 'macos-15' || 'ubuntu-latest' }}
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
       - name: Select Xcode 26
         if: inputs.platform == 'ios'
@@ -38,6 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect changed files
+        if: env.EXPO_TOKEN != ''
         uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -76,6 +83,7 @@ jobs:
         run: npm ci
 
       - name: Build decision summary
+        if: env.EXPO_TOKEN != ''
         env:
           PLATFORM_LABEL: ${{ inputs.platform == 'ios' && 'iOS app' || 'APK' }}
         run: |
@@ -88,6 +96,7 @@ jobs:
 
       - name: Find cached app
         if: |
+          env.EXPO_TOKEN != '' &&
           steps.filter.outputs.build_required != 'true' &&
           github.ref != 'refs/heads/main' &&
           !startsWith(github.ref, 'refs/tags/')
@@ -103,6 +112,7 @@ jobs:
 
       - name: Download cached app
         if: |
+          env.EXPO_TOKEN != '' &&
           steps.filter.outputs.build_required != 'true' &&
           github.ref != 'refs/heads/main' &&
           !startsWith(github.ref, 'refs/tags/') &&
@@ -117,6 +127,7 @@ jobs:
 
       - name: Handle download failure
         if: |
+          env.EXPO_TOKEN != '' &&
           steps.filter.outputs.build_required != 'true' &&
           github.ref != 'refs/heads/main' &&
           !startsWith(github.ref, 'refs/tags/') &&
@@ -129,7 +140,7 @@ jobs:
 
       - name: Setup Android build environment
         if: |
-          inputs.platform == 'android' && (
+          env.EXPO_TOKEN != '' && inputs.platform == 'android' && (
             steps.filter.outputs.build_required == 'true' ||
             github.ref == 'refs/heads/main' ||
             startsWith(github.ref, 'refs/tags/') ||
@@ -142,7 +153,7 @@ jobs:
 
       - name: Setup iOS build environment
         if: |
-          inputs.platform == 'ios' && (
+          env.EXPO_TOKEN != '' && inputs.platform == 'ios' && (
             steps.filter.outputs.build_required == 'true' ||
             github.ref == 'refs/heads/main' ||
             startsWith(github.ref, 'refs/tags/') ||
@@ -153,13 +164,15 @@ jobs:
           eas-version: '16.3.0'
           expo-token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Build app
+      - name: Build app (EAS)
         id: build-app
         if: |
-          steps.filter.outputs.build_required == 'true' ||
-          github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/') ||
-          env.BUILD_FALLBACK == 'true'
+          env.EXPO_TOKEN != '' && (
+            steps.filter.outputs.build_required == 'true' ||
+            github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/tags/') ||
+            env.BUILD_FALLBACK == 'true'
+          )
         run: |
           set -o pipefail
           npm run build:${{ inputs.build-profile }}:${{ inputs.platform }} 2>&1 \
@@ -176,7 +189,7 @@ jobs:
 
       - name: Package Android APK
         if: |
-          inputs.platform == 'android' && (
+          env.EXPO_TOKEN != '' && inputs.platform == 'android' && (
             steps.filter.outputs.build_required == 'true' ||
             github.ref == 'refs/heads/main' ||
             startsWith(github.ref, 'refs/tags/') ||
@@ -188,7 +201,7 @@ jobs:
 
       - name: Package iOS app bundle
         if: |
-          inputs.platform == 'ios' && (
+          env.EXPO_TOKEN != '' && inputs.platform == 'ios' && (
             steps.filter.outputs.build_required == 'true' ||
             github.ref == 'refs/heads/main' ||
             startsWith(github.ref, 'refs/tags/') ||
@@ -218,6 +231,50 @@ jobs:
           mv "$APP_PATH" "${{ inputs.app-filename }}"
           zip -r "${{ inputs.app-filename }}.zip" "${{ inputs.app-filename }}"
           rm -rf _extracted
+          echo "✅ iOS app built and packaged: ${{ inputs.app-filename }}.zip"
+
+      - name: Setup Java 17 (fork build)
+        if: env.EXPO_TOKEN == '' && inputs.platform == 'android'
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build Android APK without EXPO_TOKEN
+        if: env.EXPO_TOKEN == '' && inputs.platform == 'android'
+        # Match the EAS maestro profile env so Metro inlines the test dataset
+        env:
+          EXPO_PUBLIC_DATASET_TYPE: test
+          EXPO_PUBLIC_DISABLE_ANIMATIONS: 'true'
+        run: |
+          npx expo prebuild --platform android --no-install
+          (cd android && ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=x86_64)
+          mv android/app/build/outputs/apk/release/app-release.apk "${{ inputs.app-filename }}"
+          echo "✅ APK built: ${{ inputs.app-filename }}"
+
+      - name: Build iOS app without EXPO_TOKEN
+        if: env.EXPO_TOKEN == '' && inputs.platform == 'ios'
+        # Match the EAS maestro profile env so Metro inlines the test dataset
+        env:
+          SCHEME: ${{ inputs.app-filename }}
+          EXPO_PUBLIC_DATASET_TYPE: test
+          EXPO_PUBLIC_DISABLE_ANIMATIONS: 'true'
+        run: |
+          SCHEME="${SCHEME%.app}"
+          npx expo prebuild --platform ios --no-install
+          npx pod-install
+          xcodebuild \
+            -workspace "ios/${SCHEME}.xcworkspace" \
+            -scheme "${SCHEME}" \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -derivedDataPath ios/build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            build
+          APP_PATH=$(find ios/build/Build/Products/Release-iphonesimulator -name "*.app" -type d | head -1)
+          mv "$APP_PATH" "${{ inputs.app-filename }}"
+          zip -r "${{ inputs.app-filename }}.zip" "${{ inputs.app-filename }}"
           echo "✅ iOS app built and packaged: ${{ inputs.app-filename }}.zip"
 
       - name: Verify app availability

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,6 +17,9 @@ jobs:
   install-and-doctor:
     name: Install Dependencies and run Expo doctor
     runs-on: ubuntu-latest
+    # Trusted context that receives secrets: push or same-repo PR. Fork PRs don't.
+    outputs:
+      is_internal: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -29,8 +32,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}
-
-
 
   bundle-size:
     name: JS Bundle Size
@@ -92,7 +93,7 @@ jobs:
         run: node .github/scripts/reassure-compact-summary.mjs
 
       - name: Post Reassure results on PR
-        if: github.event_name == 'pull_request' && hashFiles('.reassure/output-compact.md') != ''
+        if: github.event_name == 'pull_request' && needs.install-and-doctor.outputs.is_internal == 'true' && hashFiles('.reassure/output-compact.md') != ''
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: reassure
@@ -167,7 +168,7 @@ jobs:
           show_branch: true
           show_class_names: false
           only_changed_files: true
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && needs.install-and-doctor.outputs.is_internal == 'true'
 
   integration-tests:
     name: Integration Tests
@@ -216,18 +217,6 @@ jobs:
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
-  build-android-performance:
-    name: Build Android APK (Performance)
-    needs: install-and-doctor
-    uses: ./.github/workflows/build-app.yml
-    with:
-      platform: android
-      build-profile: perf
-      artifact-name: build-apk-performance
-      app-filename: recipedia-performance.apk
-    secrets:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-
   build-ios:
     name: Build iOS App
     needs: install-and-doctor
@@ -240,14 +229,29 @@ jobs:
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
+  build-android-performance:
+    name: Build Android APK (Performance)
+    # Perf build needs the EAS perf dataset, so it can't use the fork fallback
+    if: needs.install-and-doctor.outputs.is_internal == 'true'
+    needs: install-and-doctor
+    uses: ./.github/workflows/build-app.yml
+    with:
+      platform: android
+      build-profile: perf
+      artifact-name: build-apk-performance
+      app-filename: recipedia-performance.apk
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
   e2e-tests-android:
     name: E2E Tests (Android)
-    needs: build-android
+    needs: [ build-android, install-and-doctor ]
     uses: ./.github/workflows/e2e-maestro.yml
     with:
       platform: android
       app-artifact: build-apk
-      suites: '["app-init", "bulk-import",  "duplicates-ingredient", "duplicates-recipe","duplicates-tag", "ingredient-dialog", "ingredients-db", "menu", "ocr", "recipe-create", "recipe-readonly", "recipe-edit", "search", "settings", "shopping", "tags-db", "web", "web-edge-cases"]'
+      # Forks lack QUITOQUE_*: drop the bulk-import, ocr and web suites
+      suites: ${{ needs.install-and-doctor.outputs.is_internal == 'true' && '["app-init", "bulk-import", "duplicates-ingredient", "duplicates-recipe", "duplicates-tag", "ingredient-dialog", "ingredients-db", "menu", "ocr", "recipe-create", "recipe-readonly", "recipe-edit", "search", "settings", "shopping", "tags-db", "web", "web-edge-cases"]' || '["app-init", "duplicates-ingredient", "duplicates-recipe", "duplicates-tag", "ingredient-dialog", "ingredients-db", "menu", "recipe-create", "recipe-readonly", "recipe-edit", "search", "settings", "shopping", "tags-db", "web-edge-cases"]' }}
     secrets:
       QUITOQUE_USERNAME: ${{ secrets.QUITOQUE_USERNAME }}
       QUITOQUE_PASSWORD: ${{ secrets.QUITOQUE_PASSWORD }}
@@ -267,12 +271,13 @@ jobs:
 
   e2e-tests-ios:
     name: E2E Tests (iOS)
-    needs: build-ios
+    if: needs.install-and-doctor.outputs.is_internal == 'true'
+    needs: [ build-ios, install-and-doctor ]
     uses: ./.github/workflows/e2e-maestro.yml
     with:
       platform: ios
       app-artifact: build-ios-app
-      suites: '["app-init", "bulk-import",  "duplicates-ingredient", "duplicates-recipe","duplicates-tag", "ingredient-dialog", "ingredients-db", "menu", "ocr", "recipe-create", "recipe-readonly", "recipe-edit", "search", "settings", "shopping", "tags-db", "web", "web-edge-cases"]'
+      suites: '["app-init", "bulk-import", "duplicates-ingredient", "duplicates-recipe", "duplicates-tag", "ingredient-dialog", "ingredients-db", "menu", "ocr", "recipe-create", "recipe-readonly", "recipe-edit", "search", "settings", "shopping", "tags-db", "web", "web-edge-cases"]'
     secrets:
       QUITOQUE_USERNAME: ${{ secrets.QUITOQUE_USERNAME }}
       QUITOQUE_PASSWORD: ${{ secrets.QUITOQUE_PASSWORD }}
@@ -324,7 +329,11 @@ jobs:
         if: always()
         run: |
           mkdir -p merged-reports
-          npx jrm merged-reports/report.xml "junit-reports/**/*.xml"
+          if find junit-reports -name '*.xml' -type f 2>/dev/null | grep -q .; then
+            npx jrm merged-reports/report.xml "junit-reports/**/*.xml"
+          else
+            echo "No JUnit reports to merge"
+          fi
 
       - name: Package Android Maestro logs
         if: always()
@@ -351,6 +360,7 @@ jobs:
           name: e2e-junit-merged
           path: merged-reports/report.xml
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Upload Android Maestro logs
         if: always()
@@ -359,6 +369,7 @@ jobs:
           name: maestro-logs-android.zip
           path: maestro-logs-android-merged/
           retention-days: 7
+          if-no-files-found: ignore
 
       - name: Upload iOS Maestro logs
         if: always()
@@ -367,12 +378,14 @@ jobs:
           name: maestro-logs-ios.zip
           path: maestro-logs-ios-merged/
           retention-days: 7
+          if-no-files-found: ignore
 
   test-result-summary:
     name: Generate Test Result Summary
-    if: always()
+    # Posts a PR comment (needs pull-requests: write) which forks can't do
+    if: always() && needs.install-and-doctor.outputs.is_internal == 'true'
     runs-on: ubuntu-latest
-    needs: [ merge-test-artifacts, unit-tests-and-coverage ]
+    needs: [ merge-test-artifacts, unit-tests-and-coverage, install-and-doctor ]
     steps:
       - name: Download unit test results
         if: always()


### PR DESCRIPTION
## Why

GitHub withholds repository secrets from fork-triggered `pull_request` runs (a security feature). So every external fork PR showed multiple RED checks regardless of code quality — EAS builds need `EXPO_TOKEN`, E2E suites need `QUITOQUE_*`, and those jobs can never receive them on a fork. The CI was dishonest and discouraged drive-by contributors.

## What changed

**`build-app.yml` — dual-mode build (token self-detection)**
- `EXPO_TOKEN` present (push / same-repo PRs) → existing EAS signed build, untouched.
- absent (fork PRs) → secret-free local fallback: `expo prebuild` + `gradlew assembleRelease` (debug keystore) / `xcodebuild` simulator (`CODE_SIGNING_ALLOWED=NO`). The fallback injects `EXPO_PUBLIC_DATASET_TYPE=test` to match the EAS `maestro` profile — otherwise a release bundle inlines `NODE_ENV=production` and seeds the **production** dataset, failing E2E for a non-secret reason.

**`build-test.yml` — honest gating**
- Single build jobs run everywhere. An `install-and-doctor` `is_internal` output (push or same-repo PR) is the single source of truth gating secret-dependent work.
- Android E2E runs always: full 18-suite list on trusted runs, a `QUITOQUE`-free 15-suite subset on forks (drops `bulk-import`, `ocr`, `web`).
- Perf build, iOS E2E, and the PR-comment summary stay same-repo only.
- `merge-test-artifacts` runs everywhere and tolerates missing artifacts (forks have no iOS/perf artifacts).

**`merge-maestro-logs.sh`** — exits 0 on empty input; uploads use `if-no-files-found: ignore`.

## Security

No `pull_request_target` — secrets never reach fork-controlled code. Secret-dependent jobs run only in trusted contexts (push / same-repo).

## Branch protection — required-checks follow-up (manual)

Required checks should be only those that can pass on a fork PR:
`Validate Commit Messages`, `ESLint`, `Code Formatting`, `TypeScript Check`, `Expo Configuration Check`, `Documentation Build`, `Unit Tests & Coverage`, `Integration Tests`, `Build Android APK`, `Build iOS App`, `E2E Tests (Android)` (+ `Security Audit`, `Reassure` per preference).

Remove from required (skipped on forks): `Build Android APK (Performance)`, `E2E Tests Android (Performance)`, `E2E Tests (iOS)`, `Generate Test Result Summary`.

## Validation note

The secret-free `gradlew`/`xcodebuild` path can't be exercised locally — first fork PR run validates it. Assumes Expo SDK 55 release buildType uses the debug keystore (template default) and iOS scheme `Recipedia`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)