### PR TITLE
fix(db): map insert values by column name not key order

### DIFF
--- a/src/utils/TableManipulation.tsx
+++ b/src/utils/TableManipulation.tsx
@@ -535,45 +535,53 @@ export class TableManipulation {
     return [result, params];
   }
 
-  protected verifyLengthOfElement<TElement extends string>(element: TElement[]) {
-    let isCheck: boolean = true;
-    if (element.length > this.m_columnsTable.length + 1) {
-      databaseLogger.warn(
-        'ERROR: you try to add an element in a table that is not mapping. Impossible to add this. Size of column table is ',
-        this.m_columnsTable.length,
-        ' and size of element is ',
-        element.length,
-        '\n\nelement : ',
-        element
-      );
-      isCheck = false;
+  /**
+   * Encodes an element's values in the exact order of {@link m_columnsTable}.
+   *
+   * Values are read by column name — never by object-key iteration order — so a
+   * future reordering of an encoder's object literal can never silently write a
+   * value into the wrong column. Booleans are normalised to SQLite's `'1'`/`'0'`.
+   *
+   * @param element - Object keyed by column name (plus an ignored `ID` key)
+   * @returns Encoded string values in column order, or `undefined` when the
+   *   element's non-ID keys do not exactly match the table columns
+   */
+  private encodeElementInColumnOrder<TElement>(element: TElement): string[] | undefined {
+    const nonIdKeys = Object.keys(element as object).filter(key => key !== this.m_idColumn);
+    if (nonIdKeys.length !== this.m_columnsTable.length) {
+      return undefined;
     }
-    return isCheck;
+
+    const values: string[] = [];
+    for (const col of this.m_columnsTable) {
+      if (!Object.prototype.hasOwnProperty.call(element, col.colName)) {
+        return undefined;
+      }
+      const valueToPush = (element[col.colName as keyof TElement] as string).toString();
+      if (valueToPush === 'false') {
+        values.push('0');
+      } else if (valueToPush === 'true') {
+        values.push('1');
+      } else {
+        values.push(valueToPush);
+      }
+    }
+    return values;
   }
 
   protected prepareInsertQuery<TElement>(
     elementToInsert: TElement | TElement[]
   ): [string, string[]] {
-    type TElementKey = keyof TElement;
-
     let insertQuery =
       `INSERT INTO "${this.m_tableName}" ("` +
       this.m_columnsTable.map(col => col.colName).join('","') +
       '") VALUES ';
-    const returnValues = [];
+    const returnValues: string[] = [];
 
     if (!(elementToInsert instanceof Array)) {
-      for (const key of Object.keys(elementToInsert as object).filter(key => key !== 'ID')) {
-        const valueToPush = (elementToInsert[key as TElementKey] as string).toString();
-        if (valueToPush.toString() === 'false') {
-          returnValues.push('0');
-        } else if (valueToPush === 'true') {
-          returnValues.push('1');
-        } else {
-          returnValues.push(valueToPush);
-        }
-      }
-      if (this.verifyLengthOfElement(returnValues)) {
+      const values = this.encodeElementInColumnOrder(elementToInsert);
+      if (values) {
+        returnValues.push(...values);
         insertQuery += '(' + returnValues.map(() => '?').join(',') + ');';
       } else {
         insertQuery = '';
@@ -582,21 +590,10 @@ export class TableManipulation {
       const placeHolders = [];
 
       for (const element of elementToInsert) {
-        const elementValues = [];
-
-        for (const key of Object.keys(element as object).filter(key => key !== 'ID')) {
-          const valueToPush = (element[key as TElementKey] as TElementKey).toString();
-          if (valueToPush === 'false') {
-            elementValues.push('0');
-          } else if (valueToPush === 'true') {
-            elementValues.push('1');
-          } else {
-            elementValues.push(valueToPush);
-          }
-        }
-        if (this.verifyLengthOfElement(elementValues)) {
-          placeHolders.push('(' + elementValues.map(() => '?').join(',') + ')');
-          returnValues.push(...elementValues);
+        const values = this.encodeElementInColumnOrder(element);
+        if (values) {
+          placeHolders.push('(' + values.map(() => '?').join(',') + ')');
+          returnValues.push(...values);
         }
       }
       insertQuery += placeHolders.join(',') + ';';

--- a/tests/unit/utils/TableManipulation.test.tsx
+++ b/tests/unit/utils/TableManipulation.test.tsx
@@ -76,6 +76,56 @@ describe('TableManipulation', () => {
     ).toBeUndefined();
   });
 
+  test('insertElement maps values by column name regardless of object key order', async () => {
+    await table.createTable(DB);
+
+    const reversedKeyOrder = { age: 30, name: 'John' };
+    const id = await table.insertElement<TestDbType>(reversedKeyOrder, DB);
+
+    expect(await table.searchElementById(id as number, DB)).toEqual({
+      ID: id,
+      name: 'John',
+      age: 30,
+    });
+  });
+
+  test('insertElement rejects an element whose keys do not match the columns', async () => {
+    await table.createTable(DB);
+
+    const wrongKeyName = { name: 'John', country: 'Mexico' };
+    expect(await table.insertElement(wrongKeyName, DB)).toBeUndefined();
+  });
+
+  test('insertElement encodes boolean values as SQLite 1 and 0', async () => {
+    const booleanColumns: databaseColumnType[] = [
+      { colName: 'enabled', type: encodedType.INTEGER },
+      { colName: 'archived', type: encodedType.INTEGER },
+    ];
+    const booleanTable = new TableManipulation('BooleanTable', booleanColumns);
+    await booleanTable.createTable(DB);
+
+    const id = await booleanTable.insertElement({ enabled: true, archived: false }, DB);
+
+    expect(await booleanTable.searchElementById(id as number, DB)).toEqual({
+      ID: id,
+      enabled: 1,
+      archived: 0,
+    });
+  });
+
+  test('insertArrayOfElement maps values by column name regardless of object key order', async () => {
+    await table.createTable(DB);
+
+    const reversedKeyOrder = new Array<TestDbType>(
+      { age: 30, name: 'John' },
+      { age: 8, name: 'Toto' }
+    );
+    expect(await table.insertArrayOfElement(reversedKeyOrder, DB)).toEqual(true);
+
+    expect(await table.searchElementById(1, DB)).toEqual({ ID: 1, name: 'John', age: 30 });
+    expect(await table.searchElementById(2, DB)).toEqual({ ID: 2, name: 'Toto', age: 8 });
+  });
+
   test('insertArrayOfElement should add multiple elements at once', async () => {
     await table.createTable(DB);
 


### PR DESCRIPTION
## Context

Closes #361.

`prepareInsertQuery` (`src/utils/TableManipulation.tsx`) mapped values to columns by `Object.keys(element)` iteration order, trusting it to match `m_columnsTable` order. No explicit key→column mapping existed. Worked only because every encoder happens to build its object literal in exact column order — any future reorder of an encoder literal would **silently write values into the wrong columns with no error**.

Concrete latent trap: `encodedMenuElement` type declares `COUNT` as the 3rd field, but the `encodeMenu` literal writes it last (matching column order). Aligning the literal to the type's field order would have silently written `COUNT` into the `RECIPE_TITLE` column.

## Change

- New `encodeElementInColumnOrder` helper reads values by `m_columnsTable[i].colName` explicitly — never by object-key iteration order.
- Rejects elements whose non-ID keys don't exactly match the table columns (preserves prior reject-on-mismatch behavior, now also catches wrong-key/right-count objects the old code silently mis-inserted).
- Drops now-redundant `verifyLengthOfElement` (its length guard is subsumed by the exact-match check).

## Tests (TDD)

Added failing-first tests, then fixed:
- reversed-key insert (single + array) → values land in correct columns
- key-mismatch element → rejected
- boolean → SQLite `1`/`0` encoding

New helper fully branch-covered.

## Verification

- unit: 3727 passed
- integration: 77 passed (real DB encode→insert path)
- typecheck / eslint / prettier / docs:build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)