### PR TITLE
feat(bulk-import): dismiss recipes from discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,7 @@ Key points:
 | `MenuTable` | `menuTableElement` | User's weekly cooking menu |
 | `PurchasedIngredientsTable` | `purchasedIngredientElement` | Purchase state for shopping list items |
 | `ImportHistoryTable` | `importHistoryTableElement` | Records of previously discovered bulk-import recipes |
+| `DismissedRecipesTable` | `dismissedRecipeTableElement` | Recipes permanently dismissed from bulk-import discovery |
 
 All table and column name constants live in `src/customTypes/DatabaseElementTypes.tsx`.
 
@@ -146,7 +147,7 @@ Hooks that subscribe to `RecipeDatabase` slices:
 | `useTags` | `tags` | Tag CRUD and random tag suggestions |
 | `useMenu` | `menu`, `purchased` | Menu management and purchase state |
 | `useShopping` | `menu`, `purchased` | Derived shopping list (read-only, no mutations) |
-| `useImportHistory` | — | Import history records |
+| `useImportHistory` | — | Import history and dismissed-recipe records |
 
 ---
 

--- a/src/assets/Icons.tsx
+++ b/src/assets/Icons.tsx
@@ -60,6 +60,8 @@ export const Icons: Record<string, dictionaryIcons> = {
   commentEditOutline: 'comment-edit-outline',
   bug: 'bug',
   history: 'history',
+  eyeOff: 'eye-off-outline',
+  restore: 'restore',
   undo: 'undo',
   import: 'import',
   copy: 'content-copy',

--- a/src/components/molecules/DismissedRecipeCard.tsx
+++ b/src/components/molecules/DismissedRecipeCard.tsx
@@ -1,0 +1,99 @@
+/**
+ * DismissedRecipeCard - Settings card for a permanently dismissed bulk-import recipe
+ *
+ * Displays a dismissed recipe's title with a Restore action that brings it back
+ * into future discovery runs. Rendered inside the per-provider accordions of the
+ * DismissedRecipesSettings screen, so the source provider is shown by the
+ * accordion header rather than the card itself.
+ *
+ * @example
+ * ```typescript
+ * <DismissedRecipeCard
+ *   testIdPrefix="DismissedRecipesSettings::hellofresh::0"
+ *   recipe={{ providerId: 'hellofresh', recipeUrl: 'https://...', title: 'Tikka', dismissedAt: 0 }}
+ *   onRestore={() => restore(recipe)}
+ * />
+ * ```
+ */
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Button, Card, Text } from 'react-native-paper';
+import { ImageThumbnail } from '@components/molecules/ImageThumbnail';
+import { padding, radius } from '@styles/spacing';
+import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { Icons } from '@assets/Icons';
+import { useI18n } from '@utils/i18n';
+
+const THUMBNAIL_SIZE = 64;
+
+/**
+ * Props for the DismissedRecipeCard component
+ */
+export type DismissedRecipeCardProps = {
+  /** Prefix for test ID construction */
+  testIdPrefix: string;
+  /** Dismissed recipe record to display */
+  recipe: dismissedRecipeTableElement;
+  /** Callback invoked when the recipe is restored */
+  onRestore: () => void;
+};
+
+/**
+ * DismissedRecipeCard component for the dismissed recipes management list
+ *
+ * @param props - The component props
+ * @returns JSX element representing a dismissed recipe card with a restore action
+ */
+export function DismissedRecipeCard({ testIdPrefix, recipe, onRestore }: DismissedRecipeCardProps) {
+  const { t } = useI18n();
+
+  return (
+    <Card style={styles.card}>
+      <Card.Content style={styles.content}>
+        <ImageThumbnail
+          uri={recipe.imageUrl || undefined}
+          size={THUMBNAIL_SIZE}
+          borderRadius={radius.small}
+          testID={testIdPrefix + '::Thumbnail'}
+        />
+        <Text
+          variant='titleMedium'
+          numberOfLines={2}
+          style={styles.title}
+          testID={testIdPrefix + '::Title'}
+        >
+          {recipe.title}
+        </Text>
+      </Card.Content>
+      <Card.Actions>
+        <Button
+          mode='contained-tonal'
+          icon={Icons.restore}
+          onPress={onRestore}
+          testID={testIdPrefix + '::RestoreButton'}
+        >
+          {t('bulkImport.dismissed.restore')}
+        </Button>
+      </Card.Actions>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: padding.small,
+    marginHorizontal: padding.medium,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    flex: 1,
+    marginLeft: padding.medium,
+    fontWeight: 'bold',
+  },
+});
+
+export default DismissedRecipeCard;

--- a/src/components/molecules/RecipeSelectionCard.tsx
+++ b/src/components/molecules/RecipeSelectionCard.tsx
@@ -3,13 +3,15 @@
  *
  * A card component used in the bulk import discovery screen that displays
  * a discovered recipe with a thumbnail, title, and selection checkbox.
- * Supports toggling selection state via tap on the card or checkbox.
+ * Supports toggling selection state via tap on the card or checkbox, and
+ * flagging a recipe to be permanently hidden from future discovery runs.
  *
  * Key Features:
  * - Recipe thumbnail with fallback handling
  * - Selection state with visual feedback (background color change)
  * - Checkbox for clear selection indication
- * - Separate callbacks for select/unselect actions
+ * - "Never show again" action, with an in-place dimmed/struck state and an
+ *   Undo affordance until the user confirms with Continue
  *
  * @example
  * ```typescript
@@ -17,19 +19,27 @@
  *   testId="Recipe::0"
  *   recipe={{ url: 'https://...', title: 'Chicken Tikka', imageUrl: '...' }}
  *   isSelected={false}
+ *   isDismissed={false}
  *   onSelected={() => addToSelection(recipe.url)}
  *   onUnselected={() => removeFromSelection(recipe.url)}
+ *   onDismiss={() => flagHidden(recipe.url)}
+ *   onRestore={() => unflagHidden(recipe.url)}
  * />
  * ```
  */
 
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Card, Checkbox, Text, useTheme } from 'react-native-paper';
-import { ImageThumbnail } from '@components/molecules/ImageThumbnail';
-import { padding } from '@styles/spacing';
+import { Button, Card, Checkbox, Icon, Text, useTheme } from 'react-native-paper';
+import { CustomImage } from '@components/atomic/CustomImage';
+import { padding, radius } from '@styles/spacing';
 import { DiscoveredRecipe } from '@customTypes/BulkImportTypes';
 import { Icons } from '@assets/Icons';
+import { useI18n } from '@utils/i18n';
+
+const ROW_MIN_HEIGHT = 112;
+const THUMBNAIL_WIDTH = 96;
+const SEEN_ICON_SIZE = 16;
 
 /**
  * Props for the RecipeSelectionCard component
@@ -41,18 +51,25 @@ export type RecipeSelectionCardProps = {
   recipe: DiscoveredRecipe;
   /** Whether the recipe is currently selected */
   isSelected: boolean;
+  /** Whether the recipe is flagged to be hidden (pending until Continue) */
+  isDismissed: boolean;
   /** Callback invoked when the recipe is selected */
   onSelected: () => void;
   /** Callback invoked when the recipe is unselected */
   onUnselected: () => void;
+  /** Callback invoked when the recipe is flagged to be hidden */
+  onDismiss: () => void;
+  /** Callback invoked when a pending dismissal is undone */
+  onRestore: () => void;
 };
 
 /**
  * RecipeSelectionCard component for recipe selection during bulk import
  *
  * Renders a selectable card with recipe thumbnail, title, and checkbox.
- * The card background changes color to indicate selection state.
- * Shows a "Previously seen" indicator for recipes that were discovered before.
+ * The card background changes color to indicate selection state, shows a
+ * "Previously seen" indicator for recipes discovered before, and dims with a
+ * strikethrough title while flagged to be hidden.
  *
  * @param props - The component props
  * @returns JSX element representing the selectable recipe card
@@ -61,14 +78,21 @@ export function RecipeSelectionCard({
   testId,
   recipe,
   isSelected,
+  isDismissed,
   onSelected,
   onUnselected,
+  onDismiss,
+  onRestore,
 }: RecipeSelectionCardProps) {
   const { colors } = useTheme();
+  const { t } = useI18n();
 
   const isPreviouslySeen = recipe.memoryStatus === 'seen';
 
   const handlePress = () => {
+    if (isDismissed) {
+      return;
+    }
     if (isSelected) {
       onUnselected();
     } else {
@@ -77,6 +101,9 @@ export function RecipeSelectionCard({
   };
 
   const getBackgroundColor = () => {
+    if (isDismissed) {
+      return colors.surfaceVariant;
+    }
     if (isSelected) {
       return colors.secondaryContainer;
     }
@@ -94,33 +121,68 @@ export function RecipeSelectionCard({
       style={[styles.card, { backgroundColor: getBackgroundColor() }]}
       onPress={handlePress}
     >
-      <View style={styles.content}>
-        <Checkbox
-          status={isSelected ? 'checked' : 'unchecked'}
-          onPress={handlePress}
-          testID={testId + '::Checkbox'}
-        />
-
-        <View style={styles.thumbnailWrapper}>
-          <ImageThumbnail
-            uri={recipe.imageUrl}
-            size={60}
-            borderRadius={8}
-            testID={testId + '::Thumbnail'}
-            icon={isPreviouslySeen ? Icons.history : undefined}
+      <View style={styles.row}>
+        <View style={[styles.checkboxColumn, isDismissed && styles.dimmed]}>
+          <Checkbox
+            status={isSelected ? 'checked' : 'unchecked'}
+            onPress={handlePress}
+            disabled={isDismissed}
+            testID={testId + '::Checkbox'}
           />
         </View>
 
-        <View style={styles.textContainer}>
-          <View style={styles.titleRow}>
-            <Text
-              variant='titleMedium'
-              numberOfLines={2}
-              testID={testId + '::Title'}
-              style={isPreviouslySeen && styles.titleWithIcon}
+        <View style={[styles.imageColumn, isDismissed && styles.dimmed]}>
+          <CustomImage
+            uri={recipe.imageUrl}
+            contentFit='cover'
+            borderRadius={radius.medium}
+            testID={testId + '::Thumbnail'}
+          />
+          {isPreviouslySeen && (
+            <View
+              style={[styles.seenBadge, { backgroundColor: colors.surfaceVariant }]}
+              testID={testId + '::SeenIndicator'}
             >
-              {recipe.title}
-            </Text>
+              <Icon source={Icons.history} size={SEEN_ICON_SIZE} color={colors.onSurfaceVariant} />
+            </View>
+          )}
+        </View>
+
+        <View style={styles.textColumn}>
+          <Text
+            variant='titleMedium'
+            numberOfLines={3}
+            testID={testId + '::Title'}
+            style={isDismissed && styles.dismissedTitle}
+          >
+            {recipe.title}
+          </Text>
+
+          <View style={styles.actionRow}>
+            {isDismissed ? (
+              <Button
+                mode='text'
+                compact
+                icon={Icons.undo}
+                onPress={onRestore}
+                accessibilityLabel={t('bulkImport.selection.restoreAccessibility')}
+                testID={testId + '::RestoreButton'}
+              >
+                {t('bulkImport.selection.undo')}
+              </Button>
+            ) : (
+              <Button
+                mode='text'
+                compact
+                icon={Icons.eyeOff}
+                onPress={onDismiss}
+                textColor={colors.onSurfaceVariant}
+                accessibilityLabel={t('bulkImport.selection.dismissAccessibility')}
+                testID={testId + '::DismissButton'}
+              >
+                {t('bulkImport.selection.dismiss')}
+              </Button>
+            )}
           </View>
         </View>
       </View>
@@ -133,25 +195,42 @@ const styles = StyleSheet.create({
     marginVertical: padding.small,
     marginHorizontal: padding.medium,
   },
-  content: {
+  row: {
     flexDirection: 'row',
-    alignItems: 'center',
-    padding: padding.small,
+    alignItems: 'stretch',
+    minHeight: ROW_MIN_HEIGHT,
+    paddingVertical: padding.small,
+    paddingLeft: padding.verySmall,
   },
-  thumbnailWrapper: {
+  checkboxColumn: {
+    justifyContent: 'center',
+  },
+  imageColumn: {
+    width: THUMBNAIL_WIDTH,
     marginHorizontal: padding.small,
   },
-  textContainer: {
-    flex: 1,
-    paddingRight: padding.small,
+  seenBadge: {
+    position: 'absolute',
+    top: padding.verySmall,
+    right: padding.verySmall,
+    borderRadius: radius.full,
+    padding: padding.verySmall,
   },
-  titleRow: {
+  textColumn: {
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingRight: padding.medium,
+  },
+  dismissedTitle: {
+    textDecorationLine: 'line-through',
+    opacity: 0.6,
+  },
+  dimmed: {
+    opacity: 0.4,
+  },
+  actionRow: {
     flexDirection: 'row',
-    alignItems: 'flex-start',
-  },
-  titleWithIcon: {
-    flex: 1,
-    marginLeft: padding.verySmall,
+    justifyContent: 'flex-end',
   },
 });
 

--- a/src/components/organisms/AppBar.tsx
+++ b/src/components/organisms/AppBar.tsx
@@ -11,7 +11,6 @@ export type AppBarProps = {
   onValidate?: () => Promise<void>;
   onDelete?: () => void;
   onEdit?: () => void;
-  onDismissedList?: () => void;
 };
 
 export function AppBar({
@@ -23,7 +22,6 @@ export function AppBar({
   onValidate,
   onDelete,
   onEdit,
-  onDismissedList,
 }: AppBarProps) {
   const { colors } = useTheme();
 

--- a/src/customTypes/BulkImportTypes.tsx
+++ b/src/customTypes/BulkImportTypes.tsx
@@ -141,8 +141,9 @@ export interface ParsingProgress {
  * - 'fresh': Recipe has never been seen before
  * - 'seen': Recipe was discovered but not imported in a previous session
  * - 'imported': Recipe has been successfully imported (should be hidden)
+ * - 'dismissed': Recipe was permanently dismissed by the user (should be hidden)
  */
-export type ImportMemoryStatus = 'fresh' | 'seen' | 'imported';
+export type ImportMemoryStatus = 'fresh' | 'seen' | 'imported' | 'dismissed';
 
 /**
  * Lightweight recipe data discovered during URL scanning

--- a/src/customTypes/DatabaseElementTypes.tsx
+++ b/src/customTypes/DatabaseElementTypes.tsx
@@ -313,6 +313,53 @@ export const importHistoryColumnsEncoding: databaseColumnType[] = [
   { colName: importHistoryColumnsNames.lastSeenAt, type: encodedType.INTEGER },
 ];
 
+/** Dismissed recipes table name for permanently hidden bulk-import recipes */
+export const dismissedRecipesTableName = 'DismissedRecipesTable';
+
+/**
+ * Dismissed recipe record for recipes the user chose to never see again.
+ * Filtered out of every future bulk-import discovery run for the provider.
+ */
+export type dismissedRecipeTableElement = {
+  /** Optional database ID (undefined for new records) */
+  id?: number;
+  /** Provider identifier (e.g., 'hellofresh') */
+  providerId: string;
+  /** Full recipe URL from the provider */
+  recipeUrl: string;
+  /** Recipe title (denormalized so the manage list needs no re-discovery) */
+  title: string;
+  /** Recipe thumbnail URL (empty string when unavailable) */
+  imageUrl: string;
+  /** Timestamp when the recipe was dismissed (Unix ms) */
+  dismissedAt: number;
+};
+
+export type encodedDismissedRecipeElement = {
+  ID: number;
+  PROVIDER_ID: string;
+  RECIPE_URL: string;
+  TITLE: string;
+  IMAGE_URL: string;
+  DISMISSED_AT: number;
+};
+
+export enum dismissedRecipesColumnsNames {
+  providerId = 'PROVIDER_ID',
+  recipeUrl = 'RECIPE_URL',
+  title = 'TITLE',
+  imageUrl = 'IMAGE_URL',
+  dismissedAt = 'DISMISSED_AT',
+}
+
+export const dismissedRecipesColumnsEncoding: databaseColumnType[] = [
+  { colName: dismissedRecipesColumnsNames.providerId, type: encodedType.TEXT },
+  { colName: dismissedRecipesColumnsNames.recipeUrl, type: encodedType.TEXT },
+  { colName: dismissedRecipesColumnsNames.title, type: encodedType.TEXT },
+  { colName: dismissedRecipesColumnsNames.imageUrl, type: encodedType.TEXT },
+  { colName: dismissedRecipesColumnsNames.dismissedAt, type: encodedType.INTEGER },
+];
+
 /** Menu table name for tracking recipes in the weekly menu */
 export const menuTableName = 'MenuTable';
 

--- a/src/customTypes/ScreenTypes.tsx
+++ b/src/customTypes/ScreenTypes.tsx
@@ -99,6 +99,8 @@ export type StackScreenParamList = {
   TagsSettings: undefined;
   /** Bulk import provider selection screen (no parameters) */
   BulkImportSettings: undefined;
+  /** Dismissed bulk-import recipes management screen (all providers) */
+  DismissedRecipesSettings: undefined;
   /** Bulk import discovery screen with provider ID */
   BulkImportDiscovery: { providerId: string };
   /** Bulk import validation screen with selected recipes */
@@ -178,3 +180,9 @@ export type TagsSettingsProp = NativeStackScreenProps<StackScreenParamList, 'Tag
 
 /** Props for Bug Report stack screen component */
 export type BugReportScreenProp = NativeStackScreenProps<StackScreenParamList, 'BugReport'>;
+
+/** Props for Dismissed Recipes Settings stack screen component */
+export type DismissedRecipesSettingsProp = NativeStackScreenProps<
+  StackScreenParamList,
+  'DismissedRecipesSettings'
+>;

--- a/src/hooks/useDiscoveryWorkflow.ts
+++ b/src/hooks/useDiscoveryWorkflow.ts
@@ -39,12 +39,16 @@ export interface UseDiscoveryWorkflowReturn {
   parsingProgress: ParsingProgress | null;
   error: string | null;
   isSelected: (url: string) => boolean;
+  isDismissed: (url: string) => boolean;
   selectRecipe: (url: string) => void;
   unselectRecipe: (url: string) => void;
   toggleSelectAll: () => void;
   parseSelectedRecipes: () => Promise<ConvertedImportRecipe[] | null>;
   abort: () => void;
   markUrlsAsSeen: () => Promise<void>;
+  dismissRecipe: (recipe: DiscoveredRecipe) => void;
+  restoreRecipe: (recipe: DiscoveredRecipe) => void;
+  commitDismissals: () => Promise<void>;
 }
 
 /**
@@ -72,11 +76,14 @@ export function useDiscoveryWorkflow(
   const { t } = useI18n();
   const { parseSelectedRecipes: parseSelectedRecipesViaScraper } = useRecipeScraper();
   const { processDiscoveredRecipes } = useImportMemory(providerId);
-  const { markUrlsAsSeen } = useImportHistory();
+  const { markUrlsAsSeen, markRecipesAsDismissed } = useImportHistory();
 
   const [phase, setPhase] = useState<DiscoveryPhase>(provider ? 'discovering' : 'selecting');
   const [recipes, setRecipes] = useState<DiscoveredRecipe[]>([]);
   const [selectedUrls, setSelectedUrls] = useState<Set<string>>(new Set());
+  const [pendingDismissed, setPendingDismissed] = useState<Map<string, DiscoveredRecipe>>(
+    new Map()
+  );
   const [discoveryProgress, setDiscoveryProgress] = useState<DiscoveryProgress | null>(null);
   const [parsingProgress, setParsingProgress] = useState<ParsingProgress | null>(null);
   const [error, setError] = useState<string | null>(() =>
@@ -153,6 +160,17 @@ export function useDiscoveryWorkflow(
   const isSelected = (url: string) => selectedUrls.has(url);
 
   /**
+   * Checks if a recipe is pending dismissal for this session.
+   *
+   * Pending-dismissed recipes stay visible in the list (styled as hidden) until
+   * the user presses Continue, at which point the dismissals are persisted.
+   *
+   * @param url - The recipe URL to check
+   * @returns True if the recipe is pending dismissal
+   */
+  const isDismissed = (url: string) => pendingDismissed.has(url);
+
+  /**
    * Adds a recipe to the selection
    *
    * @param url - The URL of the recipe to select
@@ -181,11 +199,13 @@ export function useDiscoveryWorkflow(
    * Otherwise, selects all visible recipes (excluding hidden imported ones).
    */
   const toggleSelectAll = () => {
-    const visibleRecipes = processDiscoveredRecipes(recipes, true);
-    if (selectedUrls.size === visibleRecipes.length) {
+    const selectableUrls = [...freshRecipes, ...seenRecipes]
+      .map(r => r.url)
+      .filter(url => !pendingDismissed.has(url));
+    if (selectedUrls.size === selectableUrls.length) {
       setSelectedUrls(new Set());
     } else {
-      setSelectedUrls(new Set(visibleRecipes.map(r => r.url)));
+      setSelectedUrls(new Set(selectableUrls));
     }
   };
 
@@ -274,16 +294,57 @@ export function useDiscoveryWorkflow(
 
   const freshRecipes = processedRecipes.filter(r => r.memoryStatus === 'fresh');
   const seenRecipes = processedRecipes.filter(r => r.memoryStatus === 'seen');
-  const totalVisibleCount = freshRecipes.length + seenRecipes.length;
+  const selectableCount = freshRecipes.length + seenRecipes.length - pendingDismissed.size;
 
   const selectedCount = selectedUrls.size;
-  const allSelected = selectedCount === totalVisibleCount && totalVisibleCount > 0;
+  const allSelected = selectedCount === selectableCount && selectableCount > 0;
   const isDiscovering = phase === 'discovering';
   const showSelectionUI = isDiscovering || phase === 'selecting';
 
   const markDiscoveredUrlsAsSeen = async () => {
     const urls = recipes.map(r => r.url);
     await markUrlsAsSeen(providerId, urls);
+  };
+
+  /**
+   * Marks a discovered recipe as pending dismissal for this session.
+   *
+   * The recipe stays visible (styled as hidden) and is removed from the
+   * selection, but nothing is persisted until {@link commitDismissals} runs on
+   * Continue. This lets the user change their mind beforehand.
+   *
+   * @param recipe - The recipe to dismiss
+   */
+  const dismissRecipe = (recipe: DiscoveredRecipe) => {
+    setPendingDismissed(prev => new Map(prev).set(recipe.url, recipe));
+    unselectRecipe(recipe.url);
+  };
+
+  /**
+   * Cancels a pending dismissal, restoring the recipe to a normal state.
+   *
+   * @param recipe - The recipe to restore
+   */
+  const restoreRecipe = (recipe: DiscoveredRecipe) => {
+    setPendingDismissed(prev => {
+      const next = new Map(prev);
+      next.delete(recipe.url);
+      return next;
+    });
+  };
+
+  /**
+   * Persists every pending dismissal so the recipes are hidden from all future
+   * discovery runs. Called when the user confirms with Continue.
+   */
+  const commitDismissals = async () => {
+    if (pendingDismissed.size === 0) return;
+    const dismissed = Array.from(pendingDismissed.values()).map(r => ({
+      url: r.url,
+      title: r.title,
+      imageUrl: imageMap.get(r.url) ?? r.imageUrl,
+    }));
+    await markRecipesAsDismissed(providerId, dismissed);
   };
 
   return {
@@ -300,11 +361,15 @@ export function useDiscoveryWorkflow(
     parsingProgress,
     error,
     isSelected,
+    isDismissed,
     selectRecipe,
     unselectRecipe,
     toggleSelectAll,
     parseSelectedRecipes,
     abort,
     markUrlsAsSeen: markDiscoveredUrlsAsSeen,
+    dismissRecipe,
+    restoreRecipe,
+    commitDismissals,
   };
 }

--- a/src/hooks/useImportHistory.ts
+++ b/src/hooks/useImportHistory.ts
@@ -9,6 +9,7 @@
  */
 
 import { RecipeDatabase } from '@utils/RecipeDatabase';
+import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
 
 /**
  * Provides imperative access to bulk import URL history.
@@ -18,7 +19,8 @@ import { RecipeDatabase } from '@utils/RecipeDatabase';
  * history changes.
  *
  * @returns Object containing `getImportedSourceUrls`, `getSeenUrls`,
- *   `markUrlsAsSeen` and `removeFromSeenHistory`
+ *   `markUrlsAsSeen`, `removeFromSeenHistory`, `getDismissedUrls`,
+ *   `getDismissedRecipes`, `markRecipesAsDismissed` and `restoreDismissedRecipes`
  */
 export function useImportHistory() {
   const db = RecipeDatabase.getInstance();
@@ -39,10 +41,33 @@ export function useImportHistory() {
     await db.removeFromSeenHistory(providerId, urls);
   };
 
+  const getDismissedUrls = (providerId: string): Set<string> => {
+    return db.getDismissedUrls(providerId);
+  };
+
+  const getDismissedRecipes = (providerId?: string): dismissedRecipeTableElement[] => {
+    return db.getDismissedRecipes(providerId);
+  };
+
+  const markRecipesAsDismissed = async (
+    providerId: string,
+    recipes: { url: string; title: string; imageUrl?: string }[]
+  ): Promise<void> => {
+    await db.markRecipesAsDismissed(providerId, recipes);
+  };
+
+  const restoreDismissedRecipes = async (providerId: string, urls: string[]): Promise<void> => {
+    await db.restoreDismissedRecipes(providerId, urls);
+  };
+
   return {
     getImportedSourceUrls,
     getSeenUrls,
     markUrlsAsSeen,
     removeFromSeenHistory,
+    getDismissedUrls,
+    getDismissedRecipes,
+    markRecipesAsDismissed,
+    restoreDismissedRecipes,
   };
 }

--- a/src/hooks/useImportMemory.ts
+++ b/src/hooks/useImportMemory.ts
@@ -32,12 +32,14 @@ export interface UseImportMemoryReturn {
  * @returns Import memory state and management functions
  */
 export function useImportMemory(providerId: string): UseImportMemoryReturn {
-  const { getImportedSourceUrls, getSeenUrls } = useImportHistory();
+  const { getImportedSourceUrls, getSeenUrls, getDismissedUrls } = useImportHistory();
 
   const importedUrls = getImportedSourceUrls(providerId);
   const seenUrls = getSeenUrls(providerId);
+  const dismissedUrls = getDismissedUrls(providerId);
 
   const getMemoryStatus = (url: string): ImportMemoryStatus => {
+    if (dismissedUrls.has(url)) return 'dismissed';
     if (importedUrls.has(url)) return 'imported';
     if (seenUrls.has(url)) return 'seen';
     return 'fresh';
@@ -52,6 +54,7 @@ export function useImportMemory(providerId: string): UseImportMemoryReturn {
         ...recipe,
         memoryStatus: getMemoryStatus(recipe.url),
       }))
+      .filter(recipe => recipe.memoryStatus !== 'dismissed')
       .filter(recipe => !hideImported || recipe.memoryStatus !== 'imported');
   };
 

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -66,6 +66,7 @@ import { DefaultPersonsSettings } from '@screens/DefaultPersonsSettings';
 import { IngredientsSettings } from '@screens/IngredientsSettings';
 import { TagsSettings } from '@screens/TagsSettings';
 import { BulkImportSettings } from '@screens/BulkImportSettings';
+import { DismissedRecipesSettings } from '@screens/DismissedRecipesSettings';
 import { BulkImportDiscovery } from '@screens/BulkImportDiscovery';
 import { BulkImportValidation } from '@screens/BulkImportValidation';
 import { BugReport } from '@screens/BugReport';
@@ -107,6 +108,7 @@ export function RootNavigator() {
       <Stack.Screen name='IngredientsSettings' component={IngredientsSettings} />
       <Stack.Screen name='TagsSettings' component={TagsSettings} />
       <Stack.Screen name='BulkImportSettings' component={BulkImportSettings} />
+      <Stack.Screen name='DismissedRecipesSettings' component={DismissedRecipesSettings} />
       <Stack.Screen name='BulkImportDiscovery' component={BulkImportDiscovery} />
       <Stack.Screen name='BulkImportValidation' component={BulkImportValidation} />
       <Stack.Screen name='BugReport' component={BugReport} />

--- a/src/screens/BulkImportDiscovery.tsx
+++ b/src/screens/BulkImportDiscovery.tsx
@@ -96,12 +96,16 @@ export function BulkImportDiscovery() {
     parsingProgress,
     error,
     isSelected,
+    isDismissed,
     selectRecipe,
     unselectRecipe,
     toggleSelectAll,
     parseSelectedRecipes,
     abort,
     markUrlsAsSeen,
+    dismissRecipe,
+    restoreRecipe,
+    commitDismissals,
   } = useDiscoveryWorkflow(provider, providerId);
 
   const { imageMap } = useVisibleImageLoader({
@@ -168,22 +172,26 @@ export function BulkImportDiscovery() {
         testId={`${screenId}::${item.key}`}
         recipe={item.recipe}
         isSelected={isSelected(item.recipe.url)}
+        isDismissed={isDismissed(item.recipe.url)}
         onSelected={() => selectRecipe(item.recipe.url)}
         onUnselected={() => unselectRecipe(item.recipe.url)}
+        onDismiss={() => dismissRecipe(item.recipe)}
+        onRestore={() => restoreRecipe(item.recipe)}
       />
     );
   };
 
   /**
    * Handles the continue action after recipe selection.
-   * Aborts discovery if still running, marks discovered URLs as seen,
-   * parses selected recipes, and navigates to the validation screen if successful.
+   * Aborts discovery if still running, persists any pending dismissals, marks
+   * discovered URLs as seen, parses selected recipes, and navigates to the
+   * validation screen if successful.
    */
   const handleContinue = async () => {
     if (isDiscovering) {
       abort();
     }
-    await markUrlsAsSeen();
+    await Promise.all([commitDismissals(), markUrlsAsSeen()]);
     const convertedRecipes = await parseSelectedRecipes();
     if (convertedRecipes) {
       navigation.navigate('BulkImportValidation', {

--- a/src/screens/DismissedRecipesSettings.tsx
+++ b/src/screens/DismissedRecipesSettings.tsx
@@ -1,0 +1,139 @@
+/**
+ * DismissedRecipesSettings - Management screen for dismissed bulk-import recipes
+ *
+ * Lists every recipe the user permanently dismissed, grouped by source provider
+ * in collapsible accordions, and lets them restore any of them back into future
+ * discovery runs. Reached from the "Bulk Import Recipes" section of the
+ * Parameters screen, alongside the ingredient and tag management screens.
+ *
+ * @example
+ * ```typescript
+ * navigation.navigate('DismissedRecipesSettings');
+ * ```
+ */
+
+import React, { useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScreenWrapper } from '@components/templates/ScreenWrapper';
+import { List, Text } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import { StackScreenNavigation } from '@customTypes/ScreenTypes';
+import { AppBar } from '@components/organisms/AppBar';
+import { DismissedRecipeCard } from '@components/molecules/DismissedRecipeCard';
+import { ProviderLogo } from '@components/molecules/ProviderLogo';
+import { useImportHistory } from '@hooks/useImportHistory';
+import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { groupDismissedRecipesByProvider } from '@utils/BulkImportUtils';
+import { getProvider } from '@providers/ProviderRegistry';
+import { useI18n } from '@utils/i18n';
+import { padding } from '@styles/spacing';
+
+const screenId = 'DismissedRecipesSettings';
+
+/**
+ * DismissedRecipesSettings screen component
+ *
+ * @returns JSX element representing the dismissed recipes management screen
+ */
+export function DismissedRecipesSettings() {
+  const { t } = useI18n();
+  const navigation = useNavigation<StackScreenNavigation>();
+
+  const { getDismissedRecipes, restoreDismissedRecipes } = useImportHistory();
+  const [recipes, setRecipes] = useState<dismissedRecipeTableElement[]>(() =>
+    getDismissedRecipes()
+  );
+
+  const groups = useMemo(
+    () =>
+      groupDismissedRecipesByProvider(
+        recipes,
+        providerId => getProvider(providerId)?.name ?? providerId
+      ),
+    [recipes]
+  );
+
+  const handleRestore = async (recipe: dismissedRecipeTableElement) => {
+    await restoreDismissedRecipes(recipe.providerId, [recipe.recipeUrl]);
+    setRecipes(prev => prev.filter(r => r.recipeUrl !== recipe.recipeUrl));
+  };
+
+  return (
+    <ScreenWrapper>
+      <AppBar
+        title={t('bulkImport.dismissed.title')}
+        onGoBack={() => navigation.goBack()}
+        testID={screenId}
+      />
+
+      {groups.length > 0 ? (
+        <ScrollView contentContainerStyle={styles.listContent}>
+          <List.AccordionGroup>
+            {groups.map(group => {
+              const groupId = `${screenId}::${group.providerId}`;
+              return (
+                <List.Accordion
+                  key={group.providerId}
+                  id={group.providerId}
+                  title={group.providerName}
+                  description={
+                    group.recipes.length === 1
+                      ? t('bulkImport.dismissed.count', { count: 1 })
+                      : t('bulkImport.dismissed.countPlural', { count: group.recipes.length })
+                  }
+                  left={() => (
+                    <ProviderLogo
+                      logoUrl={getProvider(group.providerId)?.logoUrl ?? ''}
+                      size={32}
+                      testID={groupId + '::Logo'}
+                    />
+                  )}
+                  testID={groupId}
+                >
+                  {group.recipes.map((recipe, index) => (
+                    <DismissedRecipeCard
+                      key={recipe.recipeUrl}
+                      testIdPrefix={`${groupId}::${index}`}
+                      recipe={recipe}
+                      onRestore={() => handleRestore(recipe)}
+                    />
+                  ))}
+                </List.Accordion>
+              );
+            })}
+          </List.AccordionGroup>
+        </ScrollView>
+      ) : (
+        <View style={styles.emptyState}>
+          <Text variant='titleMedium' style={styles.emptyTitle} testID={screenId + '::Empty'}>
+            {t('bulkImport.dismissed.empty')}
+          </Text>
+          <Text variant='bodyMedium' style={styles.emptyText}>
+            {t('bulkImport.dismissed.emptyDescription')}
+          </Text>
+        </View>
+      )}
+    </ScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingVertical: padding.small,
+  },
+  emptyState: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: padding.large,
+  },
+  emptyTitle: {
+    textAlign: 'center',
+    marginBottom: padding.small,
+  },
+  emptyText: {
+    textAlign: 'center',
+  },
+});
+
+export default DismissedRecipesSettings;

--- a/src/screens/Parameters.tsx
+++ b/src/screens/Parameters.tsx
@@ -130,6 +130,7 @@ export function Parameters() {
 
   const importId = sectionId + '::Import';
   const importFromWebsiteId = importId + '::FromWebsite';
+  const dismissedRecipesId = importId + '::DismissedRecipes';
 
   const aboutId = sectionId + '::About';
   const versionId = aboutId + '::Version';
@@ -244,6 +245,17 @@ export function Parameters() {
             right={props => <List.Icon {...props} icon={Icons.chevronRight} />}
             onPress={() => {
               navigate('BulkImportSettings');
+            }}
+          />
+          <Divider testID={importId + '::Divider'} />
+          <List.Item
+            testID={dismissedRecipesId + '::Item'}
+            title={t('bulkImport.dismissed.title')}
+            description={t('bulkImport.dismissed.manage')}
+            left={props => <List.Icon {...props} icon={Icons.eyeOff} />}
+            right={props => <List.Icon {...props} icon={Icons.chevronRight} />}
+            onPress={() => {
+              navigate('DismissedRecipesSettings');
             }}
           />
         </List.Section>

--- a/src/styles/spacing.tsx
+++ b/src/styles/spacing.tsx
@@ -105,6 +105,19 @@ export const padding = {
 };
 
 /**
+ * Border-radius scale for consistent rounded corners throughout the app
+ * All values are in pixels
+ */
+export const radius = {
+  /** Subtle rounding for small thumbnails */
+  small: 8,
+  /** Standard rounding for cards and images */
+  medium: 12,
+  /** Fully rounded corners for pills and circular badges */
+  full: 999,
+};
+
+/**
  * Card-related size constants for consistent card layouts
  */
 export const cardSizes = {

--- a/src/translations/en/bulkImport.ts
+++ b/src/translations/en/bulkImport.ts
@@ -43,6 +43,20 @@ export default {
     fetchingRecipes: 'Fetching recipe {{current}} of {{total}}...',
     newRecipes: 'New recipes ({{count}})',
     previouslySeen: 'Previously seen ({{count}})',
+    dismiss: 'Never show again',
+    dismissAccessibility: 'Never show this recipe again',
+    restoreAccessibility: 'Keep showing this recipe',
+    undo: 'Undo',
+  },
+
+  dismissed: {
+    title: 'Dismissed recipes',
+    manage: 'Recipes hidden from bulk import',
+    empty: 'No dismissed recipes',
+    emptyDescription: 'Recipes you hide during discovery appear here so you can restore them.',
+    restore: 'Restore',
+    count: '{{count}} dismissed recipe',
+    countPlural: '{{count}} dismissed recipes',
   },
 
   validation: {

--- a/src/translations/fr/bulkImport.ts
+++ b/src/translations/fr/bulkImport.ts
@@ -43,6 +43,21 @@ export default {
     fetchingRecipes: 'Récupération de la recette {{current}} sur {{total}}...',
     newRecipes: 'Nouvelles recettes ({{count}})',
     previouslySeen: 'Déjà vues ({{count}})',
+    dismiss: 'Ne plus afficher',
+    dismissAccessibility: 'Ne plus jamais afficher cette recette',
+    restoreAccessibility: 'Continuer à afficher cette recette',
+    undo: 'Annuler',
+  },
+
+  dismissed: {
+    title: 'Recettes masquées',
+    manage: "Recettes masquées de l'import en masse",
+    empty: 'Aucune recette masquée',
+    emptyDescription:
+      'Les recettes que vous masquez pendant la recherche apparaissent ici pour être restaurées.',
+    restore: 'Restaurer',
+    count: '{{count}} recette masquée',
+    countPlural: '{{count}} recettes masquées',
   },
 
   validation: {

--- a/src/utils/BulkImportUtils.ts
+++ b/src/utils/BulkImportUtils.ts
@@ -9,6 +9,54 @@
  */
 
 import { DiscoveredRecipe, DiscoveryListItem } from '@customTypes/BulkImportTypes';
+import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
+
+/**
+ * A group of dismissed recipes belonging to a single provider.
+ */
+export interface DismissedRecipeGroup {
+  /** Provider identifier (e.g., 'hellofresh') */
+  providerId: string;
+  /** Human-readable provider name for the group header */
+  providerName: string;
+  /** Dismissed recipes for this provider, preserving input order */
+  recipes: dismissedRecipeTableElement[];
+}
+
+/**
+ * Groups dismissed recipes by their source provider.
+ *
+ * Providers appear in the order they are first encountered in `recipes`, and the
+ * recipes within each group keep their input order, so passing a newest-first
+ * list yields newest-first groups and members.
+ *
+ * @param recipes - Dismissed recipe records to group
+ * @param resolveProviderName - Maps a provider id to its display name (falls back to the id)
+ * @returns One group per provider, in first-encountered order
+ */
+export function groupDismissedRecipesByProvider(
+  recipes: dismissedRecipeTableElement[],
+  resolveProviderName: (providerId: string) => string
+): DismissedRecipeGroup[] {
+  const groups: DismissedRecipeGroup[] = [];
+  const groupByProviderId = new Map<string, DismissedRecipeGroup>();
+
+  for (const recipe of recipes) {
+    let group = groupByProviderId.get(recipe.providerId);
+    if (!group) {
+      group = {
+        providerId: recipe.providerId,
+        providerName: resolveProviderName(recipe.providerId),
+        recipes: [],
+      };
+      groupByProviderId.set(recipe.providerId, group);
+      groups.push(group);
+    }
+    group.recipes.push(recipe);
+  }
+
+  return groups;
+}
 
 /**
  * Represents the visible range boundaries in the recipe list

--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -12,6 +12,11 @@
 import * as SQLite from 'expo-sqlite';
 import {
   coreIngredientElement,
+  dismissedRecipeTableElement,
+  dismissedRecipesColumnsEncoding,
+  dismissedRecipesColumnsNames,
+  dismissedRecipesTableName,
+  encodedDismissedRecipeElement,
   encodedImportHistoryElement,
   encodedIngredientElement,
   encodedMenuElement,
@@ -66,6 +71,7 @@ import {
 import { buildItemIndex, searchItems } from '@utils/FuzzyIndex';
 import { parseQuantity, scaleQuantityForPersons } from '@utils/Quantity';
 import { databaseLogger } from '@utils/logger';
+import { epochMillis } from '@utils/time';
 import { fisherYatesShuffle } from './FilterFunctions';
 
 /** Recipe titles are long and often paraphrased — looser than `ITEM_FUZZY` so wording variants still match. */
@@ -118,6 +124,7 @@ export class RecipeDatabase {
   protected _tagsTable: TableManipulation;
 
   protected _importHistoryTable: TableManipulation;
+  protected _dismissedRecipesTable: TableManipulation;
   protected _menuTable: TableManipulation;
   protected _purchasedIngredientsTable: TableManipulation;
 
@@ -126,6 +133,7 @@ export class RecipeDatabase {
   protected _tags: tagTableElement[];
 
   protected _importHistory: importHistoryTableElement[];
+  protected _dismissedRecipes: dismissedRecipeTableElement[];
   protected _menu: menuTableElement[];
   protected _purchasedIngredients: Map<string, boolean>;
 
@@ -145,6 +153,10 @@ export class RecipeDatabase {
       importHistoryTableName,
       importHistoryColumnsEncoding
     );
+    this._dismissedRecipesTable = new TableManipulation(
+      dismissedRecipesTableName,
+      dismissedRecipesColumnsEncoding
+    );
     this._menuTable = new TableManipulation(menuTableName, menuColumnsEncoding);
     this._purchasedIngredientsTable = new TableManipulation(
       purchasedIngredientsTableName,
@@ -155,6 +167,7 @@ export class RecipeDatabase {
     this._ingredients = [];
     this._tags = [];
     this._importHistory = [];
+    this._dismissedRecipes = [];
     this._menu = [];
     this._purchasedIngredients = new Map();
   }
@@ -310,6 +323,7 @@ export class RecipeDatabase {
       this._ingredientsTable.createTable(this._dbConnection),
       this._tagsTable.createTable(this._dbConnection),
       this._importHistoryTable.createTable(this._dbConnection),
+      this._dismissedRecipesTable.createTable(this._dbConnection),
       this._menuTable.createTable(this._dbConnection),
       this._purchasedIngredientsTable.createTable(this._dbConnection),
     ]);
@@ -317,19 +331,28 @@ export class RecipeDatabase {
     await this.migrateAddSourceColumns();
     await this.migrateWildcardSeasons();
 
-    const [ingredients, tags, recipes, importHistory, menu, purchasedIngredients] =
-      await Promise.all([
-        this.getAllIngredients(),
-        this.getAllTags(),
-        this.getAllRecipes(),
-        this.getAllImportHistory(),
-        this.getAllMenu(),
-        this.getAllPurchasedIngredients(),
-      ]);
+    const [
+      ingredients,
+      tags,
+      recipes,
+      importHistory,
+      dismissedRecipes,
+      menu,
+      purchasedIngredients,
+    ] = await Promise.all([
+      this.getAllIngredients(),
+      this.getAllTags(),
+      this.getAllRecipes(),
+      this.getAllImportHistory(),
+      this.getAllDismissedRecipes(),
+      this.getAllMenu(),
+      this.getAllPurchasedIngredients(),
+    ]);
     this._ingredients = ingredients;
     this._tags = tags;
     this._recipes = recipes;
     this._importHistory = importHistory;
+    this._dismissedRecipes = dismissedRecipes;
     this._menu = menu;
     this._purchasedIngredients = purchasedIngredients;
 
@@ -338,6 +361,7 @@ export class RecipeDatabase {
       ingredientsCount: this._ingredients.length,
       tagsCount: this._tags.length,
       importHistoryCount: this._importHistory.length,
+      dismissedRecipesCount: this._dismissedRecipes.length,
       menuItemsCount: this._menu.length,
       purchasedIngredientsCount: this._purchasedIngredients.size,
     });
@@ -1740,6 +1764,118 @@ export class RecipeDatabase {
   }
 
   /**
+   * Gets all permanently dismissed recipe URLs for a specific provider.
+   *
+   * Dismissed recipes were explicitly hidden by the user and must be filtered
+   * out of every future bulk-import discovery run.
+   *
+   * @param providerId - The provider identifier (e.g., 'hellofresh')
+   * @returns Set of URLs the user has dismissed
+   */
+  public getDismissedUrls(providerId: string): Set<string> {
+    return new Set(
+      this._dismissedRecipes.filter(r => r.providerId === providerId).map(r => r.recipeUrl)
+    );
+  }
+
+  /**
+   * Gets dismissed recipe records, optionally scoped to a provider.
+   *
+   * Returns the full records (including title) so the manage list can display
+   * them without re-running discovery. Sorted most-recently-dismissed first.
+   * When `providerId` is omitted, records from every provider are returned.
+   *
+   * @param providerId - Optional provider identifier to filter by (e.g., 'hellofresh')
+   * @returns Array of dismissed recipe records, newest first
+   */
+  public getDismissedRecipes(providerId?: string): dismissedRecipeTableElement[] {
+    return this._dismissedRecipes
+      .filter(r => providerId === undefined || r.providerId === providerId)
+      .sort((a, b) => b.dismissedAt - a.dismissedAt);
+  }
+
+  /**
+   * Permanently dismisses recipes for a specific provider.
+   *
+   * Records that the user never wants to see these recipes again. Already-dismissed
+   * URLs are skipped. Dismissed recipes are excluded from all future discovery runs.
+   *
+   * @param providerId - The provider identifier (e.g., 'hellofresh')
+   * @param recipes - Recipes to dismiss, each providing its `url`, `title` and optional `imageUrl`
+   */
+  public async markRecipesAsDismissed(
+    providerId: string,
+    recipes: { url: string; title: string; imageUrl?: string }[]
+  ): Promise<void> {
+    if (recipes.length === 0) return;
+
+    const existingDismissedUrls = this.getDismissedUrls(providerId);
+    const now = epochMillis();
+
+    const newEntries = recipes
+      .filter(recipe => !existingDismissedUrls.has(recipe.url))
+      .map(recipe => ({
+        providerId,
+        recipeUrl: recipe.url,
+        title: recipe.title,
+        imageUrl: recipe.imageUrl ?? '',
+        dismissedAt: now,
+      }));
+
+    if (newEntries.length === 0) return;
+
+    const encodedEntries = newEntries.map(entry => this.encodeDismissedRecipe(entry));
+
+    databaseLogger.debug('Dismissing recipes', {
+      providerId,
+      count: newEntries.length,
+    });
+
+    const success = await this._dismissedRecipesTable.insertArrayOfElement(
+      encodedEntries,
+      this._dbConnection
+    );
+
+    if (success) {
+      for (const entry of newEntries) {
+        this._dismissedRecipes.push(entry as dismissedRecipeTableElement);
+      }
+    } else {
+      databaseLogger.error('Failed to dismiss recipes', { providerId, count: newEntries.length });
+    }
+  }
+
+  /**
+   * Restores previously dismissed recipes for a specific provider.
+   *
+   * Removes the dismissal so the recipes reappear in future discovery runs.
+   * Used by the undo action and the manage list. Deletion is keyed on
+   * provider + URL, so it works regardless of whether the in-memory record
+   * carries a database id yet.
+   *
+   * @param providerId - The provider identifier (e.g., 'hellofresh')
+   * @param urls - Array of recipe URLs to restore
+   */
+  public async restoreDismissedRecipes(providerId: string, urls: string[]): Promise<void> {
+    if (urls.length === 0) return;
+
+    databaseLogger.debug('Restoring dismissed recipes', {
+      providerId,
+      count: urls.length,
+    });
+
+    const conditions = new Map<string, string | string[]>([
+      [dismissedRecipesColumnsNames.providerId, providerId],
+      [dismissedRecipesColumnsNames.recipeUrl, urls],
+    ]);
+    await this._dismissedRecipesTable.deleteElement(this._dbConnection, conditions);
+
+    this._dismissedRecipes = this._dismissedRecipes.filter(
+      r => !(r.providerId === providerId && urls.includes(r.recipeUrl))
+    );
+  }
+
+  /**
    * Validates and prepares a single recipe for insertion.
    *
    * Verifies that all referenced tags and ingredients exist in the database,
@@ -1857,6 +1993,7 @@ export class RecipeDatabase {
     this._ingredients = [];
     this._tags = [];
     this._importHistory = [];
+    this._dismissedRecipes = [];
     this._menu = [];
     this._purchasedIngredients = new Map();
   }
@@ -2901,6 +3038,60 @@ export class RecipeDatabase {
       PROVIDER_ID: history.providerId,
       RECIPE_URL: history.recipeUrl,
       LAST_SEEN_AT: history.lastSeenAt,
+    };
+  }
+
+  /**
+   * Retrieves all dismissed recipe records from the database
+   *
+   * @private
+   * @returns Promise resolving to array of all dismissed recipe records
+   */
+  private async getAllDismissedRecipes(): Promise<dismissedRecipeTableElement[]> {
+    const results = (await this._dismissedRecipesTable.searchElement(
+      this._dbConnection
+    )) as encodedDismissedRecipeElement[];
+
+    if (!results || !Array.isArray(results) || results.length === 0) {
+      return [];
+    }
+
+    return results.map(encoded => this.decodeDismissedRecipe(encoded));
+  }
+
+  /**
+   * Decodes a dismissed recipe record from database format
+   *
+   * @private
+   */
+  private decodeDismissedRecipe(
+    encoded: encodedDismissedRecipeElement
+  ): dismissedRecipeTableElement {
+    return {
+      id: encoded.ID,
+      providerId: encoded.PROVIDER_ID,
+      recipeUrl: encoded.RECIPE_URL,
+      title: encoded.TITLE,
+      imageUrl: encoded.IMAGE_URL,
+      dismissedAt: encoded.DISMISSED_AT,
+    };
+  }
+
+  /**
+   * Encodes a dismissed recipe record for database storage
+   *
+   * @private
+   */
+  private encodeDismissedRecipe(
+    dismissed: dismissedRecipeTableElement
+  ): encodedDismissedRecipeElement {
+    return {
+      ID: dismissed.id || 0,
+      PROVIDER_ID: dismissed.providerId,
+      RECIPE_URL: dismissed.recipeUrl,
+      TITLE: dismissed.title,
+      IMAGE_URL: dismissed.imageUrl,
+      DISMISSED_AT: dismissed.dismissedAt,
     };
   }
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,22 @@
+/**
+ * Time - Single source of truth for wall-clock timestamps
+ *
+ * Wraps the one unavoidable call to the platform clock so the rest of the app
+ * never touches the `Date` object directly. Business logic and persistence use
+ * {@link epochMillis} to obtain a timestamp, which keeps call sites free of
+ * `Date`'s footguns (mutation, 0-indexed months, parse/timezone ambiguity) and
+ * makes time deterministic in tests by mocking this module instead of the
+ * global `Date`.
+ *
+ * Timestamps are integer milliseconds since the Unix epoch (UTC), suitable for
+ * storage as an `INTEGER` column and for numeric ordering.
+ */
+
+/**
+ * Returns the current time as integer milliseconds since the Unix epoch (UTC).
+ *
+ * @returns Milliseconds elapsed since 1970-01-01T00:00:00Z
+ */
+export function epochMillis(): number {
+  return Date.now();
+}

--- a/tests/e2e/E2E_TESTING.md
+++ b/tests/e2e/E2E_TESTING.md
@@ -18,6 +18,7 @@ Maestro.
 - [Platform-Specific Testing](#platform-specific-testing)
 - [Language Support](#language-support)
 - [Common Patterns](#common-patterns)
+- [Validating Flows with the Maestro MCP Server](#validating-flows-with-the-maestro-mcp-server)
 - [Troubleshooting](#troubleshooting)
 
 ## Overview
@@ -1443,6 +1444,74 @@ visibility assertions on CI despite the app rendering correctly.
 `handleAnr.yaml` is kept as a guarded no-op safety net for **local** emulators,
 which run bare `maestro test` and do not get these adb settings. New flows do
 not need `handleAnr.yaml` when they only target CI.
+
+## Validating Flows with the Maestro MCP Server
+
+Maestro ships an MCP server (`maestro mcp`) that lets an agent drive the running
+app directly. **Every new or edited flow must be validated live against the app
+before it is considered done** — reading source and screenshots is not enough to
+prove a selector resolves.
+
+### Setup (once)
+
+```bash
+claude mcp add -s user maestro -- maestro mcp
+```
+
+Reconnect the session (`/mcp`) so the tools load. Add it at **user scope**
+(`-s user`) so it is available in every project — a project-local add lands
+under the wrong project key and silently fails to connect.
+
+### Workflow: `list_devices` → `inspect_screen` → `run`
+
+1. **`list_devices`** — pick the connected `device_id`. Share the Maestro Viewer
+   URL with the user.
+2. **`inspect_screen`** — read the REAL view hierarchy (`rid`/`txt`/`a11y`) of
+   the screen before authoring selectors. Never author a selector from a
+   screenshot; screenshots cause hallucinated text (an icon looks labelled but
+   has no text node).
+3. **`run`** — execute the flow, or drive it in small inline-YAML chunks with a
+   `take_screenshot` between steps so a failure pinpoints the exact command.
+   `run` validates syntax as part of the call.
+
+### Selector gotcha: Paper Button text lives on a `-text` child
+
+A React Native Paper `Button`'s `testID` lands on a **wrapper** whose
+accessibility text (`a11y`/content-desc) is the `accessibilityLabel` prop,
+**not** the visible label. To assert the visible label, target the label child
+`<testID>-text` (mirrors the AppBar title node `...::Title-title-text`):
+
+```yaml
+# WRONG — id wrapper carries the accessibilityLabel, not "Annuler"
+- assertVisible:
+    id: 'BulkImportDiscovery::fresh-0::RestoreButton'
+    text: 'Annuler'
+
+# RIGHT — id and text resolve to the same (-text) element
+- assertVisible:
+    id: 'BulkImportDiscovery::fresh-0::RestoreButton-text'
+    text: 'Annuler'
+```
+
+A wrapper `id` + `text` works only when the button has NO `accessibilityLabel`
+(RN then derives `a11y` from the visible text, e.g. `ContinueButton` +
+"Continuer"). `tapOn` the wrapper `id` (it is the clickable node);
+`assertVisible` the `-text` child for the label.
+
+### CRITICAL: never reload or launch the app yourself
+
+The local target is a **dev build**. `launchApp` / relaunch / cold-start drops
+to the Expo dev-client launcher ("npx expo start / Connect"), not the app —
+breaking the run and losing state.
+
+- Do NOT run `launchApp`, restart, reload, or `adb`-relaunch during local
+  validation.
+- When a step needs a fresh app state or reload (committed-DB check, onboarding
+  reset), STOP and ASK THE USER to run/reload the app, then wait for
+  confirmation and re-`inspect_screen` before continuing.
+- The committed test YAML MAY keep `launchApp` for CI — the release **test
+  build** handles it correctly (unlike the local dev build). Keep it in the
+  file; only the local reload is handed to the user.
 
 ## CI Retry Mechanism
 

--- a/tests/e2e/asserts/bulk-import/fr/assertDiscoveryScreen.yaml
+++ b/tests/e2e/asserts/bulk-import/fr/assertDiscoveryScreen.yaml
@@ -47,3 +47,8 @@ appId: "com.recipedia"
     id: "BulkImportDiscovery::ContinueButton"
     text: "Continuer"
     label: "Continue button displays correct text (French)"
+
+- assertVisible:
+    id: "BulkImportDiscovery::fresh-0::DismissButton-text"
+    text: "Ne plus afficher"
+    label: "First fresh recipe dismiss button displays correct text (French)"

--- a/tests/e2e/asserts/bulk-import/fr/assertDismissedEmpty.yaml
+++ b/tests/e2e/asserts/bulk-import/fr/assertDismissedEmpty.yaml
@@ -1,0 +1,6 @@
+appId: "com.recipedia"
+---
+- assertVisible:
+    id: "DismissedRecipesSettings::Empty"
+    text: "Aucune recette masquée"
+    label: "Empty state message is displayed (French)"

--- a/tests/e2e/asserts/bulk-import/fr/assertDismissedSettingsScreen.yaml
+++ b/tests/e2e/asserts/bulk-import/fr/assertDismissedSettingsScreen.yaml
@@ -1,0 +1,18 @@
+appId: "com.recipedia"
+---
+- assertVisible:
+    id: "DismissedRecipesSettings::AppBar::Title-title-text"
+    text: "Recettes masquées"
+    label: "App bar title displays correct text (French)"
+
+- assertVisible:
+    id: "DismissedRecipesSettings::hellofresh"
+    label: "HelloFresh provider accordion is displayed"
+
+- assertVisible:
+    id: "DismissedRecipesSettings::hellofresh::Logo"
+    label: "HelloFresh provider logo is displayed"
+
+- assertVisible:
+    text: "\\d+ recette(s)? masquée(s)?"
+    label: "Dismissed recipes count displays correct format (French)"

--- a/tests/e2e/asserts/bulk-import/fr/assertSeenSection.yaml
+++ b/tests/e2e/asserts/bulk-import/fr/assertSeenSection.yaml
@@ -9,7 +9,7 @@ appId: "com.recipedia"
     label: "First seen recipe card is displayed"
 
 - assertVisible:
-    id: "BulkImportDiscovery::seen-0::Thumbnail::Thumbnail::Icon"
+    id: "BulkImportDiscovery::seen-0::SeenIndicator"
     label: "Seen indicator icon is displayed on first seen recipe"
 
 - assertVisible:

--- a/tests/e2e/asserts/parameters/en/assertImportSection.yaml
+++ b/tests/e2e/asserts/parameters/en/assertImportSection.yaml
@@ -25,6 +25,10 @@ appId: "com.recipedia"
           id: "Parameters::Section::Import::FromWebsite::Item"
           text: "Import from meal kit service, Import all recipes from supported services"
           label: "Import item with icon on iOS"
+      - assertVisible:
+          id: "Parameters::Section::Import::DismissedRecipes::Item"
+          text: "Dismissed recipes, Recipes hidden from bulk import"
+          label: "Dismissed recipes item with icon on iOS"
 
 - runFlow:
     when:
@@ -34,3 +38,7 @@ appId: "com.recipedia"
           id: "Parameters::Section::Import::FromWebsite::Item"
           text: "Import from meal kit service, Import all recipes from supported services"
           label: "Import item on Android"
+      - assertVisible:
+          id: "Parameters::Section::Import::DismissedRecipes::Item"
+          text: "Dismissed recipes, Recipes hidden from bulk import"
+          label: "Dismissed recipes item on Android"

--- a/tests/e2e/asserts/parameters/fr/assertImportSection.yaml
+++ b/tests/e2e/asserts/parameters/fr/assertImportSection.yaml
@@ -25,6 +25,10 @@ appId: "com.recipedia"
           id: "Parameters::Section::Import::FromWebsite::Item"
           text: "Importer depuis un service, Importer toutes les recettes depuis les services supportés"
           label: "Import item with icon on iOS"
+      - assertVisible:
+          id: "Parameters::Section::Import::DismissedRecipes::Item"
+          text: "Recettes masquées, Recettes masquées de l'import en masse"
+          label: "Dismissed recipes item with icon on iOS"
 
 - runFlow:
     when:
@@ -34,3 +38,7 @@ appId: "com.recipedia"
           id: "Parameters::Section::Import::FromWebsite::Item"
           text: "Importer depuis un service, Importer toutes les recettes depuis les services supportés"
           label: "Import item on Android"
+      - assertVisible:
+          id: "Parameters::Section::Import::DismissedRecipes::Item"
+          text: "Recettes masquées, Recettes masquées de l'import en masse"
+          label: "Dismissed recipes item on Android"

--- a/tests/e2e/bulk-import.yaml
+++ b/tests/e2e/bulk-import.yaml
@@ -13,3 +13,4 @@ executionOrder:
     - "2 - Bulk Import Seen Recipes (French)"
     - "3 - Bulk Import with Skipped Recipe (all ingredients rejected)"
     - "4 - Bulk Import Quitoque with Language Filter (French)"
+    - "5 - Bulk Import Dismiss Recipes (French)"

--- a/tests/e2e/cases/bulk-import/1_bulk_import_hellofresh.yaml
+++ b/tests/e2e/cases/bulk-import/1_bulk_import_hellofresh.yaml
@@ -32,7 +32,7 @@ tags:
     label: "Assert - Verify discovery screen with recipes"
 
 - assertNotVisible:
-    id: "BulkImportDiscovery::fresh-0::Thumbnail::Thumbnail::Icon"
+    id: "BulkImportDiscovery::fresh-0::SeenIndicator"
     label: "Assert - Fresh recipe does not show seen indicator icon"
 
 - assertNotVisible:

--- a/tests/e2e/cases/bulk-import/5_bulk_import_dismiss_recipes.yaml
+++ b/tests/e2e/cases/bulk-import/5_bulk_import_dismiss_recipes.yaml
@@ -1,0 +1,121 @@
+name: "5 - Bulk Import Dismiss Recipes (French)"
+appId: "com.recipedia"
+tags:
+  - bulk-import
+---
+- runFlow:
+    file: "../../flows/parameters/language/switchToFrench.yaml"
+    label: "Setup - Switch to French language"
+
+- runFlow:
+    file: "../../flows/bulk-import/navigateToBulkImport.yaml"
+    label: "Setup - Navigate to Bulk Import from Parameters"
+
+- runFlow:
+    file: "../../flows/bulk-import/selectProvider.yaml"
+    env:
+      PROVIDER_ID: "hellofresh"
+    label: "Setup - Select HelloFresh provider"
+
+- extendedWaitUntil:
+    visible:
+      id: "BulkImportDiscovery::(fresh|seen)-0"
+    timeout: 120000
+    label: "Wait - For first recipe to appear"
+
+- tapOn:
+    id: "BulkImportDiscovery::(fresh|seen)-0::DismissButton"
+    label: "Action - Dismiss first recipe"
+
+- assertVisible:
+    id: "BulkImportDiscovery::(fresh|seen)-0::RestoreButton-text"
+    text: "Annuler"
+    label: "Assert - Dismissed recipe shows restore button with undo label"
+
+- assertVisible:
+    id: "BulkImportDiscovery::(fresh|seen)-0::Checkbox"
+    enabled: false
+    label: "Assert - Dismissed recipe checkbox is disabled"
+
+- tapOn:
+    id: "BulkImportDiscovery::(fresh|seen)-0::RestoreButton"
+    label: "Action - Undo dismissal before committing"
+
+- assertVisible:
+    id: "BulkImportDiscovery::(fresh|seen)-0::DismissButton-text"
+    text: "Ne plus afficher"
+    label: "Assert - Restored recipe shows dismiss button again"
+
+- tapOn:
+    id: "BulkImportDiscovery::(fresh|seen)-0::DismissButton"
+    label: "Action - Dismiss first recipe again"
+
+- tapOn:
+    id: "BulkImportDiscovery::(fresh|seen)-1"
+    label: "Action - Select second recipe so Continue is enabled"
+
+- assertVisible:
+    id: "BulkImportDiscovery::ContinueButton"
+    enabled: true
+    label: "Verify - Continue button is enabled"
+
+- tapOn:
+    id: "BulkImportDiscovery::ContinueButton"
+    label: "Action - Continue to validation (commits the dismissal)"
+
+- extendedWaitUntil:
+    visible:
+      id: "BulkImportValidation::AppBar::Title"
+    timeout: 200000
+    label: "Wait - For validation screen"
+
+- launchApp:
+    label: "Cleanup - Restart app to reach a clean home state"
+
+- extendedWaitUntil:
+    visible:
+      id: "Home::RecipeRecommendation::random::Carousel::Card::0::Cover"
+    timeout: 120000
+    label: "Wait - For home screen to be visible"
+
+- tapOn:
+    id: "BottomTabs::Parameters"
+    label: "Verification - Navigate to Parameters screen"
+
+- waitForAnimationToEnd
+
+- scrollUntilVisible:
+    element:
+      id: "Parameters::Section::Import::DismissedRecipes::Item"
+    direction: DOWN
+    speed: 60
+    centerElement: true
+    label: "Verification - Scroll to Dismissed recipes item"
+
+- tapOn:
+    id: "Parameters::Section::Import::DismissedRecipes::Item"
+    label: "Verification - Open Dismissed recipes settings"
+
+- runFlow:
+    file: "../../asserts/bulk-import/fr/assertDismissedSettingsScreen.yaml"
+    label: "Assert - Verify dismissed recipes settings screen"
+
+- tapOn:
+    id: "DismissedRecipesSettings::hellofresh"
+    label: "Verification - Expand HelloFresh accordion"
+
+- assertVisible:
+    id: "DismissedRecipesSettings::hellofresh::0::Title"
+    label: "Verify - Dismissed recipe title is displayed"
+
+- assertVisible:
+    id: "DismissedRecipesSettings::hellofresh::0::RestoreButton"
+    label: "Verify - Dismissed recipe restore button is displayed"
+
+- tapOn:
+    id: "DismissedRecipesSettings::hellofresh::0::RestoreButton"
+    label: "Cleanup - Restore the dismissed recipe"
+
+- runFlow:
+    file: "../../asserts/bulk-import/fr/assertDismissedEmpty.yaml"
+    label: "Cleanup - Verify dismissed recipes list is now empty"

--- a/tests/e2e/cases/bulk-import/ci/5_bulk_import_dismiss_recipes.yaml
+++ b/tests/e2e/cases/bulk-import/ci/5_bulk_import_dismiss_recipes.yaml
@@ -1,0 +1,14 @@
+name: "5 - Bulk Import Dismiss Recipes (French)"
+appId: "com.recipedia"
+tags:
+  - bulk-import
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../5_bulk_import_dismiss_recipes.yaml"
+          label: "Run 5 - Bulk Import Dismiss Recipes (French)"

--- a/tests/mocks/hooks/useDiscoveryWorkflow-mock.tsx
+++ b/tests/mocks/hooks/useDiscoveryWorkflow-mock.tsx
@@ -100,9 +100,17 @@ export function resetMockDiscoveryState() {
   mockToggleSelectAll.mockClear();
   mockParseSelectedRecipes.mockClear().mockResolvedValue([]);
   mockAbort.mockClear();
+  mockIsDismissed.mockReturnValue(false);
+  mockDismissRecipe.mockClear();
+  mockRestoreRecipe.mockClear();
+  mockCommitDismissals.mockClear();
 }
 
 export const mockMarkUrlsAsSeen = jest.fn();
+export const mockIsDismissed = jest.fn().mockReturnValue(false);
+export const mockDismissRecipe = jest.fn();
+export const mockRestoreRecipe = jest.fn();
+export const mockCommitDismissals = jest.fn();
 
 export function useDiscoveryWorkflowMock() {
   return {
@@ -119,11 +127,15 @@ export function useDiscoveryWorkflowMock() {
     parsingProgress: mockParsingProgressState,
     error: mockError,
     isSelected: mockIsSelected,
+    isDismissed: mockIsDismissed,
     selectRecipe: mockSelectRecipe,
     unselectRecipe: mockUnselectRecipe,
     toggleSelectAll: mockToggleSelectAll,
     parseSelectedRecipes: mockParseSelectedRecipes,
     abort: mockAbort,
     markUrlsAsSeen: mockMarkUrlsAsSeen,
+    dismissRecipe: mockDismissRecipe,
+    restoreRecipe: mockRestoreRecipe,
+    commitDismissals: mockCommitDismissals,
   };
 }

--- a/tests/perf/RecipeSelectionCard.perf.tsx
+++ b/tests/perf/RecipeSelectionCard.perf.tsx
@@ -37,8 +37,11 @@ function RecipeSelectionCardWrapper({
       testId='PerfTest::Card'
       recipe={recipe}
       isSelected={isSelected}
+      isDismissed={false}
       onSelected={() => setIsSelected(true)}
       onUnselected={() => setIsSelected(false)}
+      onDismiss={() => {}}
+      onRestore={() => {}}
     />
   );
 }
@@ -62,6 +65,7 @@ function BatchCardsWrapper({
           testId={`PerfTest::Card::${index}`}
           recipe={recipe}
           isSelected={selectedUrls.has(recipe.url)}
+          isDismissed={false}
           onSelected={() => setSelectedUrls(prev => new Set(prev).add(recipe.url))}
           onUnselected={() => {
             setSelectedUrls(prev => {
@@ -70,6 +74,8 @@ function BatchCardsWrapper({
               return next;
             });
           }}
+          onDismiss={() => {}}
+          onRestore={() => {}}
         />
       ))}
     </View>

--- a/tests/unit/components/molecules/DismissedRecipeCard.test.tsx
+++ b/tests/unit/components/molecules/DismissedRecipeCard.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { DismissedRecipeCard } from '@components/molecules/DismissedRecipeCard';
+import React from 'react';
+import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
+
+const mockRecipe: dismissedRecipeTableElement = {
+  id: 1,
+  providerId: 'hellofresh',
+  recipeUrl: 'https://hellofresh.com/recipe-1',
+  title: 'Dismissed Recipe',
+  imageUrl: 'https://hellofresh.com/image-1.jpg',
+  dismissedAt: 1700000000000,
+};
+
+describe('DismissedRecipeCard', () => {
+  const defaultProps = {
+    testIdPrefix: 'test-card',
+    recipe: mockRecipe,
+    onRestore: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders recipe title', () => {
+    const { getByTestId } = render(<DismissedRecipeCard {...defaultProps} />);
+
+    expect(getByTestId('test-card::Title').props.children).toBe('Dismissed Recipe');
+  });
+
+  test('renders the recipe thumbnail', () => {
+    const { getByTestId } = render(<DismissedRecipeCard {...defaultProps} />);
+
+    expect(getByTestId('test-card::Thumbnail')).toBeTruthy();
+  });
+
+  test('renders restore button', () => {
+    const { getByTestId } = render(<DismissedRecipeCard {...defaultProps} />);
+
+    expect(getByTestId('test-card::RestoreButton')).toBeTruthy();
+  });
+
+  test('calls onRestore when restore button pressed', () => {
+    const onRestore = jest.fn();
+    const { getByTestId } = render(<DismissedRecipeCard {...defaultProps} onRestore={onRestore} />);
+
+    fireEvent.press(getByTestId('test-card::RestoreButton'));
+
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/molecules/RecipeSelectionCard.test.tsx
+++ b/tests/unit/components/molecules/RecipeSelectionCard.test.tsx
@@ -15,8 +15,11 @@ describe('RecipeSelectionCard', () => {
     testId: 'test-card',
     recipe: mockRecipe,
     isSelected: false,
+    isDismissed: false,
     onSelected: jest.fn(),
     onUnselected: jest.fn(),
+    onDismiss: jest.fn(),
+    onRestore: jest.fn(),
   };
 
   beforeEach(() => {
@@ -84,12 +87,80 @@ describe('RecipeSelectionCard', () => {
     const seenRecipe: DiscoveredRecipe = { ...mockRecipe, memoryStatus: 'seen' };
     const { getByTestId } = render(<RecipeSelectionCard {...defaultProps} recipe={seenRecipe} />);
 
-    expect(getByTestId('test-card::Thumbnail::Thumbnail::Icon')).toBeTruthy();
+    expect(getByTestId('test-card::SeenIndicator')).toBeTruthy();
+  });
+
+  test('places seen indicator testID on the badge container, not the paper Icon', () => {
+    const seenRecipe: DiscoveredRecipe = { ...mockRecipe, memoryStatus: 'seen' };
+    const { queryByTestId } = render(
+      <RecipeSelectionCard {...defaultProps} recipe={seenRecipe} />
+    );
+
+    expect(queryByTestId('test-card::SeenIndicator::Source')).toBeNull();
   });
 
   test('does not render seen indicator for fresh recipes', () => {
     const { queryByTestId } = render(<RecipeSelectionCard {...defaultProps} />);
 
-    expect(queryByTestId('test-card::Thumbnail::Thumbnail::Icon')).toBeNull();
+    expect(queryByTestId('test-card::SeenIndicator')).toBeNull();
+  });
+
+  test('renders dismiss button', () => {
+    const { getByTestId } = render(<RecipeSelectionCard {...defaultProps} />);
+
+    expect(getByTestId('test-card::DismissButton')).toBeTruthy();
+  });
+
+  test('calls onDismiss when dismiss button pressed', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(<RecipeSelectionCard {...defaultProps} onDismiss={onDismiss} />);
+
+    fireEvent.press(getByTestId('test-card::DismissButton'));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not toggle selection when dismiss button pressed', () => {
+    const onSelected = jest.fn();
+    const { getByTestId } = render(
+      <RecipeSelectionCard {...defaultProps} onSelected={onSelected} />
+    );
+
+    fireEvent.press(getByTestId('test-card::DismissButton'));
+
+    expect(onSelected).not.toHaveBeenCalled();
+  });
+
+  describe('when dismissed', () => {
+    const dismissedProps = { ...defaultProps, isDismissed: true };
+
+    test('renders restore button instead of dismiss button', () => {
+      const { getByTestId, queryByTestId } = render(<RecipeSelectionCard {...dismissedProps} />);
+
+      expect(getByTestId('test-card::RestoreButton')).toBeTruthy();
+      expect(queryByTestId('test-card::DismissButton')).toBeNull();
+    });
+
+    test('calls onRestore when restore button pressed', () => {
+      const onRestore = jest.fn();
+      const { getByTestId } = render(
+        <RecipeSelectionCard {...dismissedProps} onRestore={onRestore} />
+      );
+
+      fireEvent.press(getByTestId('test-card::RestoreButton'));
+
+      expect(onRestore).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not toggle selection when the card is pressed', () => {
+      const onSelected = jest.fn();
+      const { getByTestId } = render(
+        <RecipeSelectionCard {...dismissedProps} onSelected={onSelected} />
+      );
+
+      fireEvent.press(getByTestId('test-card'));
+
+      expect(onSelected).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/hooks/useDiscoveryWorkflow.test.tsx
+++ b/tests/unit/hooks/useDiscoveryWorkflow.test.tsx
@@ -1024,4 +1024,199 @@ describe('useDiscoveryWorkflow', () => {
       expect(result.current.allSelected).toBe(false);
     });
   });
+
+  describe('dismiss recipe', () => {
+    it('dismissRecipe keeps the recipe visible and flags it', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      const target = result.current.recipes[0];
+      act(() => {
+        result.current.dismissRecipe(target);
+      });
+
+      expect(result.current.recipes).toHaveLength(2);
+      expect(result.current.isDismissed(target.url)).toBe(true);
+    });
+
+    it('dismissRecipe does not persist until committed', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.dismissRecipe(result.current.recipes[0]);
+      });
+
+      expect(database.getDismissedUrls('mock').has('https://example.com/recipe-1')).toBe(false);
+    });
+
+    it('dismissRecipe clears the recipe from the selection', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.selectRecipe('https://example.com/recipe-1');
+      });
+      expect(result.current.selectedCount).toBe(1);
+
+      act(() => {
+        result.current.dismissRecipe(result.current.recipes[0]);
+      });
+
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('restoreRecipe clears the pending dismissal flag', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      const target = result.current.recipes[0];
+      act(() => {
+        result.current.dismissRecipe(target);
+      });
+      expect(result.current.isDismissed(target.url)).toBe(true);
+
+      act(() => {
+        result.current.restoreRecipe(target);
+      });
+
+      expect(result.current.isDismissed(target.url)).toBe(false);
+    });
+
+    it('commitDismissals persists every pending dismissal', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.dismissRecipe(result.current.recipes[0]);
+      });
+
+      await act(async () => {
+        await result.current.commitDismissals();
+      });
+
+      expect(database.getDismissedUrls('mock').has('https://example.com/recipe-1')).toBe(true);
+    });
+
+    it('commitDismissals persists the imageUrl of the recipe passed to dismissRecipe', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      const enrichedRecipe = {
+        ...result.current.recipes[0],
+        imageUrl: 'https://example.com/lazily-loaded.jpg',
+      };
+      act(() => {
+        result.current.dismissRecipe(enrichedRecipe);
+      });
+
+      await act(async () => {
+        await result.current.commitDismissals();
+      });
+
+      const dismissed = database.getDismissedRecipes('mock');
+      expect(dismissed[0].recipeUrl).toBe('https://example.com/recipe-1');
+      expect(dismissed[0].imageUrl).toBe('https://example.com/lazily-loaded.jpg');
+    });
+
+    it('commitDismissals is a no-op when nothing is pending', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      await act(async () => {
+        await result.current.commitDismissals();
+      });
+
+      expect(database.getDismissedRecipes('mock')).toHaveLength(0);
+    });
+
+    it('toggleSelectAll ignores pending-dismissed recipes', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.dismissRecipe(result.current.recipes[0]);
+      });
+
+      act(() => {
+        result.current.toggleSelectAll();
+      });
+
+      expect(result.current.selectedCount).toBe(1);
+      expect(result.current.isSelected('https://example.com/recipe-1')).toBe(false);
+      expect(result.current.isSelected('https://example.com/recipe-2')).toBe(true);
+    });
+
+    it('allSelected is true when every selectable recipe is selected and one is dismissed', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.dismissRecipe(result.current.recipes[0]);
+      });
+
+      act(() => {
+        result.current.toggleSelectAll();
+      });
+
+      expect(result.current.allSelected).toBe(true);
+    });
+
+    it('toggleSelectAll selects nothing and allSelected stays false when every recipe is dismissed', async () => {
+      const provider = createMockProvider();
+      const { result } = renderHook(() => useDiscoveryWorkflow(provider, 'mock'));
+
+      await waitFor(() => {
+        expect(result.current.recipes).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.dismissRecipe(result.current.recipes[0]);
+        result.current.dismissRecipe(result.current.recipes[1]);
+      });
+
+      act(() => {
+        result.current.toggleSelectAll();
+      });
+
+      expect(result.current.selectedCount).toBe(0);
+      expect(result.current.allSelected).toBe(false);
+    });
+  });
 });

--- a/tests/unit/hooks/useImportMemory.test.tsx
+++ b/tests/unit/hooks/useImportMemory.test.tsx
@@ -75,6 +75,32 @@ describe('useImportMemory', () => {
 
       expect(result.current.getMemoryStatus(url)).toBe('imported');
     });
+
+    test('returns dismissed for URLs of dismissed recipes', async () => {
+      const url = 'https://hellofresh.com/dismissed-recipe';
+      await database.markRecipesAsDismissed('hellofresh', [{ url, title: 'Dismissed Recipe' }]);
+
+      const { result } = renderHook(() => useImportMemory('hellofresh'));
+
+      expect(result.current.getMemoryStatus(url)).toBe('dismissed');
+    });
+
+    test('dismissed takes precedence over imported and seen', async () => {
+      const url = 'https://hellofresh.com/recipe-all';
+      await database.markUrlsAsSeen('hellofresh', [url]);
+      await database.addRecipe({
+        ...testRecipes[0],
+        id: undefined,
+        title: 'All Recipe',
+        sourceUrl: url,
+        sourceProvider: 'hellofresh',
+      });
+      await database.markRecipesAsDismissed('hellofresh', [{ url, title: 'All Recipe' }]);
+
+      const { result } = renderHook(() => useImportMemory('hellofresh'));
+
+      expect(result.current.getMemoryStatus(url)).toBe('dismissed');
+    });
   });
 
   describe('processDiscoveredRecipes', () => {
@@ -190,6 +216,40 @@ describe('useImportMemory', () => {
       const processed = result.current.processDiscoveredRecipes([], false);
 
       expect(processed).toEqual([]);
+    });
+
+    test('always filters out dismissed recipes when hideImported is true', async () => {
+      await database.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'Dismissed Recipe' },
+      ]);
+
+      const recipes = [
+        createRecipe('https://hellofresh.com/recipe-1', 'Dismissed Recipe'),
+        createRecipe('https://hellofresh.com/recipe-2', 'Fresh Recipe'),
+      ];
+
+      const { result } = renderHook(() => useImportMemory('hellofresh'));
+      const processed = result.current.processDiscoveredRecipes(recipes, true);
+
+      expect(processed).toHaveLength(1);
+      expect(processed[0].title).toBe('Fresh Recipe');
+    });
+
+    test('always filters out dismissed recipes even when hideImported is false', async () => {
+      await database.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'Dismissed Recipe' },
+      ]);
+
+      const recipes = [
+        createRecipe('https://hellofresh.com/recipe-1', 'Dismissed Recipe'),
+        createRecipe('https://hellofresh.com/recipe-2', 'Fresh Recipe'),
+      ];
+
+      const { result } = renderHook(() => useImportMemory('hellofresh'));
+      const processed = result.current.processDiscoveredRecipes(recipes, false);
+
+      expect(processed).toHaveLength(1);
+      expect(processed[0].title).toBe('Fresh Recipe');
     });
   });
 

--- a/tests/unit/screens/BulkImportDiscovery.test.tsx
+++ b/tests/unit/screens/BulkImportDiscovery.test.tsx
@@ -9,11 +9,15 @@ import {
 } from '@mocks/deps/react-navigation-mock';
 import {
   mockAbort,
+  mockCommitDismissals,
   mockDiscoveryProgress,
+  mockDismissRecipe,
   mockFreshRecipes,
+  mockIsDismissed,
   mockIsSelected,
   mockParseSelectedRecipes,
   mockParsingProgress,
+  mockRestoreRecipe,
   mockSelectRecipe,
   mockToggleSelectAll,
   mockUnselectRecipe,
@@ -170,6 +174,42 @@ describe('BulkImportDiscovery', () => {
     const { getByText } = render(<BulkImportDiscovery />);
 
     expect(getByText('Network error')).toBeTruthy();
+  });
+
+  describe('dismiss recipe', () => {
+    test('calls dismissRecipe when dismiss button pressed', () => {
+      const { getByTestId } = render(<BulkImportDiscovery />);
+
+      fireEvent.press(getByTestId('BulkImportDiscovery::fresh-0::DismissButton'));
+
+      expect(mockDismissRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.com/recipe-1' })
+      );
+    });
+
+    test('shows restore button and calls restoreRecipe for a dismissed recipe', () => {
+      mockIsDismissed.mockReturnValue(true);
+      const { getByTestId } = render(<BulkImportDiscovery />);
+
+      fireEvent.press(getByTestId('BulkImportDiscovery::fresh-0::RestoreButton'));
+
+      expect(mockRestoreRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.com/recipe-1' })
+      );
+    });
+
+    test('commits pending dismissals on continue', async () => {
+      setMockDiscoveryState({ selectedCount: 2 });
+      mockParseSelectedRecipes.mockResolvedValue([{ title: 'Recipe 1' }]);
+
+      const { getByTestId } = render(<BulkImportDiscovery />);
+
+      fireEvent.press(getByTestId('BulkImportDiscovery::ContinueButton'));
+
+      await waitFor(() => {
+        expect(mockCommitDismissals).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('section headers', () => {

--- a/tests/unit/screens/DismissedRecipesSettings.test.tsx
+++ b/tests/unit/screens/DismissedRecipesSettings.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { DismissedRecipesSettings } from '@screens/DismissedRecipesSettings';
+import React from 'react';
+import { mockGoBack } from '@mocks/deps/react-navigation-mock';
+import RecipeDatabase from '@utils/RecipeDatabase';
+
+jest.mock('@react-navigation/native', () => {
+  const { reactNavigationMock } = require('@mocks/deps/react-navigation-mock');
+  return reactNavigationMock();
+});
+
+describe('DismissedRecipesSettings', () => {
+  let database: RecipeDatabase;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    database = RecipeDatabase.getInstance();
+    await database.init();
+  });
+
+  afterEach(async () => {
+    await database.closeAndReset();
+  });
+
+  test('renders app bar with title', () => {
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    expect(getByTestId('DismissedRecipesSettings::AppBar')).toBeTruthy();
+  });
+
+  test('shows empty state when no dismissed recipes', () => {
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    expect(getByTestId('DismissedRecipesSettings::Empty')).toBeTruthy();
+  });
+
+  test('groups a dismissed recipe under its provider accordion', async () => {
+    await database.markRecipesAsDismissed('hellofresh', [
+      { url: 'https://hellofresh.com/recipe-1', title: 'Dismissed Recipe' },
+    ]);
+
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    expect(getByTestId('DismissedRecipesSettings::hellofresh')).toBeTruthy();
+    expect(getByTestId('DismissedRecipesSettings::hellofresh::0::Title').props.children).toBe(
+      'Dismissed Recipe'
+    );
+  });
+
+  test('shows a separate accordion per provider', async () => {
+    await database.markRecipesAsDismissed('hellofresh', [
+      { url: 'https://hellofresh.com/recipe-1', title: 'HelloFresh Recipe' },
+    ]);
+    await database.markRecipesAsDismissed('quitoque', [
+      { url: 'https://quitoque.fr/recipe-1', title: 'Quitoque Recipe' },
+    ]);
+
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    expect(getByTestId('DismissedRecipesSettings::hellofresh')).toBeTruthy();
+    expect(getByTestId('DismissedRecipesSettings::quitoque')).toBeTruthy();
+  });
+
+  test('shows the singular count for a provider with one dismissed recipe', async () => {
+    await database.markRecipesAsDismissed('hellofresh', [
+      { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' },
+    ]);
+
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    expect(getByTestId('DismissedRecipesSettings::hellofresh::Description').props.children).toBe(
+      'bulkImport.dismissed.count'
+    );
+  });
+
+  test('shows the plural count for a provider with multiple dismissed recipes', async () => {
+    await database.markRecipesAsDismissed('hellofresh', [
+      { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' },
+      { url: 'https://hellofresh.com/recipe-2', title: 'Recipe 2' },
+    ]);
+
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    expect(getByTestId('DismissedRecipesSettings::hellofresh::Description').props.children).toBe(
+      'bulkImport.dismissed.countPlural'
+    );
+  });
+
+  test('restores a recipe and removes it from the list', async () => {
+    const url = 'https://hellofresh.com/recipe-1';
+    await database.markRecipesAsDismissed('hellofresh', [{ url, title: 'Dismissed Recipe' }]);
+
+    const { getByTestId, queryByTestId } = render(<DismissedRecipesSettings />);
+
+    fireEvent.press(getByTestId('DismissedRecipesSettings::hellofresh::0::RestoreButton'));
+
+    await waitFor(() => {
+      expect(queryByTestId('DismissedRecipesSettings::hellofresh::0::Title')).toBeNull();
+    });
+    expect(database.getDismissedUrls('hellofresh').has(url)).toBe(false);
+  });
+
+  test('navigates back when app bar back pressed', () => {
+    const { getByTestId } = render(<DismissedRecipesSettings />);
+
+    fireEvent.press(getByTestId('DismissedRecipesSettings::AppBar::BackButton'));
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/screens/Parameters.test.tsx
+++ b/tests/unit/screens/Parameters.test.tsx
@@ -213,6 +213,32 @@ describe('Parameters Screen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('TagsSettings');
   });
 
+  test('navigates to bulk import provider selection when pressed', async () => {
+    const { getByTestId } = renderParameters();
+
+    await waitFor(() => {
+      expect(getByTestId('Parameters::Section::Import::FromWebsite::Item')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('Parameters::Section::Import::FromWebsite::Item'));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('BulkImportSettings');
+  });
+
+  test('navigates to dismissed recipes management when pressed', async () => {
+    const { getByTestId } = renderParameters();
+
+    await waitFor(() => {
+      expect(getByTestId('Parameters::Section::Import::DismissedRecipes::Item')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('Parameters::Section::Import::DismissedRecipes::Item'));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('DismissedRecipesSettings');
+  });
+
   test('displays default persons from context', async () => {
     const { getByTestId } = renderParameters();
 

--- a/tests/unit/utils/BulkImportUtils.test.ts
+++ b/tests/unit/utils/BulkImportUtils.test.ts
@@ -5,8 +5,10 @@ import {
   computeBufferBounds,
   computeVisibleBounds,
   getBufferRecipesNeedingFetch,
+  groupDismissedRecipesByProvider,
 } from '@utils/BulkImportUtils';
 import { DiscoveredRecipe } from '@customTypes/BulkImportTypes';
+import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
 
 const createRecipe = (url: string, title: string): DiscoveredRecipe => ({
   url,
@@ -18,6 +20,20 @@ const createRecipeWithoutImage = (url: string): DiscoveredRecipe => ({
   url,
   title: url,
 });
+
+const createDismissed = (
+  providerId: string,
+  recipeUrl: string,
+  title: string
+): dismissedRecipeTableElement => ({
+  providerId,
+  recipeUrl,
+  title,
+  imageUrl: '',
+  dismissedAt: 0,
+});
+
+const upperCaseName = (providerId: string) => providerId.toUpperCase();
 
 describe('BulkImportUtils', () => {
   describe('buildDiscoveryListData', () => {
@@ -334,6 +350,58 @@ describe('BulkImportUtils', () => {
 
       expect(controller.signal.aborted).toBe(true);
       expect(controllers.has('gone')).toBe(false);
+    });
+  });
+
+  describe('groupDismissedRecipesByProvider', () => {
+    test('returns empty array for no recipes', () => {
+      expect(groupDismissedRecipesByProvider([], upperCaseName)).toEqual([]);
+    });
+
+    test('groups recipes of the same provider together', () => {
+      const recipes = [
+        createDismissed('hellofresh', 'url-1', 'Recipe 1'),
+        createDismissed('hellofresh', 'url-2', 'Recipe 2'),
+      ];
+
+      const groups = groupDismissedRecipesByProvider(recipes, upperCaseName);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].providerId).toBe('hellofresh');
+      expect(groups[0].recipes).toHaveLength(2);
+    });
+
+    test('resolves the provider display name', () => {
+      const recipes = [createDismissed('hellofresh', 'url-1', 'Recipe 1')];
+
+      const groups = groupDismissedRecipesByProvider(recipes, upperCaseName);
+
+      expect(groups[0].providerName).toBe('HELLOFRESH');
+    });
+
+    test('creates one group per provider in first-encountered order', () => {
+      const recipes = [
+        createDismissed('quitoque', 'url-1', 'Recipe 1'),
+        createDismissed('hellofresh', 'url-2', 'Recipe 2'),
+        createDismissed('quitoque', 'url-3', 'Recipe 3'),
+      ];
+
+      const groups = groupDismissedRecipesByProvider(recipes, upperCaseName);
+
+      expect(groups.map(g => g.providerId)).toEqual(['quitoque', 'hellofresh']);
+      expect(groups[0].recipes).toHaveLength(2);
+      expect(groups[1].recipes).toHaveLength(1);
+    });
+
+    test('preserves input order within a group', () => {
+      const recipes = [
+        createDismissed('hellofresh', 'url-1', 'First'),
+        createDismissed('hellofresh', 'url-2', 'Second'),
+      ];
+
+      const groups = groupDismissedRecipesByProvider(recipes, upperCaseName);
+
+      expect(groups[0].recipes.map(r => r.title)).toEqual(['First', 'Second']);
     });
   });
 });

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -2403,4 +2403,147 @@ describe('RecipeDatabase', () => {
       expect(db.get_recipes()).toBeDefined();
     });
   });
+
+  describe('Dismissed recipes', () => {
+    const db = RecipeDatabase.getInstance();
+
+    beforeEach(async () => {
+      await db.init();
+    });
+
+    afterEach(async () => {
+      await db.closeAndReset();
+    });
+
+    test('getDismissedUrls is empty initially', () => {
+      expect(db.getDismissedUrls('hellofresh').size).toBe(0);
+    });
+
+    test('markRecipesAsDismissed stores the URL', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' },
+      ]);
+
+      expect(db.getDismissedUrls('hellofresh').has('https://hellofresh.com/recipe-1')).toBe(true);
+    });
+
+    test('getDismissedRecipes returns records with titles', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' },
+      ]);
+
+      const dismissed = db.getDismissedRecipes('hellofresh');
+      expect(dismissed).toHaveLength(1);
+      expect(dismissed[0].title).toBe('Recipe 1');
+      expect(dismissed[0].recipeUrl).toBe('https://hellofresh.com/recipe-1');
+    });
+
+    test('getDismissedRecipes sorts most-recently-dismissed first', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/old', title: 'Old' },
+      ]);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/new', title: 'New' },
+      ]);
+
+      const dismissed = db.getDismissedRecipes('hellofresh');
+      expect(dismissed[0].title).toBe('New');
+      expect(dismissed[1].title).toBe('Old');
+    });
+
+    test('does not duplicate an already dismissed URL', async () => {
+      const recipe = { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' };
+      await db.markRecipesAsDismissed('hellofresh', [recipe]);
+      await db.markRecipesAsDismissed('hellofresh', [recipe]);
+
+      expect(db.getDismissedRecipes('hellofresh')).toHaveLength(1);
+    });
+
+    test('scopes dismissed URLs by provider', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'HF' },
+      ]);
+      await db.markRecipesAsDismissed('quitoque', [
+        { url: 'https://quitoque.fr/recipe-1', title: 'QT' },
+      ]);
+
+      expect(db.getDismissedUrls('hellofresh').size).toBe(1);
+      expect(db.getDismissedUrls('quitoque').size).toBe(1);
+      expect(db.getDismissedUrls('hellofresh').has('https://quitoque.fr/recipe-1')).toBe(false);
+    });
+
+    test('restoreDismissedRecipes removes the URL', async () => {
+      const url = 'https://hellofresh.com/recipe-1';
+      await db.markRecipesAsDismissed('hellofresh', [{ url, title: 'Recipe 1' }]);
+
+      await db.restoreDismissedRecipes('hellofresh', [url]);
+
+      expect(db.getDismissedUrls('hellofresh').has(url)).toBe(false);
+      expect(db.getDismissedRecipes('hellofresh')).toHaveLength(0);
+    });
+
+    test('markRecipesAsDismissed with empty array is a no-op', async () => {
+      await db.markRecipesAsDismissed('hellofresh', []);
+
+      expect(db.getDismissedRecipes('hellofresh')).toHaveLength(0);
+    });
+
+    test('restoreDismissedRecipes with empty array is a no-op', async () => {
+      const url = 'https://hellofresh.com/recipe-1';
+      await db.markRecipesAsDismissed('hellofresh', [{ url, title: 'Recipe 1' }]);
+
+      await db.restoreDismissedRecipes('hellofresh', []);
+
+      expect(db.getDismissedUrls('hellofresh').has(url)).toBe(true);
+    });
+
+    test('getDismissedRecipes without a provider returns records from every provider', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'HF' },
+      ]);
+      await db.markRecipesAsDismissed('quitoque', [
+        { url: 'https://quitoque.fr/recipe-1', title: 'QT' },
+      ]);
+
+      const dismissed = db.getDismissedRecipes();
+
+      expect(dismissed).toHaveLength(2);
+      expect(dismissed.map(r => r.providerId).sort()).toEqual(['hellofresh', 'quitoque']);
+    });
+
+    test('markRecipesAsDismissed stores the provided image URL', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        {
+          url: 'https://hellofresh.com/recipe-1',
+          title: 'Recipe 1',
+          imageUrl: 'https://hellofresh.com/image-1.jpg',
+        },
+      ]);
+
+      expect(db.getDismissedRecipes('hellofresh')[0].imageUrl).toBe(
+        'https://hellofresh.com/image-1.jpg'
+      );
+    });
+
+    test('markRecipesAsDismissed defaults a missing image URL to an empty string', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' },
+      ]);
+
+      expect(db.getDismissedRecipes('hellofresh')[0].imageUrl).toBe('');
+    });
+
+    test('restoreDismissedRecipes only removes the provided URLs', async () => {
+      await db.markRecipesAsDismissed('hellofresh', [
+        { url: 'https://hellofresh.com/recipe-1', title: 'Recipe 1' },
+        { url: 'https://hellofresh.com/recipe-2', title: 'Recipe 2' },
+      ]);
+
+      await db.restoreDismissedRecipes('hellofresh', ['https://hellofresh.com/recipe-1']);
+
+      expect(db.getDismissedUrls('hellofresh').has('https://hellofresh.com/recipe-1')).toBe(false);
+      expect(db.getDismissedUrls('hellofresh').has('https://hellofresh.com/recipe-2')).toBe(true);
+    });
+  });
 });

--- a/tests/unit/utils/time.test.ts
+++ b/tests/unit/utils/time.test.ts
@@ -1,0 +1,21 @@
+import { epochMillis } from '@utils/time';
+
+describe('epochMillis', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the current epoch milliseconds from the platform clock', () => {
+    const fixed = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockReturnValue(fixed);
+
+    expect(epochMillis()).toBe(fixed);
+  });
+
+  it('returns an integer value', () => {
+    const result = epochMillis();
+
+    expect(Number.isInteger(result)).toBe(true);
+    expect(result).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

Let users permanently dismiss ("Never show again") recipes during bulk-import discovery, and manage/restore them from a dedicated settings screen.

Closes #326

## Changes

- **`feat(bulk-import): dismiss recipes from discovery`**
  - New `DismissedRecipesTable` persisting provider, url, and denormalized `title`/`imageUrl` so the manage list needs no re-discovery.
  - New `'dismissed'` `ImportMemoryStatus` — dismissed recipes are filtered out of every future discovery run (takes precedence over `imported`/`seen`).
  - `RecipeSelectionCard` gains a "Never show again" action with an in-place dimmed/struck state and Undo until the user confirms with Continue.
  - Two-phase dismissal: session-pending in `useDiscoveryWorkflow`, persisted to the DB only on Continue via `commitDismissals` (parallel with `markUrlsAsSeen`).
  - New `DismissedRecipesSettings` screen — dismissed recipes grouped per provider in accordions, each restorable; reachable from the Parameters "Bulk Import" section.

- **`feat(time): add epochMillis wall-clock seam`**
  - Single source of truth for timestamps (`src/utils/time.ts`); business logic and persistence no longer touch `Date` directly, enabling deterministic time in tests. Refs #403.

- **`docs(architecture): document dismissed recipes table`**

## Notes

- The dismissed record captures the recipe object passed at dismiss time (already merged with the visibility-loaded `imageMap`), so the persisted thumbnail matches what the user saw — not the raw, often-empty discovery `imageUrl`. Covered by a regression test.

## Testing

- New unit suites: `time`, `DismissedRecipeCard`, `DismissedRecipesSettings`, plus additions to `useDiscoveryWorkflow`, `useImportMemory`, `RecipeDatabase`, `BulkImportUtils`, `Parameters`, `RecipeSelectionCard` and the perf harness.
- Full changed suites green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
