### PR TITLE
fix(database): add singleton teardown for RecipeDatabase (#351)

### DIFF
--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -114,7 +114,7 @@ export type StoreSlice = 'recipes' | 'ingredients' | 'tags' | 'menu' | 'purchase
  * ```
  */
 export class RecipeDatabase {
-  static #instance: RecipeDatabase;
+  static #instance: RecipeDatabase | undefined;
 
   protected _databaseName: string;
   protected _dbConnection: SQLite.SQLiteDatabase;
@@ -185,11 +185,26 @@ export class RecipeDatabase {
    * ```
    */
   public static getInstance(): RecipeDatabase {
-    if (!RecipeDatabase.#instance) {
-      RecipeDatabase.#instance = new RecipeDatabase();
-    }
+    return (RecipeDatabase.#instance ??= new RecipeDatabase());
+  }
 
-    return RecipeDatabase.#instance;
+  /**
+   * Tears down the singleton instance completely.
+   *
+   * Closes the database connection, clears every registered store listener, and
+   * discards the cached singleton so the next {@link getInstance} call builds a
+   * fresh instance. Call this when the app reinitializes its data layer (e.g. a
+   * settings reset or full data wipe) to guarantee no stale instance keeps its
+   * listeners registered and firing store notifications alongside the new one.
+   *
+   * @returns Promise that resolves once teardown is complete. No-op if no
+   * instance currently exists.
+   */
+  public static async resetInstance(): Promise<void> {
+    if (RecipeDatabase.#instance) {
+      await RecipeDatabase.#instance.closeAndReset();
+      RecipeDatabase.#instance = undefined;
+    }
   }
 
   /**

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -2546,4 +2546,95 @@ describe('RecipeDatabase', () => {
       expect(db.getDismissedUrls('hellofresh').has('https://hellofresh.com/recipe-2')).toBe(true);
     });
   });
+
+  describe('subscribe / unsubscribe', () => {
+    const db = RecipeDatabase.getInstance();
+
+    beforeEach(async () => {
+      await db.init();
+    });
+
+    afterEach(async () => {
+      await db.closeAndReset();
+    });
+
+    test('notifies a subscribed callback when the slice mutates', async () => {
+      const callback = jest.fn();
+      db.subscribe('tags', callback);
+
+      await db.addTag(testTags[0]);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test('stops notifying after the returned unsubscribe is called', async () => {
+      const callback = jest.fn();
+      const unsubscribe = db.subscribe('tags', callback);
+
+      await db.addTag(testTags[0]);
+      unsubscribe();
+      await db.addTag(testTags[1]);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test('only notifies callbacks for the mutated slice', async () => {
+      const tagsCallback = jest.fn();
+      const ingredientsCallback = jest.fn();
+      db.subscribe('tags', tagsCallback);
+      db.subscribe('ingredients', ingredientsCallback);
+
+      await db.addTag(testTags[0]);
+
+      expect(tagsCallback).toHaveBeenCalledTimes(1);
+      expect(ingredientsCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getInstance', () => {
+    afterEach(async () => {
+      await RecipeDatabase.resetInstance();
+    });
+
+    test('returns the same instance across repeated calls', () => {
+      expect(RecipeDatabase.getInstance()).toBe(RecipeDatabase.getInstance());
+    });
+  });
+
+  describe('resetInstance', () => {
+    afterEach(async () => {
+      await RecipeDatabase.resetInstance();
+    });
+
+    test('builds a fresh instance on the next getInstance', async () => {
+      const first = RecipeDatabase.getInstance();
+      await first.init();
+
+      await RecipeDatabase.resetInstance();
+      const second = RecipeDatabase.getInstance();
+
+      expect(second).not.toBe(first);
+    });
+
+    test('tears down the stale instance so it no longer fires notifications', async () => {
+      const first = RecipeDatabase.getInstance();
+      await first.init();
+      const staleCallback = jest.fn();
+      first.subscribe('tags', staleCallback);
+
+      await RecipeDatabase.resetInstance();
+
+      const second = RecipeDatabase.getInstance();
+      await second.init();
+      await second.addTag(testTags[0]);
+
+      expect(staleCallback).not.toHaveBeenCalled();
+    });
+
+    test('is a no-op when no instance exists', async () => {
+      await RecipeDatabase.resetInstance();
+
+      await expect(RecipeDatabase.resetInstance()).resolves.toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #351.

`RecipeDatabase.getInstance()` had no teardown path — the cached `#instance` was never discarded. If the app reinitializes its data layer (settings reset / data wipe), the old singleton would stay alive with its store listeners still registered, firing notifications alongside the new instance.

## Changes

- Add static `RecipeDatabase.resetInstance()` — closes the DB connection, clears every registered store listener, and discards the cached singleton so the next `getInstance()` builds fresh. No-op when no instance exists.
- Type `#instance` as `RecipeDatabase | undefined` and switch `getInstance()` to `??=` — cast-free.
- Add unit tests: subscribe/unsubscribe contract (the issue's second case, already implemented but previously uncovered), singleton identity, and the new teardown.

## Notes

`resetInstance()` is currently test-only — no production data-wipe flow exists yet. It closes the missing-teardown gap #351 flags and is ready to wire up when such a feature lands. The unsubscribe half of #351 was already satisfied (`subscribe()` returns an unsubscribe fn consumed by `useSyncExternalStore`); this PR adds the coverage that documents it.

## Verification

- typecheck / docs:build / eslint clean
- RecipeDatabase unit suite: 166 pass (7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)