### PR TITLE
ci(dependabot): skip iOS build/E2E and perf jobs for bumps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -219,6 +219,9 @@ jobs:
 
   build-ios:
     name: Build iOS App
+    # Skipped for dependabot: iOS-only breakage from a dep bump is caught by
+    # build-android; keeps the routine-bump pipeline fast and low-flake.
+    if: github.actor != 'dependabot[bot]'
     needs: install-and-doctor
     uses: ./.github/workflows/build-app.yml
     with:
@@ -231,8 +234,9 @@ jobs:
 
   build-android-performance:
     name: Build Android APK (Performance)
-    # Perf build needs the EAS perf dataset, so it can't use the fork fallback
-    if: needs.install-and-doctor.outputs.is_internal == 'true'
+    # Perf build needs the EAS perf dataset, so it can't use the fork fallback.
+    # Also skipped for dependabot: perf regressions aren't caused by dep bumps.
+    if: needs.install-and-doctor.outputs.is_internal == 'true' && github.actor != 'dependabot[bot]'
     needs: install-and-doctor
     uses: ./.github/workflows/build-app.yml
     with:
@@ -262,7 +266,7 @@ jobs:
   e2e-tests-android-performance:
     name: E2E Tests Android (Performance)
     needs: [ build-android-performance, e2e-tests-android ]
-    if: ${{ always() && needs.build-android-performance.result == 'success' }}
+    if: ${{ always() && needs.build-android-performance.result == 'success' && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/e2e-maestro.yml
     with:
       platform: android
@@ -271,7 +275,8 @@ jobs:
 
   e2e-tests-ios:
     name: E2E Tests (iOS)
-    if: needs.install-and-doctor.outputs.is_internal == 'true'
+    # Skipped for dependabot alongside build-ios (see above).
+    if: needs.install-and-doctor.outputs.is_internal == 'true' && github.actor != 'dependabot[bot]'
     needs: [ build-ios, install-and-doctor ]
     uses: ./.github/workflows/e2e-maestro.yml
     with:


### PR DESCRIPTION
## Summary
- Skip `build-ios`, `e2e-tests-ios`, `build-android-performance`, `e2e-tests-android-performance` for `github.actor == 'dependabot[bot]'`
- Keep `build-android`, `e2e-tests-android`, `reassure-performance` (and all quality.yml jobs) running for every PR, including dependabot

## Why
Dependabot PRs currently run the full pipeline — iOS build, iOS E2E, perf build, perf E2E — despite:
- running secret-starved (Dependabot context withholds repo secrets from `secrets.*`)
- dep bumps rarely breaking iOS-only or perf-only code paths

That made routine bumps slow, flaky, and low-signal to merge.

Android build + Android E2E stay on for dependabot since they're the floor that still exercises the `github-actions`-ecosystem bumps used downstream (`download-artifact`, `delete-artifact` in `merge-test-artifacts`). Reassure stays on too since it's itself a dependabot-tracked dependency (`testing` group) and needs its own bump validated.

## Test plan
- [ ] Confirm a dependabot PR skips `build-ios` / `e2e-tests-ios` / `build-android-performance` / `e2e-tests-android-performance`
- [ ] Confirm a dependabot PR still runs `build-android`, `e2e-tests-android`, `reassure-performance`, and all `quality.yml` jobs
- [ ] Confirm human-authored PRs are unaffected (full pipeline still runs)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>