### PR TITLE
fix(app): add error boundaries with crash report + retry (#352)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import {PaperProvider} from 'react-native-paper';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {darkTheme, lightTheme} from '@styles/theme';
 import AppWrapper from '@components/organisms/AppWrapper';
+import {ErrorBoundary} from '@components/organisms/ErrorBoundary';
 import {getDarkMode, initSettings, setDarkMode as setDarkModeSetting,} from '@utils/settings';
 import * as SplashScreen from 'expo-splash-screen';
 import {useFetchFonts} from '@styles/typography';
@@ -146,9 +147,13 @@ export function App() {
     useFetchFonts();
 
     return (
-        <ScraperProvider>
-            <AppContent/>
-        </ScraperProvider>
+        <SafeAreaProvider>
+            <ErrorBoundary>
+                <ScraperProvider>
+                    <AppContent/>
+                </ScraperProvider>
+            </ErrorBoundary>
+        </SafeAreaProvider>
     );
 }
 

--- a/src/components/molecules/ErrorFallback.tsx
+++ b/src/components/molecules/ErrorFallback.tsx
@@ -1,0 +1,130 @@
+/**
+ * ErrorFallback - Recovery UI shown when an {@link ErrorBoundary} catches a render error.
+ *
+ * Presentational component with two variants:
+ * - recoverable (default): icon, title, message and a single "report & retry" action.
+ *   Pressing it sends an automatic crash report and then lets the boundary re-mount
+ *   the children, so the one button both reports and recovers.
+ * - persistent (`persistent`): shown after a retry already failed once - icon, title and
+ *   a "please restart" message, with no action, since retrying is proven futile.
+ *
+ * Text is start-aligned (not centred) for readability, and the insets are consumed
+ * directly so it lays out correctly even when the root boundary catches a crash that
+ * happens above the app's own SafeAreaProvider.
+ */
+
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button, Icon, Text, useTheme } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useI18n } from '@utils/i18n';
+import { padding } from '@styles/spacing';
+import { Icons } from '@assets/Icons';
+
+export type ErrorFallbackProps = {
+  onReport?: () => Promise<void>;
+  persistent?: boolean;
+  testID?: string;
+};
+
+const ICON_SIZE = 40;
+
+export function ErrorFallback({
+  onReport,
+  persistent = false,
+  testID = 'ErrorFallback',
+}: ErrorFallbackProps) {
+  const { t } = useI18n();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const [reporting, setReporting] = useState(false);
+
+  const handleReport = onReport
+    ? async () => {
+        setReporting(true);
+        try {
+          await onReport();
+        } finally {
+          setReporting(false);
+        }
+      }
+    : undefined;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: insets.top + padding.veryLarge,
+          paddingBottom: insets.bottom + padding.veryLarge,
+        },
+      ]}
+      testID={testID}
+    >
+      <View style={styles.content}>
+        <View style={styles.header}>
+          <Icon source={Icons.alertWithCircle} size={ICON_SIZE} color={colors.error} />
+          <Text
+            variant='headlineSmall'
+            accessibilityRole='header'
+            style={[styles.title, { color: colors.onSurface }]}
+            testID={`${testID}::Title`}
+          >
+            {t('errorBoundary.title')}
+          </Text>
+        </View>
+        <Text
+          variant='bodyMedium'
+          style={{ color: colors.onSurfaceVariant }}
+          testID={`${testID}::Message`}
+        >
+          {t(persistent ? 'errorBoundary.persistentMessage' : 'errorBoundary.message')}
+        </Text>
+      </View>
+      {handleReport && (
+        <Button
+          mode='contained'
+          buttonColor={colors.errorContainer}
+          textColor={colors.onErrorContainer}
+          onPress={handleReport}
+          loading={reporting}
+          disabled={reporting}
+          style={styles.action}
+          testID={`${testID}::Report`}
+        >
+          {t('errorBoundary.report')}
+        </Button>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: padding.veryLarge,
+  },
+  content: {
+    width: '100%',
+    maxWidth: 440,
+    alignItems: 'flex-start',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: padding.medium,
+    marginBottom: padding.extraLarge,
+  },
+  title: {
+    flex: 1,
+  },
+  action: {
+    width: '100%',
+    maxWidth: 440,
+  },
+});
+
+export default ErrorFallback;

--- a/src/components/organisms/ErrorBoundary.tsx
+++ b/src/components/organisms/ErrorBoundary.tsx
@@ -1,0 +1,114 @@
+/**
+ * ErrorBoundary - React error boundary guarding a subtree against render crashes.
+ *
+ * Any error thrown while rendering, in a lifecycle method, or in a constructor of
+ * a descendant is caught here, logged, and replaced by an {@link ErrorFallback}
+ * recovery screen instead of unmounting the whole app. The fallback's single action
+ * sends a crash report and then re-mounts the children (an automatic retry). If that
+ * retry crashes again, the fallback switches to a "please restart" message with no
+ * action, since retrying is proven futile.
+ *
+ * Also hides the native splash screen on catch: an early first-render crash happens
+ * before {@link https://docs.expo.dev/versions/latest/sdk/splash-screen | SplashScreen.hideAsync}
+ * is reached in `App`, which would otherwise leave the fallback hidden behind the splash.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundary>
+ *   <AppContent />
+ * </ErrorBoundary>
+ * ```
+ */
+
+import React, { Component, ComponentType, ErrorInfo, ReactNode } from 'react';
+import * as SplashScreen from 'expo-splash-screen';
+import { ErrorFallback } from '@components/molecules/ErrorFallback';
+import { appLogger } from '@utils/logger';
+import { reportCrash } from '@utils/BugReport';
+
+export type ErrorBoundaryProps = {
+  children: ReactNode;
+  testID?: string;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error: Error | null;
+  componentStack: string | null;
+  retriedOnce: boolean;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    componentStack: null,
+    retriedOnce: false,
+  };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    appLogger.error('Render error caught by ErrorBoundary', {
+      error,
+      componentStack: errorInfo.componentStack,
+    });
+
+    this.setState({ componentStack: errorInfo.componentStack ?? null });
+
+    SplashScreen.hideAsync().catch(() => {});
+  }
+
+  override componentDidUpdate(_prevProps: ErrorBoundaryProps, prevState: ErrorBoundaryState) {
+    if (prevState.hasError && !this.state.hasError && this.state.retriedOnce) {
+      this.setState({ retriedOnce: false });
+    }
+  }
+
+  reportAndRecover = async (): Promise<void> => {
+    await reportCrash(
+      this.state.error ?? new Error('Unknown render error'),
+      this.state.componentStack
+    );
+    this.setState({ hasError: false, error: null, componentStack: null, retriedOnce: true });
+  };
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorFallback
+          persistent={this.state.retriedOnce}
+          onReport={this.state.retriedOnce ? undefined : this.reportAndRecover}
+          testID={this.props.testID}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * Wraps a component in an {@link ErrorBoundary} so a render crash inside it is
+ * contained instead of taking down the whole navigation tree.
+ *
+ * @param WrappedComponent - the component to protect
+ * @param testID - optional testID forwarded to the boundary's fallback
+ * @returns a component rendering `WrappedComponent` inside an error boundary
+ */
+export function withErrorBoundary<P extends object>(
+  WrappedComponent: ComponentType<P>,
+  testID?: string
+): ComponentType<P> {
+  const Guarded = (props: P) => (
+    <ErrorBoundary testID={testID}>
+      <WrappedComponent {...props} />
+    </ErrorBoundary>
+  );
+  Guarded.displayName = `withErrorBoundary(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+  return Guarded;
+}
+
+export default ErrorBoundary;

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -73,6 +73,11 @@ import { BugReport } from '@screens/BugReport';
 import { Stack } from '@customTypes/ScreenTypes';
 import { BottomTabs } from '@navigation/BottomTabs';
 import { navigationLogger } from '@utils/logger';
+import { withErrorBoundary } from '@components/organisms/ErrorBoundary';
+
+const GuardedBulkImportDiscovery = withErrorBoundary(BulkImportDiscovery);
+const GuardedRecipeAddOcr = withErrorBoundary(RecipeAddOcr);
+const GuardedRecipeAddScrape = withErrorBoundary(RecipeAddScrape);
 
 /**
  * RootNavigator component - Main app navigation container
@@ -101,15 +106,15 @@ export function RootNavigator() {
       <Stack.Screen name='RecipeView' component={RecipeView} />
       <Stack.Screen name='RecipeEdit' component={RecipeEdit} />
       <Stack.Screen name='RecipeAddManual' component={RecipeAddManual} />
-      <Stack.Screen name='RecipeAddOcr' component={RecipeAddOcr} />
-      <Stack.Screen name='RecipeAddScrape' component={RecipeAddScrape} />
+      <Stack.Screen name='RecipeAddOcr' component={GuardedRecipeAddOcr} />
+      <Stack.Screen name='RecipeAddScrape' component={GuardedRecipeAddScrape} />
       <Stack.Screen name='LanguageSettings' component={LanguageSettings} />
       <Stack.Screen name='DefaultPersonsSettings' component={DefaultPersonsSettings} />
       <Stack.Screen name='IngredientsSettings' component={IngredientsSettings} />
       <Stack.Screen name='TagsSettings' component={TagsSettings} />
       <Stack.Screen name='BulkImportSettings' component={BulkImportSettings} />
       <Stack.Screen name='DismissedRecipesSettings' component={DismissedRecipesSettings} />
-      <Stack.Screen name='BulkImportDiscovery' component={BulkImportDiscovery} />
+      <Stack.Screen name='BulkImportDiscovery' component={GuardedBulkImportDiscovery} />
       <Stack.Screen name='BulkImportValidation' component={BulkImportValidation} />
       <Stack.Screen name='BugReport' component={BugReport} />
     </Stack.Navigator>

--- a/src/translations/en/errorBoundary.ts
+++ b/src/translations/en/errorBoundary.ts
@@ -1,0 +1,6 @@
+export default {
+  title: 'Something went wrong',
+  message: 'The app ran into an unexpected error. Your saved recipes are safe.',
+  report: 'Report & retry',
+  persistentMessage: 'The problem is still happening. Please restart the app.',
+};

--- a/src/translations/en/index.ts
+++ b/src/translations/en/index.ts
@@ -12,12 +12,14 @@ import months from './months';
 import onboarding from './onboarding';
 import bulkImport from './bulkImport';
 import bugReport from './bugReport';
+import errorBoundary from './errorBoundary';
 
 export default {
   ...common,
   ...parameters,
   bulkImport,
   bugReport,
+  errorBoundary,
   ...seasons,
   ...months,
   ...recipe,

--- a/src/translations/fr/errorBoundary.ts
+++ b/src/translations/fr/errorBoundary.ts
@@ -1,0 +1,7 @@
+export default {
+  title: 'Une erreur est survenue',
+  message:
+    "L'application a rencontré une erreur inattendue. Vos recettes enregistrées sont intactes.",
+  report: 'Signaler et réessayer',
+  persistentMessage: "Le problème persiste. Veuillez redémarrer l'application.",
+};

--- a/src/translations/fr/index.ts
+++ b/src/translations/fr/index.ts
@@ -12,12 +12,14 @@ import months from './months';
 import onboarding from './onboarding';
 import bulkImport from './bulkImport';
 import bugReport from './bugReport';
+import errorBoundary from './errorBoundary';
 
 export default {
   ...common,
   ...parameters,
   bulkImport,
   bugReport,
+  errorBoundary,
   ...seasons,
   ...months,
   ...recipe,

--- a/src/utils/BugReport.ts
+++ b/src/utils/BugReport.ts
@@ -14,7 +14,12 @@
  * ```
  */
 
-import { composeAsync, isAvailableAsync, MailComposerResult } from 'expo-mail-composer';
+import {
+  composeAsync,
+  isAvailableAsync,
+  MailComposerResult,
+  MailComposerStatus,
+} from 'expo-mail-composer';
 import { File, Paths } from 'expo-file-system';
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
@@ -158,6 +163,73 @@ export async function sendBugReport(
  */
 export async function isMailAvailable(): Promise<boolean> {
   return isAvailableAsync();
+}
+
+/**
+ * Outcome of an automatic crash report attempt.
+ *
+ * - `sent`: the mail composer reported the report as sent.
+ * - `cancelled`: the user dismissed the mail composer without sending.
+ * - `mail_unavailable`: no mail app is configured on the device.
+ * - `error`: the mail composer failed to open or threw.
+ */
+export type CrashReportOutcome = 'sent' | 'cancelled' | 'mail_unavailable' | 'error';
+
+/**
+ * Builds the pre-filled description for an automatic crash report.
+ *
+ * The full error (with its stack) is already written to the log files by the
+ * error boundary, which are attached to the report; this description gives the
+ * developer an immediate summary without opening the logs.
+ *
+ * @param error - The error caught by the boundary
+ * @param componentStack - React component stack from `componentDidCatch`, if available
+ * @returns Formatted crash description
+ */
+export function buildCrashDescription(error: Error, componentStack: string | null): string {
+  return [
+    'Automatic crash report — the app recovered from an unexpected error.',
+    '',
+    `Error: ${error.message || 'Unknown error'}`,
+    '',
+    'Component stack:',
+    componentStack ?? 'unavailable',
+  ].join('\n');
+}
+
+/**
+ * Composes and sends an automatic crash report email for an error caught by an
+ * error boundary, attaching the recent log files and device info.
+ *
+ * Does not throw: failures are reported through the returned {@link CrashReportOutcome}
+ * so the recovery UI can surface them to the user.
+ *
+ * @param error - The error caught by the boundary
+ * @param componentStack - React component stack from `componentDidCatch`, if available
+ * @returns Promise resolving to the report outcome
+ */
+export async function reportCrash(
+  error: Error,
+  componentStack: string | null
+): Promise<CrashReportOutcome> {
+  if (!(await isMailAvailable())) {
+    bugReportLogger.warn('Crash report skipped: mail unavailable');
+    return 'mail_unavailable';
+  }
+
+  try {
+    const result = await sendBugReport(buildCrashDescription(error, componentStack), []);
+    if (result.status === MailComposerStatus.SENT) {
+      return 'sent';
+    }
+    if (result.status === MailComposerStatus.CANCELLED) {
+      return 'cancelled';
+    }
+    return 'error';
+  } catch (reportError) {
+    bugReportLogger.error('Failed to send crash report', { error: reportError });
+    return 'error';
+  }
 }
 
 /**

--- a/tests/mocks/deps/safe-area-context-mock.tsx
+++ b/tests/mocks/deps/safe-area-context-mock.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const mockInsets = { top: 47, right: 0, bottom: 34, left: 0 };
+
+export function safeAreaContextMock() {
+  return {
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SafeAreaView: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useSafeAreaInsets: () => mockInsets,
+    initialWindowMetrics: {
+      frame: { x: 0, y: 0, width: 0, height: 0 },
+      insets: mockInsets,
+    },
+  };
+}

--- a/tests/mocks/utils/bug-report-mock.tsx
+++ b/tests/mocks/utils/bug-report-mock.tsx
@@ -1,0 +1,7 @@
+export const mockReportCrash = jest.fn().mockResolvedValue('sent');
+
+export function bugReportMock() {
+  return {
+    reportCrash: mockReportCrash,
+  };
+}

--- a/tests/unit/components/molecules/ErrorFallback.test.tsx
+++ b/tests/unit/components/molecules/ErrorFallback.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { ErrorFallback } from '@components/molecules/ErrorFallback';
+import { mockInsets } from '@mocks/deps/safe-area-context-mock';
+import { padding } from '@styles/spacing';
+
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
+jest.mock('react-native-safe-area-context', () =>
+  require('@mocks/deps/safe-area-context-mock').safeAreaContextMock()
+);
+
+describe('ErrorFallback', () => {
+  test('renders title, message and report action in recoverable mode', () => {
+    const { getByTestId } = render(
+      <ErrorFallback onReport={jest.fn().mockResolvedValue(undefined)} />
+    );
+
+    expect(getByTestId('ErrorFallback::Title')).toBeTruthy();
+    expect(getByTestId('ErrorFallback::Message')).toHaveTextContent('errorBoundary.message');
+    expect(getByTestId('ErrorFallback::Report')).toBeTruthy();
+  });
+
+  test('uses provided testID', () => {
+    const { getByTestId } = render(
+      <ErrorFallback onReport={jest.fn().mockResolvedValue(undefined)} testID='Boom' />
+    );
+
+    expect(getByTestId('Boom')).toBeTruthy();
+    expect(getByTestId('Boom::Report')).toBeTruthy();
+  });
+
+  test('pads the container with the safe-area insets', () => {
+    const { getByTestId } = render(
+      <ErrorFallback onReport={jest.fn().mockResolvedValue(undefined)} />
+    );
+
+    const style = StyleSheet.flatten(getByTestId('ErrorFallback').props.style);
+
+    expect(style.paddingTop).toBe(mockInsets.top + padding.veryLarge);
+    expect(style.paddingBottom).toBe(mockInsets.bottom + padding.veryLarge);
+  });
+
+  test('calls onReport when the report action is pressed', async () => {
+    const onReport = jest.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(<ErrorFallback onReport={onReport} />);
+
+    fireEvent.press(getByTestId('ErrorFallback::Report'));
+
+    await waitFor(() => expect(onReport).toHaveBeenCalledTimes(1));
+  });
+
+  test('disables the report action while reporting is in progress', async () => {
+    let resolveReport: () => void = () => {};
+    const onReport = jest.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveReport = resolve;
+        })
+    );
+    const { getByTestId } = render(<ErrorFallback onReport={onReport} />);
+
+    fireEvent.press(getByTestId('ErrorFallback::Report'));
+
+    await waitFor(() => expect(getByTestId('ErrorFallback::Report')).toBeDisabled());
+
+    resolveReport();
+
+    await waitFor(() => expect(getByTestId('ErrorFallback::Report')).toBeEnabled());
+  });
+
+  test('shows the persistent message and no action when persistent', () => {
+    const { getByTestId, queryByTestId } = render(<ErrorFallback persistent />);
+
+    expect(getByTestId('ErrorFallback::Message')).toHaveTextContent(
+      'errorBoundary.persistentMessage'
+    );
+    expect(queryByTestId('ErrorFallback::Report')).toBeNull();
+  });
+});

--- a/tests/unit/components/organisms/ErrorBoundary.test.tsx
+++ b/tests/unit/components/organisms/ErrorBoundary.test.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { ErrorBoundary, withErrorBoundary } from '@components/organisms/ErrorBoundary';
+import { mockHideAsync } from '@mocks/deps/expo-splash-screen-mock';
+import { mockReportCrash } from '@mocks/utils/bug-report-mock';
+
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
+jest.mock('expo-splash-screen', () =>
+  require('@mocks/deps/expo-splash-screen-mock').expoSplashScreenMock()
+);
+
+jest.mock('@utils/BugReport', () => require('@mocks/utils/bug-report-mock').bugReportMock());
+
+function Boom({ crash }: { crash: boolean }): React.ReactElement {
+  if (crash) {
+    throw new Error('render exploded');
+  }
+  return <Text testID='SafeChild'>safe</Text>;
+}
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockHideAsync.mockClear();
+    mockReportCrash.mockClear();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('renders children when no error thrown', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ErrorBoundary>
+        <Boom crash={false} />
+      </ErrorBoundary>
+    );
+
+    expect(getByTestId('SafeChild')).toBeTruthy();
+    expect(queryByTestId('ErrorFallback')).toBeNull();
+  });
+
+  test('renders fallback when a child throws during render', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+
+    expect(getByTestId('ErrorFallback::Title')).toBeTruthy();
+    expect(queryByTestId('SafeChild')).toBeNull();
+  });
+
+  test('hides the splash screen when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+
+    expect(mockHideAsync).toHaveBeenCalled();
+  });
+
+  test('swallows a splash-hide rejection without surfacing it', async () => {
+    mockHideAsync.mockRejectedValueOnce(new Error('splash already hidden'));
+
+    const { getByTestId } = render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+    await Promise.resolve();
+
+    expect(getByTestId('ErrorFallback::Title')).toBeTruthy();
+  });
+
+  test('does not hide the splash screen while children render normally', () => {
+    render(
+      <ErrorBoundary>
+        <Boom crash={false} />
+      </ErrorBoundary>
+    );
+
+    expect(mockHideAsync).not.toHaveBeenCalled();
+  });
+
+  test('forwards testID to fallback', () => {
+    const { getByTestId } = render(
+      <ErrorBoundary testID='RootBoundary'>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+
+    expect(getByTestId('RootBoundary')).toBeTruthy();
+  });
+
+  test('renders a report action and the recoverable message on first crash', () => {
+    const { getByTestId } = render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+
+    expect(getByTestId('ErrorFallback::Report')).toBeTruthy();
+    expect(getByTestId('ErrorFallback::Message')).toHaveTextContent('errorBoundary.message');
+  });
+
+  test('reports the caught error and component stack when the report action is pressed', async () => {
+    const { getByTestId } = render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('ErrorFallback::Report'));
+    });
+
+    const [reportedError, componentStack] = mockReportCrash.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect(reportedError.message).toBe('render exploded');
+    expect(typeof componentStack).toBe('string');
+    expect(componentStack.length).toBeGreaterThan(0);
+  });
+
+  test('recovers and re-renders children after reporting', async () => {
+    let crashNext = true;
+    const FlakyBoom = () => {
+      if (crashNext) {
+        throw new Error('render exploded');
+      }
+      return <Text testID='SafeChild'>safe</Text>;
+    };
+    const { getByTestId, queryByTestId } = render(
+      <ErrorBoundary>
+        <FlakyBoom />
+      </ErrorBoundary>
+    );
+
+    expect(getByTestId('ErrorFallback::Report')).toBeTruthy();
+
+    crashNext = false;
+    await act(async () => {
+      fireEvent.press(getByTestId('ErrorFallback::Report'));
+    });
+
+    expect(getByTestId('SafeChild')).toBeTruthy();
+    expect(queryByTestId('ErrorFallback')).toBeNull();
+  });
+
+  test('shows a persistent message with no action when the retry crashes again', async () => {
+    const { getByTestId, queryByTestId } = render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('ErrorFallback::Report'));
+    });
+
+    expect(queryByTestId('ErrorFallback::Report')).toBeNull();
+    expect(getByTestId('ErrorFallback::Message')).toHaveTextContent(
+      'errorBoundary.persistentMessage'
+    );
+  });
+
+  test('stores a null component stack when React provides none', () => {
+    const ref = React.createRef<ErrorBoundary>();
+    render(
+      <ErrorBoundary ref={ref}>
+        <Boom crash={false} />
+      </ErrorBoundary>
+    );
+
+    act(() => {
+      ref.current?.componentDidCatch(new Error('boom'), { componentStack: null });
+    });
+
+    expect(ref.current?.state.componentStack).toBeNull();
+  });
+
+  test('reports a fallback error when no error is stored in state', async () => {
+    const ref = React.createRef<ErrorBoundary>();
+    render(
+      <ErrorBoundary ref={ref}>
+        <Boom crash={false} />
+      </ErrorBoundary>
+    );
+
+    await act(async () => {
+      await ref.current?.reportAndRecover();
+    });
+
+    expect(mockReportCrash).toHaveBeenCalledWith(expect.any(Error), null);
+    expect(mockReportCrash.mock.calls[0][0].message).toBe('Unknown render error');
+  });
+
+  describe('withErrorBoundary', () => {
+    test('renders wrapped component output when it does not throw', () => {
+      const Guarded = withErrorBoundary(Boom);
+      const { getByTestId } = render(<Guarded crash={false} />);
+
+      expect(getByTestId('SafeChild')).toBeTruthy();
+    });
+
+    test('renders fallback when wrapped component throws', () => {
+      const Guarded = withErrorBoundary(Boom, 'GuardedBoom');
+      const { getByTestId } = render(<Guarded crash={true} />);
+
+      expect(getByTestId('GuardedBoom')).toBeTruthy();
+    });
+
+    test('sets a descriptive displayName from the component name', () => {
+      const Guarded = withErrorBoundary(Boom);
+
+      expect(Guarded.displayName).toBe('withErrorBoundary(Boom)');
+    });
+
+    test('prefers an explicit displayName over the function name', () => {
+      const Named = ({ crash }: { crash: boolean }) => <Boom crash={crash} />;
+      Named.displayName = 'ExplicitName';
+
+      const Guarded = withErrorBoundary(Named);
+
+      expect(Guarded.displayName).toBe('withErrorBoundary(ExplicitName)');
+    });
+
+    test('falls back to "Component" for an anonymous component', () => {
+      const nameless = jest.fn(() => null);
+      Object.defineProperty(nameless, 'name', { value: '' });
+
+      const Guarded = withErrorBoundary(nameless as unknown as React.ComponentType);
+
+      expect(Guarded.displayName).toBe('withErrorBoundary(Component)');
+    });
+  });
+});

--- a/tests/unit/utils/BugReport.test.ts
+++ b/tests/unit/utils/BugReport.test.ts
@@ -1,10 +1,12 @@
 import {
+  buildCrashDescription,
   buildEmailBody,
   buildEmailSubject,
   deleteOldLogFiles,
   getRecentLogFiles,
   isMailAvailable,
   pickScreenshots,
+  reportCrash,
   sendBugReport,
 } from '@utils/BugReport';
 import { mockDirectoryList, mockFileExists } from '@mocks/deps/expo-file-system-mock';
@@ -231,6 +233,85 @@ describe('BugReport utils', () => {
       mockExpoConstants.expoConfig = originalExpoConfig;
       const callArgs = mockComposeAsync.mock.calls[0][0];
       expect(callArgs.subject).toContain('N/A');
+    });
+  });
+
+  describe('buildCrashDescription', () => {
+    it('includes the error message', () => {
+      const description = buildCrashDescription(new Error('boom while rendering'), null);
+      expect(description).toContain('boom while rendering');
+    });
+
+    it('includes the component stack when provided', () => {
+      const description = buildCrashDescription(
+        new Error('boom'),
+        '\n    in RecipeCard\n    in Screen'
+      );
+      expect(description).toContain('in RecipeCard');
+    });
+
+    it('remains a non-empty string when the component stack is null', () => {
+      const description = buildCrashDescription(new Error('boom'), null);
+      expect(description.length).toBeGreaterThan(0);
+    });
+
+    it('falls back to a generic message when the error message is empty', () => {
+      const description = buildCrashDescription(new Error(''), null);
+      expect(description).toContain('Unknown error');
+    });
+  });
+
+  describe('reportCrash', () => {
+    beforeEach(() => {
+      mockComposeAsync.mockResolvedValue({ status: 'sent' });
+      mockFileExists.mockReturnValue(false);
+    });
+
+    it('returns mail_unavailable and skips the composer when mail is unavailable', async () => {
+      mockIsAvailableAsync.mockResolvedValue(false);
+
+      const outcome = await reportCrash(new Error('boom'), null);
+
+      expect(outcome).toBe('mail_unavailable');
+      expect(mockComposeAsync).not.toHaveBeenCalled();
+    });
+
+    it('sends a report containing the crash details when mail is available', async () => {
+      mockIsAvailableAsync.mockResolvedValue(true);
+
+      const outcome = await reportCrash(new Error('render exploded'), '\n    in RecipeCard');
+
+      expect(outcome).toBe('sent');
+      const body = mockComposeAsync.mock.calls[0][0].body;
+      expect(body).toContain('render exploded');
+      expect(body).toContain('in RecipeCard');
+    });
+
+    it('returns cancelled when the user dismisses the composer', async () => {
+      mockIsAvailableAsync.mockResolvedValue(true);
+      mockComposeAsync.mockResolvedValue({ status: 'cancelled' });
+
+      const outcome = await reportCrash(new Error('boom'), null);
+
+      expect(outcome).toBe('cancelled');
+    });
+
+    it('returns error when the composer neither sends nor is cancelled', async () => {
+      mockIsAvailableAsync.mockResolvedValue(true);
+      mockComposeAsync.mockResolvedValue({ status: 'saved' });
+
+      const outcome = await reportCrash(new Error('boom'), null);
+
+      expect(outcome).toBe('error');
+    });
+
+    it('returns error when the composer throws', async () => {
+      mockIsAvailableAsync.mockResolvedValue(true);
+      mockComposeAsync.mockRejectedValue(new Error('mail failed'));
+
+      const outcome = await reportCrash(new Error('boom'), null);
+
+      expect(outcome).toBe('error');
     });
   });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -86,5 +86,14 @@
     "notExported": false,
     "invalidLink": true,
     "notDocumented": false
+  },
+  "externalSymbolLinkMappings": {
+    "@types/react": {
+      "React.Component.setState": "https://react.dev/reference/react/Component#setstate",
+      "React.Component.render": "https://react.dev/reference/react/Component#render",
+      "React.ComponentLifecycle.componentDidMount": "https://react.dev/reference/react/Component#componentdidmount",
+      "React.NewLifecycle.getSnapshotBeforeUpdate": "https://react.dev/reference/react/Component#getsnapshotbeforeupdate",
+      "React.StaticLifecycle.getDerivedStateFromProps": "https://react.dev/reference/react/Component#static-getderivedstatefromprops"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Guards the app against React render crashes with error boundaries. A render error inside a guarded subtree now shows a recovery screen instead of a white screen of death, and the user can send a crash report and let the app try to recover.

Closes #352.

## What's in it

**`feat(bug-report): add reportCrash helper for automatic crash reports`** (`27cfc0a8`)
- `buildCrashDescription` formats a caught error + its component stack.
- `reportCrash` checks mail availability, sends via the existing `sendBugReport` (recent logs + device info attached) and maps the composer result to a typed `CrashReportOutcome`.

**`fix(app): add error boundaries with crash report + retry (#352)`** (`537949e8`)
- Class `ErrorBoundary` guarding the **app root** and the risky **OCR / scrape / bulk-import** screens.
- Two-phase recovery flow in `ErrorFallback`:
  - **First crash** → error-tinted **"Report & retry"** action → emails an automatic crash report (best effort) then re-mounts the children.
  - **Repeated crash** (retry failed) → a **"please restart"** message with no action, so a deterministic crash can't loop.
- Root `SafeAreaProvider` so the fallback lays out correctly even when the crash happens above the app's own providers.
- Top-anchored recovery UI (icon + title on one row, muted reassurance body, bottom-anchored button) with start-aligned, accessible text.
- en/fr translations; TypeDoc external-symbol mappings to silence warnings from the first class component.

## Behaviour notes
- Report is best-effort: if mail is unavailable or cancelled, the app still retries.
- Screen-level guards contain crashes to that screen; the root boundary is the last-resort net.
- Known limitation (deferred): the **root** fallback renders the default light theme, since the dark-mode context lives below the root boundary. Screen-level guards theme correctly.

## Tests
- `ErrorBoundary` + `ErrorFallback` at 100% coverage; `reportCrash` / `buildCrashDescription` fully covered.
- Covers: recoverable → recover, recoverable → persistent, splash-hide on catch, null error/component-stack fallbacks, en/fr translation symmetry.
- typecheck ✅ · lint ✅ · full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)