### PR TITLE
feat(ui): theme Android nav bar and iOS root view via expo-system-ui

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -55,6 +55,7 @@ module.exports = {
         '^react-native-webview$': '<rootDir>/tests/mocks/deps/react-native-webview-mock.tsx',
         '^expo-mail-composer$': '<rootDir>/tests/mocks/deps/expo-mail-composer-mock.tsx',
         '^expo-status-bar$': '<rootDir>/tests/mocks/deps/expo-status-bar-mock.tsx',
+        '^expo-system-ui$': '<rootDir>/tests/mocks/deps/expo-system-ui-mock.ts',
         '^expo-image-manipulator$': '<rootDir>/tests/mocks/deps/expo-image-manipulator-mock.tsx',
         '^@react-native-ml-kit/text-recognition$': '<rootDir>/tests/mocks/deps/react-native-ml-kit-text-recognition-mock.ts',
     },

--- a/src/components/atomic/AppStatusBar.tsx
+++ b/src/components/atomic/AppStatusBar.tsx
@@ -1,14 +1,23 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
+import * as SystemUI from 'expo-system-ui';
+import { useTheme } from 'react-native-paper';
 import { DarkModeContext } from '@context/DarkModeContext';
 
 /**
  * AppStatusBar - Centralized status bar component
  *
- * Automatically handles status bar style based on the dark mode context.
+ * Handles the status bar style based on the dark mode context and keeps the
+ * system UI background (Android navigation bar, iOS root view) themed to the
+ * active surface color so it matches the bottom bar sitting above it.
  */
 export function AppStatusBar() {
   const { isDarkMode } = useContext(DarkModeContext);
+  const { colors } = useTheme();
+
+  useEffect(() => {
+    void SystemUI.setBackgroundColorAsync(colors.surface);
+  }, [colors.surface]);
 
   return <StatusBar style={isDarkMode ? 'light' : 'dark'} animated={true} />;
 }

--- a/tests/mocks/deps/expo-system-ui-mock.ts
+++ b/tests/mocks/deps/expo-system-ui-mock.ts
@@ -1,0 +1,2 @@
+export const setBackgroundColorAsync = jest.fn(async () => undefined);
+export const getBackgroundColorAsync = jest.fn(async () => null);

--- a/tests/unit/components/atomic/AppStatusBar.test.tsx
+++ b/tests/unit/components/atomic/AppStatusBar.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import * as SystemUI from 'expo-system-ui';
+import { useTheme } from 'react-native-paper';
 import { AppStatusBar } from '@components/atomic/AppStatusBar';
 import { DarkModeContext } from '@context/DarkModeContext';
 
@@ -28,5 +30,11 @@ describe('AppStatusBar component', () => {
     const { getByTestId } = renderWithDarkMode(false);
     const statusBar = getByTestId('StatusBar');
     expect(statusBar.props.animated).toBe(true);
+  });
+
+  it('themes the system UI background with the active theme surface color', () => {
+    (useTheme as jest.Mock).mockReturnValueOnce({ colors: { surface: '#123456' } });
+    renderWithDarkMode(false);
+    expect(SystemUI.setBackgroundColorAsync).toHaveBeenCalledWith('#123456');
   });
 });


### PR DESCRIPTION
## Summary

Closes #382.

Themes the system UI background so it follows the app light/dark theme:
- **Android**: the navigation bar (transparent under edge-to-edge) shows the themed root view background.
- **iOS**: the root view background (visible on overscroll bounce / pre-content flash) is themed too.

`AppStatusBar` now reads the active React Native Paper theme via `useTheme()` and syncs the system UI background to `colors.surface` through `expo-system-ui`'s `setBackgroundColorAsync`. `surface` (not `background`) is used to match the bottom tab bar sitting directly above the nav bar (`BottomTabs.tsx` uses `colors.surface`), giving a seamless edge.

## How

- `AppStatusBar` gains a `useEffect` that calls `SystemUI.setBackgroundColorAsync(colors.surface)`, keyed on the surface color. `DarkModeContext` is still used for the status bar style (`darkTheme` doesn't set `theme.dark`, so the Paper flag is unreliable for that).
- No new util file — logic is 3 lines inline in the effect, using the Paper `useTheme()` hook rather than manually selecting `darkTheme`/`lightTheme`.

## Tests

- `expo-system-ui` mock added (`tests/mocks/deps/`) + jest moduleNameMapper entry.
- `AppStatusBar.test.tsx` asserts the system UI background is themed to the active surface color.
- 100% branch + line coverage on the changed component; typecheck + eslint clean.

## Notes

- No native device run yet — nav bar visual not confirmed on a real Android device (needs a dev-build run).

## Commits

- `feat(ui): theme Android nav bar and iOS root view via expo-system-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)