### PR TITLE
ci(perf): fix flashlight script split by emulator-runner

### DIFF
--- a/.github/scripts/run-perf-screens.sh
+++ b/.github/scripts/run-perf-screens.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Profiles each performance screen flow with Flashlight, one at a time.
+#
+# Must live in its own file (not inline in the workflow's emulator-runner
+# `script:` block): reactivecircus/android-emulator-runner splits that block on
+# newlines and runs each line via a separate `sh -c`, so multi-line constructs
+# (for loops, function definitions, backslash continuations) are impossible
+# there. Invoking this script is a single line, so it runs as one shell.
+#
+# Usage: run-perf-screens.sh <apk-path>
+
+set -u
+
+APK_PATH="$1"
+FLASHLIGHT="$HOME/.flashlight/bin/flashlight"
+SCREENS_DIR="tests/e2e/cases/performance/screens"
+
+sleep 10
+echo "🔄 Waiting for device..."
+adb wait-for-device
+
+adb install "$APK_PATH"
+
+mkdir -p perf-results perf-reports maestro_logs_performance
+
+run_screen() {
+  local case="$1"
+  local name="$2"
+  "$FLASHLIGHT" test \
+    --bundleId "com.recipedia" \
+    --testCommand "maestro test $case --debug-output=maestro_logs_performance/$name" \
+    --resultsFilePath "perf-results/$name.json" \
+    --duration 300000 \
+    --iterationCount 3
+}
+
+# 00_seed runs first (clearState seeds the DB); the warm screens reuse that
+# seeded DB, so screens must run in filename order. Each screen is profiled with
+# 3 iterations (averages out noise). --duration is a per-iteration cap; 5 min
+# covers the heaviest flow (parameters re-scales all ~1200 recipes) and
+# flashlight stops early when a flow finishes.
+for case in "$SCREENS_DIR"/*.yaml; do
+  name=$(basename "$case" .yaml)
+  echo "▶ $name"
+  # One retry absorbs transient flakiness (e.g. an ANR dialog); on a second
+  # failure we move on so the remaining screens still run.
+  run_screen "$case" "$name" \
+    || { echo "::warning::retrying $name"; run_screen "$case" "$name" || echo "::warning::$name failed"; }
+  "$FLASHLIGHT" report \
+    --resultsFilePath "perf-results/$name.json" \
+    --outputFilePath "perf-reports/$name.html" || true
+done

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -152,38 +152,10 @@ jobs:
           arch: x86_64
           profile: Nexus 5
           emulator-options: -no-snapshot -no-window -noaudio -no-boot-anim -wipe-data -memory 4096 -cores 4
-          script: |
-            sleep 10
-            echo "🔄 Waiting for device..."
-            adb wait-for-device
-
-            adb install "${{ steps.find-apk.outputs.apk_path }}"
-
-            mkdir -p perf-results perf-reports maestro_logs_performance
-
-            # 00_seed runs first (clearState seeds the DB); the warm screens reuse
-            # that seeded DB, so screens must run in filename order. Each screen is
-            # profiled with 3 iterations (averages out noise). --duration is a
-            # per-iteration cap; 5 min covers the heaviest flow (parameters re-scales
-            # all ~1200 recipes) and flashlight stops early when a flow finishes.
-            for case in tests/e2e/cases/performance/screens/*.yaml; do
-              name=$(basename "$case" .yaml)
-              run_screen() {
-                ~/.flashlight/bin/flashlight test \
-                  --bundleId "com.recipedia" \
-                  --testCommand "maestro test $case --debug-output=maestro_logs_performance/$name" \
-                  --resultsFilePath "perf-results/$name.json" \
-                  --duration 300000 \
-                  --iterationCount 3
-              }
-              echo "▶ $name"
-              # One retry absorbs transient flakiness (e.g. an ANR dialog); on a
-              # second failure we move on so the remaining screens still run.
-              run_screen || { echo "::warning::retrying $name"; run_screen || echo "::warning::$name failed"; }
-              ~/.flashlight/bin/flashlight report \
-                --resultsFilePath "perf-results/$name.json" \
-                --outputFilePath "perf-reports/$name.html" || true
-            done
+          # android-emulator-runner splits `script` on newlines and runs each
+          # line via a separate `sh -c`, so the profiling loop lives in its own
+          # file (run as one shell) — see run-perf-screens.sh.
+          script: bash .github/scripts/run-perf-screens.sh "${{ steps.find-apk.outputs.apk_path }}"
 
       # A broken flow (no result) fails; FPS regressions only warn (single-run
       # device FPS is too noisy to hard-gate). Writes the merged FPS table to the UI.


### PR DESCRIPTION
## Problem

The **Run Flashlight Performance Tests** CI job aborted before any screen ran:

```
/usr/bin/sh -c for case in tests/e2e/cases/performance/screens/*.yaml; do
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting "done")
Error: The process '/usr/bin/sh' failed with exit code 2
```

## Root cause

`reactivecircus/android-emulator-runner` does not run the `script:` block as one shell. Its `parseScript` splits on newlines, drops comment/blank lines, and runs **each remaining line via a separate `sh -c`**:

```js
rawScript.trim().split(/\r\n|\n|\r/).map(v => v.trim())
  .filter(v => !v.startsWith('#') && v.length > 0)
// → for (const line of scripts) exec('sh', ['-c', line])
```

So the multi-line `for … done` loop, the `run_screen()` function, and `\` continuations were impossible inline. The loop's first line `for … do` ran alone → `unexpected end of file`, exit 2.

## Fix

Move the profiling loop into `.github/scripts/run-perf-screens.sh` (runs as one `bash` process) and invoke it as a single line:

```yaml
script: bash .github/scripts/run-perf-screens.sh "${{ steps.find-apk.outputs.apk_path }}"
```

Behavior preserved: device wait, install, `mkdir`, filename-ordered screen loop, one-retry-then-skip, per-screen HTML report.

## Verification (local)

- Replicated the runner's `parseScript` + per-line `sh -c` loop → old block reproduces the exact CI error (`unexpected end of file`, exit 2).
- Ran the new single-line invocation through the same emulation with stubbed `adb`/`flashlight`: full loop executes end-to-end — all 7 screens in filename order, retry path fires correctly, report per screen, exit 0.
- `bash -n` clean; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)