### PR TITLE
fix(ci): make E2E artifact merge resilient to cache miss

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -335,7 +335,7 @@ jobs:
         run: |
           mkdir -p merged-reports
           if find junit-reports -name '*.xml' -type f 2>/dev/null | grep -q .; then
-            npx jrm merged-reports/report.xml "junit-reports/**/*.xml"
+            npx --yes junit-report-merger@9.0.3 merged-reports/report.xml "junit-reports/**/*.xml"
           else
             echo "No JUnit reports to merge"
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recipedia",
-  "version": "2.43.0",
+  "version": "2.44.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recipedia",
-      "version": "2.43.0",
+      "version": "2.44.2",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
@@ -98,7 +98,6 @@
         "jest": "~29.7.0",
         "jest-expo": "56.0.5",
         "jest-junit": "^16.0.0",
-        "junit-report-merger": "9.0.3",
         "knip": "6.27.0",
         "lint-staged": "16.1.5",
         "metro-react-native-babel-preset": "~0.77.0",
@@ -6689,58 +6688,6 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^25.1.0"
-      }
-    },
-    "node_modules/@oozcitak/dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-2.0.2.tgz",
-      "integrity": "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/url": "^3.0.0",
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@oozcitak/infra": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-2.0.2.tgz",
-      "integrity": "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@oozcitak/url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-3.0.0.tgz",
-      "integrity": "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/util": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@oozcitak/util": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-10.0.0.tgz",
-      "integrity": "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -20498,35 +20445,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/junit-report-merger": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/junit-report-merger/-/junit-report-merger-9.0.3.tgz",
-      "integrity": "sha512-Z7r4qCVp2w/SwmcJPWseA4jgzlcAw6xgbd665tWlMHQGu5RGAo+fr/4tT93/VFgD+elP8gkFqidBcDwk2SQZcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "~14.0.0",
-        "tinyglobby": "^0.2.15",
-        "xmlbuilder2": "4.0.1"
-      },
-      "bin": {
-        "jrm": "cli.js",
-        "junit-report-merger": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/junit-report-merger/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -31006,52 +30924,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/xmlbuilder2": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.1.tgz",
-      "integrity": "sha512-vXeky0YRVjhx5pseJDQLk0F6u7gyA8++ceVOS88r4dWu4lWdY/ZjbL45QrN+g0GzZLg1D5AkzThpikZa98SC/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oozcitak/dom": "^2.0.2",
-        "@oozcitak/infra": "^2.0.2",
-        "@oozcitak/util": "^10.0.0",
-        "js-yaml": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/xmlbuilder2/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/xmlbuilder2/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "jest": "~29.7.0",
     "jest-expo": "56.0.5",
     "jest-junit": "^16.0.0",
-    "junit-report-merger": "9.0.3",
     "knip": "6.27.0",
     "lint-staged": "16.1.5",
     "metro-react-native-babel-preset": "~0.77.0",


### PR DESCRIPTION
## What

The **Merge E2E Test Artifacts** job fails when the `node_modules` cache misses.

Fix: `npx jrm ...` → `npx --yes junit-report-merger@9.0.3 ...` and drop the `junit-report-merger` devDependency (CI-only).

## Why

The merge job restores `node_modules` from cache but has no `npm ci` fallback. On a cache miss the `jrm` bin is absent, so `npx jrm` treats `jrm` as a registry package name and dies with:

```
npm error could not determine executable to run
##[error]Process completed with exit code 1.
```

(Seen in run `29602261387`, job `88069479716` — cache miss logged as `Cache not found for input keys: Linux-node_modules-...`.)

Using the real package name lets npx fetch it on demand regardless of cache state. Version pinned for determinism.

## Changes

- `.github/workflows/build-test.yml` — merge step uses `npx --yes junit-report-merger@9.0.3`
- `package.json` — remove `junit-report-merger` devDependency
- `package-lock.json` — synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)