### PR TITLE
test(e2e): suppress emulator ANR dialogs + disable animations in CI

### DIFF
--- a/.github/scripts/run-e2e-android.sh
+++ b/.github/scripts/run-e2e-android.sh
@@ -6,6 +6,13 @@ SUITE="$1"
 
 echo "🔄 Waiting for device..."
 adb wait-for-device
+
+echo "🛡️  Suppressing system error/ANR dialogs and disabling animations..."
+adb shell settings put global hide_error_dialogs 1
+adb shell settings put global window_animation_scale 0
+adb shell settings put global transition_animation_scale 0
+adb shell settings put global animator_duration_scale 0
+
 adb logcat -c
 
 echo "🚀 Running E2E tests on suite: $SUITE ..."

--- a/tests/e2e/E2E_TESTING.md
+++ b/tests/e2e/E2E_TESTING.md
@@ -1424,6 +1424,26 @@ search, Pattern B when it wants to keep browsing with the current filter.
 - pressKey: 'BACK'
 ```
 
+## Emulator Dialog Suppression (Android CI)
+
+`.github/scripts/run-e2e-android.sh` applies these emulator settings before
+running Maestro, once the device is booted:
+
+```bash
+adb shell settings put global hide_error_dialogs 1      # no system crash/ANR dialogs
+adb shell settings put global window_animation_scale 0
+adb shell settings put global transition_animation_scale 0
+adb shell settings put global animator_duration_scale 0
+```
+
+`hide_error_dialogs 1` stops the launcher ANR dialog
+(`Pixel Launcher isn't responding`) from ever rendering, which was tripping
+visibility assertions on CI despite the app rendering correctly.
+
+`handleAnr.yaml` is kept as a guarded no-op safety net for **local** emulators,
+which run bare `maestro test` and do not get these adb settings. New flows do
+not need `handleAnr.yaml` when they only target CI.
+
 ## CI Retry Mechanism
 
 E2E tests can fail on CI due to infrastructure flakiness — ANR dialogs, scroll


### PR DESCRIPTION
## Problem

Android E2E suites intermittently failed because a system-level `Pixel Launcher isn't responding` ANR dialog popped up on the CI emulator under CPU starvation, sitting on top of the correctly-rendered app. Visibility assertions tripped on the dialog instead of the real screen (see run 29162853870, all 7 `performance` flows failing at `Wait for Home screen`).

## Fix

`.github/scripts/run-e2e-android.sh` now applies emulator settings once the device is booted, before Maestro runs:

```bash
adb shell settings put global hide_error_dialogs 1        # dialog never renders
adb shell settings put global window_animation_scale 0
adb shell settings put global transition_animation_scale 0
adb shell settings put global animator_duration_scale 0
```

`hide_error_dialogs 1` is the root fix — the launcher ANR dialog never renders, so Maestro can't trip on it. Animation-scale zeroing is belt-and-suspenders over the emulator-runner's `disable-animations: true`.

## handleAnr.yaml kept (intentional)

Acceptance #2 allows removing/reducing `handleAnr.yaml`. Kept it as a **guarded no-op safety net**: local runs use bare `maestro test` with no adb wrapper, so they don't get `hide_error_dialogs`. Ripping it out (4 flows, 12 call sites) would reinstate local flakiness for zero CI benefit. Documented its status in `E2E_TESTING.md`.

## Acceptance

- [x] CI emulator setup applies `hide_error_dialogs` + animation-disable
- [x] `handleAnr.yaml` reduced to documented local safety net
- [ ] Re-run `performance` suite green (verified on CI)

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)