### PR TITLE
fix: reset purchased items after final cook

### DIFF
--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -1339,6 +1339,9 @@ export class RecipeDatabase {
     if (success) {
       menuItem.isCooked = newCookedStatus;
       this._menu = [...this._menu];
+      if (newCookedStatus && this._menu.every(item => item.isCooked)) {
+        await this.clearPurchasedIngredients();
+      }
       this.notify('menu');
       databaseLogger.debug('Menu item cooked status toggled', {
         menuId,

--- a/tests/integration/MenuAndShoppingPipeline.test.tsx
+++ b/tests/integration/MenuAndShoppingPipeline.test.tsx
@@ -344,6 +344,51 @@ describe('Menu and Shopping Pipeline', () => {
       });
     });
 
+    test('cooking the last remaining menu item clears stale purchased state for the next shopping cycle', async () => {
+      await database.addRecipe(pastaRecipe);
+      const addedRecipe = database.get_recipes()[0];
+
+      const { result } = renderMenuAndShopping();
+
+      await act(async () => {
+        await result.current.menu.addRecipeToMenu(addedRecipe);
+      });
+
+      await waitFor(() => {
+        expect(result.current.shopping.shopping).toHaveLength(3);
+      });
+
+      await act(async () => {
+        await result.current.menu.togglePurchased('Pasta');
+      });
+
+      await waitFor(() => {
+        expect(
+          result.current.shopping.shopping.find(item => item.name === 'Pasta')?.purchased
+        ).toBe(true);
+      });
+
+      const menuId = result.current.menu.menu[0].id!;
+
+      await act(async () => {
+        await result.current.menu.toggleMenuItemCooked(menuId);
+      });
+
+      await waitFor(() => {
+        expect(result.current.shopping.shopping).toHaveLength(0);
+      });
+
+      await act(async () => {
+        await result.current.menu.toggleMenuItemCooked(menuId);
+      });
+
+      await waitFor(() => {
+        expect(
+          result.current.shopping.shopping.find(item => item.name === 'Pasta')?.purchased
+        ).toBe(false);
+      });
+    });
+
     test('only non-cooked recipes in a mixed menu contribute to shopping list', async () => {
       await database.addMultipleRecipes([pastaRecipe, saladRecipe]);
       const recipes = database.get_recipes();

--- a/tests/integration/MenuAndShoppingPipeline.test.tsx
+++ b/tests/integration/MenuAndShoppingPipeline.test.tsx
@@ -346,7 +346,7 @@ describe('Menu and Shopping Pipeline', () => {
 
     test('cooking the last remaining menu item clears stale purchased state for the next shopping cycle', async () => {
       await database.addRecipe(pastaRecipe);
-      const addedRecipe = database.get_recipes()[0];
+      const addedRecipe = database.get_recipes()[0]!;
 
       const { result } = renderMenuAndShopping();
 
@@ -368,7 +368,7 @@ describe('Menu and Shopping Pipeline', () => {
         ).toBe(true);
       });
 
-      const menuId = result.current.menu.menu[0].id!;
+      const menuId = result.current.menu.menu[0]!.id!;
 
       await act(async () => {
         await result.current.menu.toggleMenuItemCooked(menuId);

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -1973,6 +1973,21 @@ describe('RecipeDatabase', () => {
         expect(db.get_menu()[0]!.isCooked).toBe(false);
       });
 
+      test('clears purchased ingredients when the last remaining menu item is marked cooked', async () => {
+        const recipe = db.get_recipes()[0];
+        await db.addRecipeToMenu(recipe);
+        const menuItem = db.get_menu()[0];
+
+        await db.setPurchased(recipe.ingredients[0].name, true);
+        expect(db.get_purchasedIngredients().get(recipe.ingredients[0].name)).toBe(true);
+
+        const result = await db.toggleMenuItemCooked(menuItem.id!);
+
+        expect(result).toBe(true);
+        expect(db.get_menu()[0].isCooked).toBe(true);
+        expect(db.get_purchasedIngredients().size).toBe(0);
+      });
+
       test('returns false for non-existent menu item', async () => {
         const result = await db.toggleMenuItemCooked(99999);
 

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -1974,17 +1974,17 @@ describe('RecipeDatabase', () => {
       });
 
       test('clears purchased ingredients when the last remaining menu item is marked cooked', async () => {
-        const recipe = db.get_recipes()[0];
+        const recipe = db.get_recipes()[0]!;
         await db.addRecipeToMenu(recipe);
-        const menuItem = db.get_menu()[0];
+        const menuItem = db.get_menu()[0]!;
 
-        await db.setPurchased(recipe.ingredients[0].name, true);
-        expect(db.get_purchasedIngredients().get(recipe.ingredients[0].name)).toBe(true);
+        await db.setPurchased(recipe.ingredients[0]!.name, true);
+        expect(db.get_purchasedIngredients().get(recipe.ingredients[0]!.name)).toBe(true);
 
         const result = await db.toggleMenuItemCooked(menuItem.id!);
 
         expect(result).toBe(true);
-        expect(db.get_menu()[0].isCooked).toBe(true);
+        expect(db.get_menu()[0]!.isCooked).toBe(true);
         expect(db.get_purchasedIngredients().size).toBe(0);
       });
 


### PR DESCRIPTION
# PR Draft: Reset purchased state when the shopping session is fully cooked

Target issue: https://github.com/AntoC-dev/Recipedia/issues/305

## Title

fix: reset purchased items after the last menu item is cooked

## Summary

- clear stale purchased-ingredient state when the final uncooked menu item becomes cooked
- keep existing mixed-menu behavior unchanged while uncooked recipes still remain
- add unit and integration regressions covering the next shopping cycle

## Why

Issue `#305` groups several UI bugs; this patch takes the shopping-list reset subcase.

Today, marking the last remaining menu item as cooked empties the computed shopping list, but the persisted purchased map is left behind. That stale purchase state leaks into the next shopping cycle, so re-added ingredients can appear pre-checked even though the previous list was already completed.

This patch treats "all menu items are cooked" as the end of the current shopping session and clears purchased state at that boundary.

## Verification

```bash
npx jest --config jest.config.js --runTestsByPath tests/integration/MenuAndShoppingPipeline.test.tsx tests/unit/utils/RecipeDatabase.test.tsx
git diff --check
```

Observed:

- `jest`: `2 passed` suites, `175 passed` tests
- `git diff --check`: pass

## Scope Notes

- This patch only touches shopping-session reset behavior when the final uncooked menu item becomes cooked.
- It does not change unrelated issue `#305` items such as dropdown positioning, tutorial overlay width, or translation copy.
