### PR TITLE
fix(a11y): expose RecipeCard, SquareButton and HorizontalList to screen readers

### DIFF
--- a/src/components/atomic/SquareButton.tsx
+++ b/src/components/atomic/SquareButton.tsx
@@ -40,6 +40,7 @@ import { squareButtonStyles, viewInsideButtonCentered } from '@styles/buttons';
 
 import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
 import { CustomImage } from '@components/atomic/CustomImage';
+import { useI18n } from '@utils/i18n';
 
 /** Props for recipe type button */
 export type propIsRecipe = { type: 'recipe'; recipe: recipeTableElement };
@@ -58,6 +59,8 @@ export type SquareButtonProps = {
   onPressFunction: () => void;
   /** Unique identifier for testing and accessibility */
   testID: string;
+  /** Screen-reader label; defaults to the recipe title, or a generic image label */
+  accessibilityLabel?: string;
 } & (propIsRecipe | propIsImg);
 
 /**
@@ -67,18 +70,25 @@ export type SquareButtonProps = {
  * @returns JSX element representing a square image button
  */
 export function SquareButton(buttonProps: SquareButtonProps) {
+  const { t } = useI18n();
   let img: string;
+  let defaultLabel: string;
   switch (buttonProps.type) {
     case 'recipe':
       img = buttonProps.recipe.image_Source;
+      defaultLabel = buttonProps.recipe.title;
       break;
     case 'image':
       img = buttonProps.imgSrc;
+      defaultLabel = t('imageButton');
       break;
   }
 
   return (
     <Pressable
+      testID={buttonProps.testID}
+      accessibilityRole={'button'}
+      accessibilityLabel={buttonProps.accessibilityLabel ?? defaultLabel}
       style={squareButtonStyles(buttonProps.side).squareButton}
       onPress={buttonProps.onPressFunction}
     >

--- a/src/components/molecules/HorizontalList.tsx
+++ b/src/components/molecules/HorizontalList.tsx
@@ -49,6 +49,7 @@ import { smallCardWidth, viewButtonStyles } from '@styles/buttons';
 import React from 'react';
 import { View } from 'react-native';
 import { TagButton } from '@components/atomic/TagButton';
+import { useI18n } from '@utils/i18n';
 
 /** Props for Tag mode */
 export type TagProp = {
@@ -86,6 +87,7 @@ export type HorizontalListProps = {
  * @returns JSX element representing a multi-line wrapping list of tags or images
  */
 export function HorizontalList(props: HorizontalListProps) {
+  const { t } = useI18n();
   /**
    * Renders individual list items based on the content type
    * @param item - The item data to render
@@ -107,6 +109,7 @@ export function HorizontalList(props: HorizontalListProps) {
             testID={props.testID + `::List#${index}`}
             side={smallCardWidth}
             imgSrc={item}
+            accessibilityLabel={t('imageButtonNumbered', { number: index + 1 })}
             onPressFunction={() => props.onPress?.(item)}
             type={'image'}
           />

--- a/src/components/molecules/RecipeCard.tsx
+++ b/src/components/molecules/RecipeCard.tsx
@@ -92,12 +92,15 @@ export function RecipeCard({ testId, size, recipe }: RecipeCardProps) {
           borderTopRightRadius: radius,
         }}
       />
-      <Card.Title
+      <Text
         testID={testId + '::Title'}
-        title={recipe.title}
-        titleNumberOfLines={2}
-        titleVariant={size === 'small' ? 'labelLarge' : 'titleMedium'}
-      />
+        accessible={true}
+        variant={size === 'small' ? 'labelLarge' : 'titleMedium'}
+        numberOfLines={2}
+        style={{ padding: padding.medium }}
+      >
+        {recipe.title}
+      </Text>
       {size === 'medium' && (
         <View>
           <Card.Content style={{ padding: padding.medium }}>

--- a/src/translations/en/common.ts
+++ b/src/translations/en/common.ts
@@ -40,6 +40,10 @@ export default {
   minutes: 'minutes',
   hours: 'hours',
 
+  // Accessibility labels
+  imageButton: 'Image',
+  imageButtonNumbered: 'Image {{number}}',
+
   // Home screen recommendations
   recommendations: {
     randomSelection: 'Random Selection',

--- a/src/translations/fr/common.ts
+++ b/src/translations/fr/common.ts
@@ -39,6 +39,10 @@ export default {
   minutes: 'minutes',
   hours: 'heures',
 
+  // Accessibility labels
+  imageButton: 'Image',
+  imageButtonNumbered: 'Image {{number}}',
+
   // Home screen recommendations
   recommendations: {
     randomSelection: 'Sélection aléatoire',

--- a/tests/mocks/deps/react-native-paper-mock.tsx
+++ b/tests/mocks/deps/react-native-paper-mock.tsx
@@ -127,6 +127,7 @@ export const Text: React.FC<any> = props => (
     testID={props.testID}
     style={props.style}
     numberOfLines={props.numberOfLines}
+    accessible={props.accessible}
     {...{ variant: props.variant }}
   >
     {props.children}
@@ -201,7 +202,9 @@ export const Card: React.FC<any> & {
     testID={props.testID}
     style={props.style}
     onPress={props.onPress}
-    accessible={true}
+    accessible={props.accessible}
+    accessibilityRole={props.accessibilityRole}
+    accessibilityLabel={props.accessibilityLabel}
   >
     <View>{props.children}</View>
   </TouchableOpacity>

--- a/tests/mocks/utils/i18n-mock.tsx
+++ b/tests/mocks/utils/i18n-mock.tsx
@@ -58,6 +58,8 @@ export function i18nMock() {
     fruits: 'filters.fruits',
     meat: 'filters.meat',
     searchRecipeTitle: 'searchRecipeTitle',
+    imageButton: 'Image',
+    imageButtonNumbered: 'Image {{number}}',
 
     'recipe.nutrition.title': 'recipe.nutrition.title',
     'recipe.nutrition.titleSimple': 'recipe.nutrition.titleSimple',

--- a/tests/unit/components/atomic/SquareButton.test.tsx
+++ b/tests/unit/components/atomic/SquareButton.test.tsx
@@ -3,6 +3,8 @@ import { SquareButton } from '@components/atomic/SquareButton';
 import React from 'react';
 import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
 
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
 const mockRecipe: recipeTableElement = {
   id: 1,
   title: 'Test Recipe',
@@ -55,9 +57,43 @@ describe('SquareButton', () => {
       <SquareButton {...defaultImageProps} onPressFunction={onPressFunction} />
     );
 
-    fireEvent.press(getByTestId('test-button::SquareButton').parent!);
+    fireEvent.press(getByTestId('test-button'));
 
     expect(onPressFunction).toHaveBeenCalledTimes(1);
+  });
+
+  test('exposes button role and recipe title for recipe type', () => {
+    const { getByTestId } = render(<SquareButton {...defaultRecipeProps} />);
+
+    const button = getByTestId('test-button');
+
+    expect(button.props.accessibilityRole).toBe('button');
+    expect(button.props.accessibilityLabel).toBe(mockRecipe.title);
+  });
+
+  test('exposes button role and generic label for image type', () => {
+    const { getByTestId } = render(<SquareButton {...defaultImageProps} />);
+
+    const button = getByTestId('test-button');
+
+    expect(button.props.accessibilityRole).toBe('button');
+    expect(button.props.accessibilityLabel).toBe('Image');
+  });
+
+  test('uses provided accessibilityLabel over default', () => {
+    const { getByTestId } = render(
+      <SquareButton {...defaultImageProps} accessibilityLabel='Recipe photo' />
+    );
+
+    expect(getByTestId('test-button').props.accessibilityLabel).toBe('Recipe photo');
+  });
+
+  test('uses provided accessibilityLabel over recipe title', () => {
+    const { getByTestId } = render(
+      <SquareButton {...defaultRecipeProps} accessibilityLabel='Custom recipe label' />
+    );
+
+    expect(getByTestId('test-button').props.accessibilityLabel).toBe('Custom recipe label');
   });
 
   test('renders CustomImage with correct testID for image type', () => {

--- a/tests/unit/components/molecules/HorizontalList.test.tsx
+++ b/tests/unit/components/molecules/HorizontalList.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { HorizontalList } from '@components/molecules/HorizontalList';
 import React from 'react';
 
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
 describe('HorizontalList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -84,6 +86,13 @@ describe('HorizontalList', () => {
       fireEvent.press(getByTestId('test-list::List#0::SquareButton').parent!);
 
       expect(onPress).toHaveBeenCalledWith('https://example.com/img1.jpg');
+    });
+
+    test('gives each image button a numbered accessibility label', () => {
+      const { getByTestId } = render(<HorizontalList {...imageProps} />);
+
+      expect(getByTestId('test-list::List#0').props.accessibilityLabel).toBe('Image 1');
+      expect(getByTestId('test-list::List#1').props.accessibilityLabel).toBe('Image 2');
     });
 
     test('handles empty array', () => {

--- a/tests/unit/components/molecules/RecipeCard.test.tsx
+++ b/tests/unit/components/molecules/RecipeCard.test.tsx
@@ -51,11 +51,11 @@ describe('RecipeCard Component', () => {
     expect(getByTestId(`${testId}::Cover::Source`).props.children).toEqual(
       recipe.image_Source.length > 0 ? recipe.image_Source : 'no-image'
     );
-    expect(getByTestId(`${testId}::Title::TitleText`).props.children).toEqual(recipe.title);
-    expect(getByTestId(`${testId}::Title::TitleText`).props.numberOfLines).toEqual(2);
+    expect(getByTestId(`${testId}::Title`).props.children).toEqual(recipe.title);
+    expect(getByTestId(`${testId}::Title`).props.numberOfLines).toEqual(2);
 
     const expectedVariant = size === 'small' ? 'labelLarge' : 'titleMedium';
-    expect(getByTestId(`${testId}::Title::TitleVariant`).props.children).toEqual(expectedVariant);
+    expect(getByTestId(`${testId}::Title`).props.variant).toEqual(expectedVariant);
 
     if (size === 'medium') {
       const expectedTags = recipe.tags.map(tag => tag.name).join(', ');
@@ -84,6 +84,19 @@ describe('RecipeCard Component', () => {
     const { getByTestId, queryByTestId } = renderRecipeCard({ size: 'medium' });
 
     assertRecipeDataDisplay(getByTestId, queryByTestId, 'medium');
+  });
+
+  test('exposes each card field as its own accessible element', () => {
+    const { getByTestId } = renderRecipeCard({ size: 'medium' });
+
+    const card = getByTestId(`test-recipe-card::${sampleRecipe.title}`);
+    expect(card.props.accessible).toBe(false);
+
+    expect(getByTestId('test-recipe-card::Title').props.accessible).toBe(true);
+    expect(getByTestId('test-recipe-card::Title').props.children).toBe(sampleRecipe.title);
+    expect(getByTestId('test-recipe-card::Content').props.accessible).toBe(true);
+    expect(getByTestId('test-recipe-card::PrepTime').props.accessible).toBe(true);
+    expect(getByTestId('test-recipe-card::Persons').props.accessible).toBe(true);
   });
 
   test('navigates to Recipe screen when card is pressed', () => {


### PR DESCRIPTION
## Summary

Fixes #353. Makes the app's core interactive list/grid elements reachable and announceable by screen readers (VoiceOver / TalkBack), and — importantly — keeps them targetable by our Maestro iOS E2E selectors.

Rebased onto latest `main` and squashed to a single, coherent commit.

## RecipeCard — per-field accessibility

The card container stays `accessible={false}`; each field is exposed as its own accessible element with a stable `testID`:

- **Title** is now a plain accessible `<Text testID="…::Title">` instead of `<Card.Title>`. Paper's `Card.Title` silently drops any `testID`/`accessible` passed to it (no `...rest` spread), so the title could never be individually targeted or exposed to the a11y tree.
- `Content` (tags), `PrepTime`, `Persons` remain individually accessible.

**Why per-field and not a single composed label:** a single `accessible={true}` card with a `"{title}, {time} minutes, {persons} persons"` label collapses the subtree on iOS, so the bare title is no longer a matchable node — which broke the iOS E2E suites (`app-init`, `recipe-readonly`, `recipe-edit`, `search`) that assert/tap recipe cards by title text. Per-field accessibility is the model that works end-to-end today.

The nicer single-swipe-stop "button" a11y (one composed label + `button` role for the whole card) is deferred to **#424**, pending validation that Maestro `id:` selectors still resolve `accessible={false}` children on iOS.

## SquareButton

- Adds `accessibilityRole="button"` + `accessibilityLabel` (new optional prop) and a `testID` on the `Pressable`.
- Label defaults to the recipe title for `recipe` type, or the localized `imageButton` string for `image` type; callers can override.

## HorizontalList

- Passes numbered `"Image N"` labels (`imageButtonNumbered`) to its image buttons so gallery items are distinguishable.

## i18n

- New en/fr keys: `imageButton` (`"Image"`), `imageButtonNumbered` (`"Image {{number}}"`).

## Tests

- **RecipeCard**: asserts the per-field accessible model (card `accessible={false}`; title/tags/prep-time/servings each accessible with their testIDs).
- **SquareButton**: role + default/override labels.
- **HorizontalList**: numbered image labels.
- Paper `Text` mock forwards `accessible` so the field-level assertions can read it.

## Verification

- `npm run test:unit` — full suite green (193 suites / 3884 tests).
- typecheck clean, lint clean, prettier clean, en/fr key parity green.
- Pre-commit (husky/lint-staged) ran clean — no `--no-verify` needed.

## Follow-up

- **#424** — single-element "button" a11y for the whole card (better VoiceOver), gated on a Maestro `id:`/`accessible={false}` simulator check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
