### PR TITLE
refactor(types): add Draft types, make persisted id required

### DIFF
--- a/src/assets/datasets/en/ingredients.ts
+++ b/src/assets/datasets/en/ingredients.ts
@@ -1,6 +1,6 @@
-import { ingredientTableElement, ingredientType } from '@customTypes/DatabaseElementTypes';
+import { IngredientDraft, ingredientType } from '@customTypes/DatabaseElementTypes';
 
-export const englishIngredients: ingredientTableElement[] = [
+export const englishIngredients: IngredientDraft[] = [
   {
     name: 'Carrot',
     unit: '',

--- a/src/assets/datasets/en/recipes.ts
+++ b/src/assets/datasets/en/recipes.ts
@@ -1,6 +1,6 @@
-import { ingredientType, recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { ingredientType, RecipeDraft } from '@customTypes/DatabaseElementTypes';
 
-export const englishRecipes: recipeTableElement[] = [
+export const englishRecipes: RecipeDraft[] = [
   {
     image_Source: 'spaghetti_bolognaise.webp',
     title: 'Spaghetti Bolognese',

--- a/src/assets/datasets/en/tags.ts
+++ b/src/assets/datasets/en/tags.ts
@@ -1,6 +1,6 @@
-import { tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { TagDraft } from '@customTypes/DatabaseElementTypes';
 
-export const englishTags: tagTableElement[] = [
+export const englishTags: TagDraft[] = [
   { name: 'Breakfast' },
   { name: 'Lunch' },
   { name: 'Dinner' },

--- a/src/assets/datasets/fr/ingredients.ts
+++ b/src/assets/datasets/fr/ingredients.ts
@@ -1,6 +1,6 @@
-import { ingredientTableElement, ingredientType } from '@customTypes/DatabaseElementTypes';
+import { IngredientDraft, ingredientType } from '@customTypes/DatabaseElementTypes';
 
-export const frenchIngredients: ingredientTableElement[] = [
+export const frenchIngredients: IngredientDraft[] = [
   {
     name: 'Carotte',
     unit: '',

--- a/src/assets/datasets/fr/recipes.ts
+++ b/src/assets/datasets/fr/recipes.ts
@@ -1,6 +1,6 @@
-import { ingredientType, recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { ingredientType, RecipeDraft } from '@customTypes/DatabaseElementTypes';
 
-export const frenchRecipes: recipeTableElement[] = [
+export const frenchRecipes: RecipeDraft[] = [
   {
     image_Source: 'spaghetti_bolognaise.webp',
     title: 'Spaghetti Bolognaise',

--- a/src/assets/datasets/fr/tags.ts
+++ b/src/assets/datasets/fr/tags.ts
@@ -1,6 +1,6 @@
-import { tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { TagDraft } from '@customTypes/DatabaseElementTypes';
 
-export const frenchTags: tagTableElement[] = [
+export const frenchTags: TagDraft[] = [
   { name: 'Petit-déjeuner' },
   { name: 'Déjeuner' },
   { name: 'Dîner' },

--- a/src/components/dialogs/ItemDialog.tsx
+++ b/src/components/dialogs/ItemDialog.tsx
@@ -80,9 +80,9 @@ import { useTags } from '@hooks/useTags';
 import { useIngredients } from '@hooks/useIngredients';
 import {
   FormIngredientElement,
-  ingredientTableElement,
+  IngredientDraft,
   ingredientType,
-  tagTableElement,
+  TagDraft,
 } from '@customTypes/DatabaseElementTypes';
 import { useShoppingCategories } from '@hooks/useCategories';
 import { SelectableAccordion } from '@components/molecules/SelectableAccordion';
@@ -101,16 +101,16 @@ export type ItemIngredientType = {
   /** Current ingredient data (may have optional fields for new/incomplete ingredients) */
   value: FormIngredientElement;
   /** Callback fired when ingredient operation is confirmed */
-  onConfirmIngredient: (mode: DialogMode, newItem: ingredientTableElement) => void | Promise<void>;
+  onConfirmIngredient: (mode: DialogMode, newItem: IngredientDraft) => void | Promise<void>;
 };
 
 /** Configuration for tag dialogs */
 export type ItemTagType = {
   type: 'Tag';
   /** Current tag data */
-  value: tagTableElement;
+  value: TagDraft;
   /** Callback fired when tag operation is confirmed */
-  onConfirmTag: (mode: DialogMode, newItem: tagTableElement) => void | Promise<void>;
+  onConfirmTag: (mode: DialogMode, newItem: TagDraft) => void | Promise<void>;
 };
 
 /**
@@ -258,10 +258,10 @@ export function ItemDialog({ onClose, isVisible, testId, mode, item }: ItemDialo
   const handleDeleteConfirm = () => {
     switch (item.type) {
       case 'Ingredient':
-        void item.onConfirmIngredient(mode, item.value as ingredientTableElement);
+        void item.onConfirmIngredient(mode, item.value as IngredientDraft);
         break;
       case 'Tag':
-        void item.onConfirmTag(mode, item.value as tagTableElement);
+        void item.onConfirmTag(mode, item.value as TagDraft);
         break;
       default:
         uiLogger.error('Unreachable code in ItemDialog');

--- a/src/components/dialogs/SimilarityDialog.tsx
+++ b/src/components/dialogs/SimilarityDialog.tsx
@@ -59,7 +59,12 @@ import { StyleSheet, View } from 'react-native';
 import { Button, Dialog, Portal, Text } from 'react-native-paper';
 import { useI18n } from '@utils/i18n';
 import { databaseLogger } from '@utils/logger';
-import { ingredientTableElement, tagTableElement } from '@customTypes/DatabaseElementTypes';
+import {
+  IngredientDraft,
+  ingredientTableElement,
+  TagDraft,
+  tagTableElement,
+} from '@customTypes/DatabaseElementTypes';
 import { DialogMode, ItemDialog } from './ItemDialog';
 import { DatabasePickerDialog } from './DatabasePickerDialog';
 import { ConfirmationDialog } from './ConfirmationDialog';
@@ -237,17 +242,14 @@ export function SimilarityDialog({ testId, isVisible, onClose, item }: Similarit
    * @async
    * @returns Promise<void> - Resolves when all operations complete
    */
-  const handleItemDialogConfirm = async (
-    mode: DialogMode,
-    newItem: ingredientTableElement | tagTableElement
-  ) => {
+  const handleItemDialogConfirm = async (mode: DialogMode, newItem: IngredientDraft | TagDraft) => {
     if (mode === 'add') {
       try {
         if (item.type === 'Ingredient') {
-          const createdIngredient = await addIngredient(newItem as ingredientTableElement);
+          const createdIngredient = await addIngredient(newItem as IngredientDraft);
           item.onConfirm(createdIngredient);
         } else {
-          const createdTag = await addTag(newItem as tagTableElement);
+          const createdTag = await addTag(newItem as TagDraft);
           item.onConfirm(createdTag);
         }
       } catch (error) {
@@ -390,17 +392,16 @@ export function SimilarityDialog({ testId, isVisible, onClose, item }: Similarit
                   value: {
                     name: item.newItemName,
                   },
-                  onConfirmIngredient: (mode: DialogMode, newItem: ingredientTableElement) => {
+                  onConfirmIngredient: (mode: DialogMode, newItem: IngredientDraft) => {
                     void handleItemDialogConfirm(mode, newItem);
                   },
                 }
               : {
                   type: item.type,
                   value: {
-                    id: -1,
                     name: item.newItemName,
                   },
-                  onConfirmTag: (mode: DialogMode, newItem: tagTableElement) => {
+                  onConfirmTag: (mode: DialogMode, newItem: TagDraft) => {
                     void handleItemDialogConfirm(mode, newItem);
                   },
                 }

--- a/src/components/organisms/ValidationReviewList.tsx
+++ b/src/components/organisms/ValidationReviewList.tsx
@@ -15,6 +15,7 @@ import { FlashList } from '@shopify/flash-list';
 import {
   FormIngredientElement,
   ingredientTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import {
@@ -39,7 +40,7 @@ const LIST_BOTTOM_PADDING = 80;
 
 export type ValidationReviewListProps = {
   testID: string;
-  rawTags: tagTableElement[];
+  rawTags: TagDraft[];
   rawIngredients: FormIngredientElement[];
   onImport: (mappings: ResolutionMappings) => void;
   recipeCount: number;

--- a/src/customTypes/BulkImportTypes.tsx
+++ b/src/customTypes/BulkImportTypes.tsx
@@ -20,6 +20,7 @@ import {
   nutritionTableElement,
   preparationStepElement,
   recipeTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import { IgnoredIngredientPatterns } from '@utils/RecipeScraperConverter';
@@ -186,7 +187,7 @@ export interface FullyDiscoveredRecipe {
   /** List of parsed ingredients */
   ingredients: FormIngredientElement[];
   /** List of recipe tags/categories */
-  tags: tagTableElement[];
+  tags: TagDraft[];
   /** List of preparation steps */
   preparation: preparationStepElement[];
   /** Nutritional information */
@@ -227,7 +228,7 @@ export interface ConvertedImportRecipe {
   /** List of ingredients */
   ingredients: FormIngredientElement[];
   /** List of tags/categories */
-  tags: tagTableElement[];
+  tags: TagDraft[];
   /** List of preparation steps */
   preparation: preparationStepElement[];
   /** Nutritional information */
@@ -260,7 +261,7 @@ export interface BatchValidationState {
   /** Map of unique ingredients by normalized name */
   uniqueIngredients: Map<string, FormIngredientElement>;
   /** Map of unique tags by normalized name */
-  uniqueTags: Map<string, tagTableElement>;
+  uniqueTags: Map<string, TagDraft>;
   /** Map of ingredient names to their validated database entries */
   ingredientMappings: Map<string, ingredientTableElement>;
   /** Map of tag names to their validated database entries */

--- a/src/customTypes/DatabaseElementTypes.tsx
+++ b/src/customTypes/DatabaseElementTypes.tsx
@@ -67,6 +67,34 @@ export const recipeTableName = 'RecipesTable';
 export const ingredientsTableName = 'IngredientsTable';
 export const tagTableName = 'TagsTable';
 
+/**
+ * Draft variant of a persisted DB element: the same shape without the
+ * database-assigned `id`.
+ *
+ * Represents a record built in memory but not yet inserted. The database
+ * assigns `id` on insert, producing the full persisted type. Use this for
+ * insert inputs so that persisted reads keep a guaranteed, non-optional `id`.
+ *
+ * @typeParam T - A persisted element type whose `id` is a required `number`
+ */
+export type Draft<T extends { id: number }> = Omit<T, 'id'>;
+
+/**
+ * Attaches a database-assigned `id` to a {@link Draft}, producing the persisted
+ * element.
+ *
+ * Use this instead of inlining `{ ...draft, id }` after an insert returns the
+ * new row id.
+ *
+ * @typeParam T - A persisted element type whose `id` is a required `number`
+ * @param draft - The draft to promote
+ * @param id - The database-assigned id to attach
+ * @returns The persisted element with its `id` set
+ */
+export function withId<T extends { id: number }>(draft: Draft<T>, id: number): T {
+  return { ...draft, id } as T;
+}
+
 /** SQLite data type enumeration */
 export enum encodedType {
   INTEGER = 'INTEGER',
@@ -103,8 +131,8 @@ export enum recipeColumnsNames {
  * Represents a fully decoded recipe with all related data
  */
 export type recipeTableElement = {
-  /** Optional database ID (undefined for new recipes) */
-  id?: number;
+  /** Database ID assigned on insert. Always present on persisted recipes. */
+  id: number;
   /** Path or URI to recipe image */
   image_Source: string;
   /** Recipe title/name */
@@ -129,6 +157,21 @@ export type recipeTableElement = {
   sourceUrl?: string;
   /** Provider ID from bulk import (e.g., 'hellofresh') */
   sourceProvider?: string;
+};
+
+/**
+ * A recipe payload that may not yet be persisted.
+ *
+ * `id` is present when editing an existing recipe and absent for a brand-new
+ * one. Its embedded ingredients and tags are drafts too: a recipe built from a
+ * form, OCR, scraper, or seed data may reference ingredients/tags not yet
+ * resolved to master rows. Snapshot/insert/update pipelines accept this shape;
+ * persisted reads return the id-required {@link recipeTableElement}.
+ */
+export type RecipeDraft = Omit<Draft<recipeTableElement>, 'ingredients' | 'tags'> & {
+  id?: number;
+  ingredients: IngredientDraft[];
+  tags: TagDraft[];
 };
 
 export type encodedRecipeElement = {
@@ -165,8 +208,12 @@ export const recipeColumnsEncoding: databaseColumnType[] = [
  * Supports both database storage and recipe usage
  */
 export type ingredientTableElement = {
-  /** Optional database ID (undefined for new ingredients) */
-  id?: number;
+  /**
+   * Database ID from the master ingredients table. Always present on persisted
+   * reads (the decoder resolves every occurrence to its master row). Absent only
+   * on an {@link IngredientDraft} not yet inserted/resolved.
+   */
+  id: number;
   /** Ingredient name */
   name: string;
   /** Unit of measurement (cups, grams, pieces, etc.) */
@@ -191,6 +238,15 @@ export type ingredientTableElement = {
  * When confirmed/validated, convert to ingredientTableElement
  */
 export type FormIngredientElement = Partial<ingredientTableElement>;
+
+/**
+ * An ingredient occurrence that may not yet be resolved to a master row.
+ *
+ * `id` is present when the occurrence already maps to a master ingredient and
+ * absent for a newly typed one (form input, OCR, scraper, seed data). Persisted
+ * reads return the id-required {@link ingredientTableElement}.
+ */
+export type IngredientDraft = Draft<ingredientTableElement> & { id?: number };
 
 export type coreIngredientElement = Pick<ingredientTableElement, 'name'> & {
   quantityPerPerson: number | undefined;
@@ -219,8 +275,6 @@ export const ingredientColumnsEncoding: databaseColumnType[] = [
 ];
 
 export type nutritionTableElement = {
-  /** Optional database ID (undefined for new nutrition data) */
-  id?: number;
   /** Energy in kcal per 100g */
   energyKcal: number;
   /** Energy in kJ per 100g */
@@ -257,11 +311,23 @@ export type preparationStepElement = {
  * Simple tag data structure for recipe categorization
  */
 export type tagTableElement = {
-  /** Optional database ID (undefined for new tags) */
-  id?: number;
+  /**
+   * Database ID from the tags table. Always present on persisted reads. Absent
+   * only on a {@link TagDraft} not yet matched to or created in the master table.
+   */
+  id: number;
   /** Tag name/label */
   name: string;
 };
+
+/**
+ * A tag that may not yet exist in the master table.
+ *
+ * `id` is present when the tag already maps to a master row and absent for one
+ * freshly typed into the recipe form or shipped in seed data. Persisted reads
+ * return the id-required {@link tagTableElement}.
+ */
+export type TagDraft = Draft<tagTableElement> & { id?: number };
 
 export enum tagsColumnsNames {
   name = 'NAME',
@@ -284,8 +350,6 @@ export const importHistoryTableName = 'ImportHistoryTable';
  * Used to show visual indicators for previously seen recipes during bulk import
  */
 export type importHistoryTableElement = {
-  /** Optional database ID (undefined for new records) */
-  id?: number;
   /** Provider identifier (e.g., 'hellofresh') */
   providerId: string;
   /** Full recipe URL from the provider */
@@ -321,8 +385,6 @@ export const dismissedRecipesTableName = 'DismissedRecipesTable';
  * Filtered out of every future bulk-import discovery run for the provider.
  */
 export type dismissedRecipeTableElement = {
-  /** Optional database ID (undefined for new records) */
-  id?: number;
   /** Provider identifier (e.g., 'hellofresh') */
   providerId: string;
   /** Full recipe URL from the provider */
@@ -368,8 +430,8 @@ export const menuTableName = 'MenuTable';
  * The menu is the single source of truth - the shopping list is generated from it.
  */
 export type menuTableElement = {
-  /** Optional database ID (undefined for new menu items) */
-  id?: number;
+  /** Database ID assigned on insert. Always present on persisted menu items. */
+  id: number;
   /** Recipe ID from the recipes table */
   recipeId: number;
   /** Recipe title (denormalized for quick display) */
@@ -455,7 +517,7 @@ export function extractIngredientsNameWithQuantity(
   );
 }
 
-export function extractTagsName(tags: tagTableElement[]): string[] {
+export function extractTagsName(tags: TagDraft[]): string[] {
   const result: string[] = [];
   tags.forEach(element => {
     result.push(element.name);
@@ -464,18 +526,7 @@ export function extractTagsName(tags: tagTableElement[]): string[] {
   return result;
 }
 
-export function isRecipePartiallyEqual(
-  recipe1: recipeTableElement,
-  recipe2: recipeTableElement
-): boolean {
-  return (
-    recipe1.image_Source === recipe2.image_Source &&
-    recipe1.title === recipe2.title &&
-    recipe1.description === recipe2.description
-  );
-}
-
-export function isRecipeEqual(recipe1: recipeTableElement, recipe2: recipeTableElement): boolean {
+export function isRecipeEqual(recipe1: RecipeDraft, recipe2: RecipeDraft): boolean {
   return (
     recipe1.image_Source === recipe2.image_Source &&
     recipe1.title === recipe2.title &&
@@ -502,7 +553,7 @@ export function isIngredientEqual(
   );
 }
 
-export function isTagEqual(tag1: tagTableElement, tag2: tagTableElement): boolean {
+export function isTagEqual(tag1: TagDraft, tag2: TagDraft): boolean {
   return tag1.name === tag2.name;
 }
 

--- a/src/customTypes/ItemDialogTypes.ts
+++ b/src/customTypes/ItemDialogTypes.ts
@@ -6,11 +6,7 @@
  * independently of the component.
  */
 
-import {
-  FormIngredientElement,
-  ingredientType,
-  tagTableElement,
-} from '@customTypes/DatabaseElementTypes';
+import { FormIngredientElement, ingredientType, TagDraft } from '@customTypes/DatabaseElementTypes';
 
 /**
  * Minimal structural type covering both item configurations accepted by the dialog.
@@ -18,7 +14,7 @@ import {
  * to prevent a circular dependency with the component file.
  */
 type ItemProp =
-  { type: 'Ingredient'; value: FormIngredientElement } | { type: 'Tag'; value: tagTableElement };
+  { type: 'Ingredient'; value: FormIngredientElement } | { type: 'Tag'; value: TagDraft };
 
 /**
  * Unified RHF form value shape covering both Tag and Ingredient dialogs.

--- a/src/customTypes/OCRTypes.tsx
+++ b/src/customTypes/OCRTypes.tsx
@@ -1,16 +1,32 @@
 import { default as RecipeTranslations } from '@translations/en/recipe';
 
-/** Type representing nutrition data extracted from OCR */
+/**
+ * Nutrition data extracted from an OCR scan of a nutrition label.
+ *
+ * Every field is optional: OCR may fail to locate a given value on the label,
+ * in which case the field stays `undefined` and the UI leaves it blank. Values
+ * are per 100g unless {@link portionWeight} is used to derive per-portion figures.
+ */
 export type nutritionObject = {
+  /** Energy in kcal per 100g */
   energyKcal?: number;
+  /** Energy in kJ per 100g */
   energyKj?: number;
+  /** Total fats in grams per 100g */
   fat?: number;
+  /** Saturated fats in grams per 100g (subset of total fats) */
   saturatedFat?: number;
+  /** Total carbohydrates in grams per 100g */
   carbohydrates?: number;
+  /** Sugars in grams per 100g (subset of carbohydrates) */
   sugars?: number;
+  /** Dietary fiber in grams per 100g */
   fiber?: number;
+  /** Proteins in grams per 100g */
   protein?: number;
+  /** Salt in grams per 100g */
   salt?: number;
+  /** Portion size in grams, used to convert per-100g values to per-portion */
   portionWeight?: number;
 };
 

--- a/src/customTypes/RecipeNavigationTypes.tsx
+++ b/src/customTypes/RecipeNavigationTypes.tsx
@@ -11,6 +11,7 @@ import {
   FormIngredientElement,
   nutritionTableElement,
   recipeTableElement,
+  TagDraft,
 } from '@customTypes/DatabaseElementTypes';
 
 /**
@@ -85,8 +86,12 @@ export interface AddFromPicProp extends BaseRecipeProp {
  * Type for scraped recipe data passed to the Recipe screen.
  * Uses FormIngredientElement[] for ingredients since they need validation.
  */
-export type ScrapedRecipeData = Omit<Partial<recipeTableElement>, 'ingredients' | 'nutrition'> & {
+export type ScrapedRecipeData = Omit<
+  Partial<recipeTableElement>,
+  'ingredients' | 'nutrition' | 'tags'
+> & {
   ingredients?: FormIngredientElement[];
+  tags?: TagDraft[];
   nutrition?: nutritionTableElement;
 };
 

--- a/src/customTypes/ValidationTypes.ts
+++ b/src/customTypes/ValidationTypes.ts
@@ -10,11 +10,12 @@
 import {
   FormIngredientElement,
   ingredientTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 
 /** A tag that needs validation, with pre-computed similar items from the database */
-export type TagWithSimilarity = tagTableElement & {
+export type TagWithSimilarity = TagDraft & {
   similarItems: tagTableElement[];
 };
 

--- a/src/hooks/useIngredients.ts
+++ b/src/hooks/useIngredients.ts
@@ -10,7 +10,11 @@
 
 import { useSyncExternalStore } from 'react';
 import { RecipeDatabase } from '@utils/RecipeDatabase';
-import { ingredientTableElement, ingredientType } from '@customTypes/DatabaseElementTypes';
+import {
+  IngredientDraft,
+  ingredientTableElement,
+  ingredientType,
+} from '@customTypes/DatabaseElementTypes';
 import {
   DetailedSearchResult,
   ITEM_FUZZY,
@@ -44,9 +48,7 @@ export function useIngredients() {
     () => db.get_ingredients()
   );
 
-  const addIngredient = async (
-    ingredient: ingredientTableElement
-  ): Promise<ingredientTableElement> => {
+  const addIngredient = async (ingredient: IngredientDraft): Promise<ingredientTableElement> => {
     return db.addIngredient(ingredient);
   };
 
@@ -72,9 +74,7 @@ export function useIngredients() {
     return db.getRandomIngredientsByType(type, count);
   };
 
-  const addMultipleIngredients = async (
-    ingredientsToAdd: ingredientTableElement[]
-  ): Promise<void> => {
+  const addMultipleIngredients = async (ingredientsToAdd: IngredientDraft[]): Promise<void> => {
     await db.addMultipleIngredients(ingredientsToAdd);
   };
 

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -14,7 +14,7 @@
 
 import { useSyncExternalStore, useState } from 'react';
 import { RecipeDatabase } from '@utils/RecipeDatabase';
-import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { RecipeDraft, recipeTableElement } from '@customTypes/DatabaseElementTypes';
 import { deleteFile, isTemporaryImageUri } from '@utils/FileGestion';
 import { databaseLogger } from '@utils/logger';
 
@@ -40,12 +40,12 @@ export function useRecipes() {
   );
   const [scalingProgress, setScalingProgress] = useState<number | undefined>(undefined);
 
-  const addRecipe = async (recipe: recipeTableElement): Promise<void> => {
+  const addRecipe = async (recipe: RecipeDraft): Promise<recipeTableElement> => {
     databaseLogger.debug('useRecipes: addRecipe', { recipeTitle: recipe.title });
-    await db.addRecipe(recipe);
+    return db.addRecipe(recipe);
   };
 
-  const editRecipe = async (recipe: recipeTableElement): Promise<recipeTableElement> => {
+  const editRecipe = async (recipe: RecipeDraft & { id: number }): Promise<recipeTableElement> => {
     databaseLogger.debug('useRecipes: editRecipe', {
       recipeId: recipe.id,
       recipeTitle: recipe.title,
@@ -67,11 +67,11 @@ export function useRecipes() {
     return db.deleteRecipe(recipe);
   };
 
-  const findSimilarRecipes = (recipe: recipeTableElement): recipeTableElement[] => {
+  const findSimilarRecipes = (recipe: RecipeDraft): recipeTableElement[] => {
     return db.findSimilarRecipes(recipe);
   };
 
-  const addMultipleRecipes = async (recipesToAdd: recipeTableElement[]): Promise<void> => {
+  const addMultipleRecipes = async (recipesToAdd: RecipeDraft[]): Promise<void> => {
     databaseLogger.debug('useRecipes: addMultipleRecipes', { count: recipesToAdd.length });
     await db.addMultipleRecipes(recipesToAdd);
   };

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -10,7 +10,7 @@
 
 import { useSyncExternalStore } from 'react';
 import { RecipeDatabase } from '@utils/RecipeDatabase';
-import { tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { TagDraft, tagTableElement } from '@customTypes/DatabaseElementTypes';
 import {
   DetailedSearchResult,
   ITEM_FUZZY,
@@ -39,7 +39,7 @@ export function useTags() {
     () => db.get_tags()
   );
 
-  const addTag = async (tag: tagTableElement): Promise<tagTableElement> => {
+  const addTag = async (tag: TagDraft): Promise<tagTableElement> => {
     return db.addTag(tag);
   };
 
@@ -67,7 +67,7 @@ export function useTags() {
     return db.searchRandomlyTags(count);
   };
 
-  const addMultipleTags = async (tagsToAdd: tagTableElement[]): Promise<void> => {
+  const addMultipleTags = async (tagsToAdd: TagDraft[]): Promise<void> => {
     await db.addMultipleTags(tagsToAdd);
   };
 

--- a/src/hooks/useValidationReviewState.ts
+++ b/src/hooks/useValidationReviewState.ts
@@ -12,6 +12,7 @@ import React, { useState } from 'react';
 import {
   FormIngredientElement,
   ingredientTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import {
@@ -88,7 +89,7 @@ export function refreshSimilarityFor<
  * @returns Review state with sorted items, actions, and resolution mappings
  */
 export function useValidationReviewState(
-  rawTags: tagTableElement[],
+  rawTags: TagDraft[],
   rawIngredients: FormIngredientElement[],
   findSimilarTags: (name: string) => tagTableElement[],
   findSimilarIngredients: (name: string) => ingredientTableElement[]
@@ -113,7 +114,7 @@ export function useValidationReviewState(
     computeIngredientSimilarity(rawIngredients, findSimilarIngredients)
   );
 
-  const [pendingTagsIndex] = useState<ItemSearchIndex<tagTableElement>>(() =>
+  const [pendingTagsIndex] = useState<ItemSearchIndex<TagDraft>>(() =>
     buildItemIndex(rawTags, { fuzzy: ITEM_FUZZY, getName: t => t.name })
   );
   const [pendingIngredientsIndex] = useState<

--- a/src/hooks/useValidationWorkflow.ts
+++ b/src/hooks/useValidationWorkflow.ts
@@ -10,7 +10,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   ingredientTableElement,
-  recipeTableElement,
+  RecipeDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import {
@@ -112,7 +112,7 @@ export interface UseValidationWorkflowReturn {
  */
 export function useValidationWorkflow(
   selectedRecipes: ConvertedImportRecipe[],
-  addMultipleRecipes: (recipes: recipeTableElement[]) => Promise<void>,
+  addMultipleRecipes: (recipes: RecipeDraft[]) => Promise<void>,
   defaultPersons: number,
   findSimilarTags: (name: string) => tagTableElement[],
   findSimilarIngredients: (name: string) => ingredientTableElement[],

--- a/src/screens/IngredientsSettings.tsx
+++ b/src/screens/IngredientsSettings.tsx
@@ -29,7 +29,12 @@ import React, { useState } from 'react';
 import { View } from 'react-native';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
 import { useNavigation } from '@react-navigation/native';
-import { FormIngredientElement, ingredientTableElement } from '@customTypes/DatabaseElementTypes';
+import {
+  FormIngredientElement,
+  IngredientDraft,
+  ingredientTableElement,
+  withId,
+} from '@customTypes/DatabaseElementTypes';
 import { SettingsItemList } from '@components/organisms/SettingsItemList';
 import { AppBar } from '@components/organisms/AppBar';
 import { BottomActionButton } from '@components/atomic/BottomActionButton';
@@ -64,7 +69,7 @@ export function IngredientsSettings() {
 
   const testId = 'IngredientsSettings';
 
-  const handleAddIngredient = async (newIngredient: ingredientTableElement) => {
+  const handleAddIngredient = async (newIngredient: IngredientDraft) => {
     const insertedIngredient = await addIngredient(newIngredient);
     if (!insertedIngredient) {
       ingredientsSettingsLogger.warn('Failed to add ingredient to database', {
@@ -114,21 +119,27 @@ export function IngredientsSettings() {
   };
 
   // Dialog action handlers
-  const handleDialogConfirm = async (mode: DialogMode, newIngredient: ingredientTableElement) => {
-    switch (mode) {
-      case 'add':
-        await handleAddIngredient(newIngredient);
-        break;
-      case 'edit':
-        if (selectedIngredient) {
-          await handleEditIngredient(newIngredient);
+  const handleDialogConfirm = async (mode: DialogMode, newIngredient: IngredientDraft) => {
+    if (mode === 'add') {
+      await handleAddIngredient(newIngredient);
+      setIsDialogOpen(false);
+      return;
+    }
+    if (newIngredient.id === undefined) {
+      ingredientsSettingsLogger.error(
+        'Cannot edit or delete an ingredient without a persisted id',
+        {
+          ingredientName: newIngredient.name,
         }
-        break;
-      case 'delete':
-        if (selectedIngredient) {
-          await handleDeleteIngredient(newIngredient);
-        }
-        break;
+      );
+      setIsDialogOpen(false);
+      return;
+    }
+    const persistedIngredient = withId<ingredientTableElement>(newIngredient, newIngredient.id);
+    if (mode === 'edit') {
+      await handleEditIngredient(persistedIngredient);
+    } else {
+      await handleDeleteIngredient(persistedIngredient);
     }
     setIsDialogOpen(false);
   };

--- a/src/screens/Menu.tsx
+++ b/src/screens/Menu.tsx
@@ -76,8 +76,8 @@ export function Menu() {
                   key={item.id}
                   testId={`${screenId}::MenuItem::${index + 1}`}
                   menuItem={item}
-                  onToggleCooked={() => void (item.id && handleToggleCooked(item.id))}
-                  onRemove={() => void (item.id && handleRemove(item.id))}
+                  onToggleCooked={() => void handleToggleCooked(item.id)}
+                  onRemove={() => void handleRemove(item.id)}
                 />
               ))}
             </List.Section>
@@ -95,8 +95,8 @@ export function Menu() {
                   key={item.id}
                   testId={`${screenId}::MenuItem::${toCookItems.length + index + 1}`}
                   menuItem={item}
-                  onToggleCooked={() => void (item.id && handleToggleCooked(item.id))}
-                  onRemove={() => void (item.id && handleRemove(item.id))}
+                  onToggleCooked={() => void handleToggleCooked(item.id)}
+                  onRemove={() => void handleRemove(item.id)}
                 />
               ))}
             </List.Section>

--- a/src/screens/TagsSettings.tsx
+++ b/src/screens/TagsSettings.tsx
@@ -34,7 +34,7 @@ import React, { useState } from 'react';
 import { View } from 'react-native';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
 import { useNavigation } from '@react-navigation/native';
-import { tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { TagDraft, tagTableElement, withId } from '@customTypes/DatabaseElementTypes';
 import { SettingsItemList } from '@components/organisms/SettingsItemList';
 import { AppBar } from '@components/organisms/AppBar';
 import { BottomActionButton } from '@components/atomic/BottomActionButton';
@@ -62,7 +62,7 @@ export function TagsSettings() {
 
   const [dialogVisible, setDialogVisible] = useState(false);
   const [dialogMode, setDialogMode] = useState<DialogMode>('add');
-  const [currentTag, setCurrentTag] = useState<tagTableElement>({ name: '' });
+  const [currentTag, setCurrentTag] = useState<TagDraft>({ name: '' });
 
   const testId = 'TagsSettings';
 
@@ -83,7 +83,7 @@ export function TagsSettings() {
     }
   };
 
-  const handleAddtag = async (newTag: tagTableElement) => {
+  const handleAddtag = async (newTag: TagDraft) => {
     await addTag(newTag);
   };
 
@@ -112,17 +112,24 @@ export function TagsSettings() {
   };
 
   // Dialog action handlers
-  const handleDialogConfirm = async (mode: DialogMode, newTag: tagTableElement) => {
-    switch (mode) {
-      case 'add':
-        await handleAddtag(newTag);
-        break;
-      case 'edit':
-        await handleEditTag(newTag);
-        break;
-      case 'delete':
-        await handleDeleteTag(newTag);
-        break;
+  const handleDialogConfirm = async (mode: DialogMode, newTag: TagDraft) => {
+    if (mode === 'add') {
+      await handleAddtag(newTag);
+      closeDialog();
+      return;
+    }
+    if (newTag.id === undefined) {
+      tagsSettingsLogger.error('Cannot edit or delete a tag without a persisted id', {
+        tagName: newTag.name,
+      });
+      closeDialog();
+      return;
+    }
+    const persistedTag = withId<tagTableElement>(newTag, newTag.id);
+    if (mode === 'edit') {
+      await handleEditTag(persistedTag);
+    } else {
+      await handleDeleteTag(persistedTag);
     }
     closeDialog();
   };

--- a/src/screens/recipe/RecipeFormScreen.tsx
+++ b/src/screens/recipe/RecipeFormScreen.tsx
@@ -327,15 +327,16 @@ function RecipeFormBody({
       recipeLogger.info('Saving edited recipe to database', {
         recipeTitle: form.getValues('recipeTitle'),
       });
+      if (routeProps.mode !== 'edit') return;
+      const originalRecipe = routeProps.recipe;
       const recipeToEdit = buildSnapshot();
-      const originalRecipe = routeProps.mode === 'edit' ? routeProps.recipe : recipeToEdit;
       const defaultPersons = await getDefaultPersons();
       const scaledRecipe = scaleRecipeForSave(recipeToEdit, defaultPersons);
 
-      let savedRecipe = recipeToEdit;
+      let savedRecipe: recipeTableElement = originalRecipe;
       let scaledFromServings: number | undefined;
       if (!isRecipeEqual(originalRecipe, scaledRecipe)) {
-        savedRecipe = await editRecipe(scaledRecipe);
+        savedRecipe = await editRecipe({ ...scaledRecipe, id: originalRecipe.id });
         scaledFromServings = getServingsScaledFrom(recipeToEdit.persons, defaultPersons);
         baselineRef.current = savedRecipe;
         try {
@@ -378,7 +379,7 @@ function RecipeFormBody({
         recipeLogger.info('Saving new recipe to database', {
           recipeTitle: form.getValues('recipeTitle'),
         });
-        await addRecipe(scaledRecipe);
+        const savedRecipe = await addRecipe(scaledRecipe);
         clearCache();
         recipeLogger.info('Recipe add completed successfully', {
           recipeTitle: form.getValues('recipeTitle'),
@@ -389,7 +390,7 @@ function RecipeFormBody({
           content: t('addedToDatabase', { recipeName: recipeToAdd.title }),
           confirmText: t('understood'),
           onConfirm: () =>
-            onSaveSuccess(scaledRecipe, getServingsScaledFrom(recipeToAdd.persons, defaultPersons)),
+            onSaveSuccess(savedRecipe, getServingsScaledFrom(recipeToAdd.persons, defaultPersons)),
         });
       } catch (error) {
         validationLogger.error('Failed to validate and add recipe to database', {

--- a/src/screens/recipe/helpers/createRecipeSnapshot.ts
+++ b/src/screens/recipe/helpers/createRecipeSnapshot.ts
@@ -1,5 +1,5 @@
 /**
- * Builds a `recipeTableElement` snapshot from the current form values and a
+ * Builds a {@link RecipeDraft} snapshot from the current form values and a
  * baseline recipe (preserves the persisted `id`, `season`, and
  * `sourceProvider` that aren't form-managed).
  *
@@ -10,11 +10,16 @@
  */
 
 import type { UseFormReturn } from 'react-hook-form';
-import { ingredientTableElement, recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import {
+  ingredientTableElement,
+  RecipeDraft,
+  recipeTableElement,
+} from '@customTypes/DatabaseElementTypes';
 import type { RecipeFormInput } from '@schemas/recipeFormSchema';
 
 /**
- * Returns a fully-populated `recipeTableElement` from the current form state.
+ * Returns a fully-populated {@link RecipeDraft} from the current form state
+ * (`id` present only when editing an existing recipe).
  *
  * The supplied `baseline` carries non-form fields the snapshot must round-trip:
  * - `id`, `season`, `sourceProvider` from the persisted recipe, when available.
@@ -26,13 +31,13 @@ import type { RecipeFormInput } from '@schemas/recipeFormSchema';
  * @param baseline - The most recent persisted recipe, or `null` for fresh adds
  * @param fallbackSourceUrl - Optional source URL used when no baseline exists
  *   (e.g. `addFromScrape` mode)
- * @returns A snapshot of the current form payload as a `recipeTableElement`
+ * @returns A snapshot of the current form payload as a {@link RecipeDraft}
  */
 export function createRecipeSnapshot(
   form: UseFormReturn<RecipeFormInput>,
   baseline: recipeTableElement | null,
   fallbackSourceUrl?: string
-): recipeTableElement {
+): RecipeDraft {
   const values = form.getValues();
   const sourceUrl = baseline?.sourceUrl ?? fallbackSourceUrl;
   return {

--- a/src/styles/typography.tsx
+++ b/src/styles/typography.tsx
@@ -40,9 +40,6 @@ export const noteSeparator = '%%';
 /** All calendar months as string values (1-12) */
 export const ALL_MONTHS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const;
 
-/** All months pre-encoded for database storage */
-export const ALL_MONTHS_ENCODED = ALL_MONTHS.join(EncodingSeparator);
-
 /** Regular expression to replace all newline characters */
 export const replaceAllBackToLine = /\n/g;
 

--- a/src/utils/BatchValidation.ts
+++ b/src/utils/BatchValidation.ts
@@ -10,6 +10,7 @@
 import {
   FormIngredientElement,
   ingredientTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import {
@@ -33,10 +34,10 @@ import { scaleQuantityForPersons } from '@utils/Quantity';
  */
 export function collectUniqueItems(recipes: ConvertedImportRecipe[]): {
   uniqueIngredients: Map<string, FormIngredientElement>;
-  uniqueTags: Map<string, tagTableElement>;
+  uniqueTags: Map<string, TagDraft>;
 } {
   const uniqueIngredients = new Map<string, FormIngredientElement>();
-  const uniqueTags = new Map<string, tagTableElement>();
+  const uniqueTags = new Map<string, TagDraft>();
 
   for (const recipe of recipes) {
     for (const ing of recipe.ingredients) {

--- a/src/utils/DatasetLoader.ts
+++ b/src/utils/DatasetLoader.ts
@@ -8,11 +8,7 @@
  * @module DatasetLoader
  */
 
-import {
-  ingredientTableElement,
-  recipeTableElement,
-  tagTableElement,
-} from '@customTypes/DatabaseElementTypes';
+import { IngredientDraft, RecipeDraft, TagDraft } from '@customTypes/DatabaseElementTypes';
 import { appLogger } from '@utils/logger';
 import { DEFAULT_LANGUAGE, SupportedLanguage } from '@utils/i18n';
 
@@ -34,9 +30,9 @@ import { performanceRecipes } from '@assets/datasets/performance/recipes';
  * A complete set of seed data for one dataset variant.
  */
 export interface DatasetCollection {
-  ingredients: ingredientTableElement[];
-  tags: tagTableElement[];
-  recipes: recipeTableElement[];
+  ingredients: IngredientDraft[];
+  tags: TagDraft[];
+  recipes: RecipeDraft[];
 }
 
 /**

--- a/src/utils/FileGestion.tsx
+++ b/src/utils/FileGestion.tsx
@@ -39,7 +39,7 @@ import pkg from '@app/package.json';
 import { productionRecipesImages, testRecipesImages } from '@utils/Constants';
 import { getDatasetType } from '@utils/DatasetLoader';
 import { fileSystemLogger } from '@utils/logger';
-import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { RecipeDraft } from '@customTypes/DatabaseElementTypes';
 import { forEachChunk } from '@utils/chunk';
 
 const DIRECTORY_NAME = Constants.expoConfig?.name || pkg.name;
@@ -486,7 +486,7 @@ export async function copyDatasetImages(): Promise<void> {
  * // Recipe with image_Source: 'pasta.png' becomes 'file:///documents/Recipedia/pasta.png'
  * ```
  */
-export function transformDatasetRecipeImages(recipes: recipeTableElement[]): recipeTableElement[] {
+export function transformDatasetRecipeImages<T extends RecipeDraft>(recipes: T[]): T[] {
   return recipes.map(recipe => ({
     ...recipe,
     image_Source: APP_DIR.uri + recipe.image_Source,

--- a/src/utils/OCR.tsx
+++ b/src/utils/OCR.tsx
@@ -89,32 +89,50 @@ const INGREDIENT_PARSING = {
 } as const;
 
 /** Type representing person count and cooking time extracted from OCR */
-export type personAndTimeObject = { person: number; time: number };
+export type personAndTimeObject = {
+  /** Number of servings the recipe yields */
+  person: number;
+  /** Total preparation time in minutes */
+  time: number;
+};
+/** Field names of {@link personAndTimeObject}, used to drive OCR field extraction. */
 export const keysPersonsAndTimeObject = Object.keys({
   person: 0,
   time: 0,
 } as personAndTimeObject) as (keyof personAndTimeObject)[];
 
 /** Type representing a tag extracted from OCR */
-export type tagObject = { id?: string; name: string };
+export type tagObject = {
+  /** Database ID when the tag already exists, `undefined` for a newly scanned tag */
+  id?: string;
+  /** Tag label as read from the image */
+  name: string;
+};
+/** Field names of {@link tagObject}, used to drive OCR field extraction. */
 export const keysTagObject = Object.keys({
   name: '',
 } as tagObject) as (keyof tagObject)[];
 
 /** Type representing ingredient quantity for a specific number of persons */
 export type ingredientQuantityPerPersons = {
+  /** Serving count this quantity applies to */
   persons: number;
+  /** Quantity as a string to preserve fractional and textual amounts */
   quantity: string;
 };
 
 /** Type representing an ingredient with multiple quantity specifications */
 export type ingredientObject = {
+  /** Ingredient name as read from the image */
   name: string;
+  /** Unit of measurement (g, ml, cups, …) */
   unit: string;
+  /** Quantity broken down per serving count, supporting multi-column labels */
   quantityPerPersons: ingredientQuantityPerPersons[];
   /** Optional usage note from additional parentheticals */
   note?: string;
 };
+/** Field names of {@link ingredientObject} (excluding `note`), used to drive OCR field extraction. */
 export const keysIngredientObject = Object.keys({
   name: '',
   unit: '',

--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -12,6 +12,7 @@
 import * as SQLite from 'expo-sqlite';
 import {
   coreIngredientElement,
+  Draft,
   dismissedRecipeTableElement,
   dismissedRecipesColumnsEncoding,
   dismissedRecipesColumnsNames,
@@ -24,16 +25,18 @@ import {
   encodedRecipeElement,
   encodedTagElement,
   importHistoryColumnsEncoding,
+  importHistoryColumnsNames,
   importHistoryTableElement,
   importHistoryTableName,
+  IngredientDraft,
   ingredientColumnsEncoding,
   ingredientsColumnsNames,
   ingredientsTableName,
   ingredientTableElement,
   ingredientType,
   isIngredientEqual,
-  isRecipePartiallyEqual,
   isTagEqual,
+  TagDraft,
   menuColumnsEncoding,
   menuColumnsNames,
   menuTableElement,
@@ -46,6 +49,7 @@ import {
   recipeColumnsEncoding,
   recipeColumnsNames,
   recipeDatabaseName,
+  RecipeDraft,
   recipeTableElement,
   recipeTableName,
   tagColumnsEncoding,
@@ -54,13 +58,7 @@ import {
   tagTableName,
 } from '@customTypes/DatabaseElementTypes';
 import { TableManipulation } from './TableManipulation';
-import {
-  ALL_MONTHS,
-  ALL_MONTHS_ENCODED,
-  EncodingSeparator,
-  noteSeparator,
-  textSeparator,
-} from '@styles/typography';
+import { ALL_MONTHS, EncodingSeparator, noteSeparator, textSeparator } from '@styles/typography';
 import {
   constructImageUri,
   deleteFile,
@@ -85,6 +83,16 @@ const RECIPE_TITLE_FUZZY = 0.3;
  * callbacks are triggered on each mutation.
  */
 export type StoreSlice = 'recipes' | 'ingredients' | 'tags' | 'menu' | 'purchased';
+
+/**
+ * A recipe whose embedded tags and ingredients have been resolved to persisted
+ * master rows (each carrying its database `id`), ready for encoding and
+ * insertion. The recipe's own `id` presence is preserved from the input draft.
+ */
+type PreparedRecipe<T extends RecipeDraft = RecipeDraft> = Omit<T, 'tags' | 'ingredients'> & {
+  tags: tagTableElement[];
+  ingredients: ingredientTableElement[];
+};
 
 /**
  * RecipeDatabase - Singleton class for managing recipe data storage and operations
@@ -231,10 +239,7 @@ export class RecipeDatabase {
    * // scaledRecipe.ingredients[0].quantity === "200"
    * ```
    */
-  public static scaleRecipeToPersons(
-    recipe: recipeTableElement,
-    targetPersons: number
-  ): recipeTableElement {
+  public static scaleRecipeToPersons<T extends RecipeDraft>(recipe: T, targetPersons: number): T {
     if (!recipe.persons || recipe.persons <= 0 || recipe.persons === targetPersons) {
       return recipe;
     }
@@ -344,7 +349,6 @@ export class RecipeDatabase {
     ]);
 
     await this.migrateAddSourceColumns();
-    await this.migrateWildcardSeasons();
 
     const [
       ingredients,
@@ -426,7 +430,7 @@ export class RecipeDatabase {
    * console.log(`Ingredient added with ID: ${ingredient.id}`);
    * ```
    */
-  public async addIngredient(ingredient: ingredientTableElement): Promise<ingredientTableElement> {
+  public async addIngredient(ingredient: IngredientDraft): Promise<ingredientTableElement> {
     const ingToAdd = this.encodeIngredientForDb(ingredient);
     const dbRes = await this._ingredientsTable.insertElement(ingToAdd, this._dbConnection);
 
@@ -470,7 +474,7 @@ export class RecipeDatabase {
    * console.log(`Tag added with ID: ${tag.id}`);
    * ```
    */
-  public async addTag(newTag: tagTableElement): Promise<tagTableElement> {
+  public async addTag(newTag: TagDraft): Promise<tagTableElement> {
     const tagToAdd = this.encodeTagForDb(newTag);
     const dbRes = await this._tagsTable.insertElement(tagToAdd, this._dbConnection);
 
@@ -527,7 +531,7 @@ export class RecipeDatabase {
    * ]);
    * ```
    */
-  public async addMultipleIngredients(ingredients: ingredientTableElement[]) {
+  public async addMultipleIngredients(ingredients: IngredientDraft[]) {
     if (ingredients.length === 0) return;
 
     const encodedIngredients = ingredients.map(ing => this.encodeIngredientForDb(ing));
@@ -582,7 +586,7 @@ export class RecipeDatabase {
    * ]);
    * ```
    */
-  public async addMultipleTags(tags: tagTableElement[]) {
+  public async addMultipleTags(tags: TagDraft[]) {
     if (tags.length === 0) {
       return;
     }
@@ -625,7 +629,8 @@ export class RecipeDatabase {
    * adding them automatically if they don't exist.
    *
    * @param rec - The recipe object to add
-   * @returns Promise that resolves when the recipe is added
+   * @returns The persisted recipe, decoded from the database with its assigned id
+   * @throws Error if the database insertion or the post-insert lookup fails
    *
    * @example
    * ```typescript
@@ -642,7 +647,7 @@ export class RecipeDatabase {
    * });
    * ```
    */
-  public async addRecipe(rec: recipeTableElement) {
+  public async addRecipe(rec: RecipeDraft): Promise<recipeTableElement> {
     const recipe = await this.prepareRecipe(rec);
 
     const recipeConverted = this.encodeRecipe(recipe);
@@ -658,7 +663,7 @@ export class RecipeDatabase {
       databaseLogger.error('Failed to add recipe - database insertion failed', {
         recipeTitle: recipe.title,
       });
-      return;
+      throw new Error(`Failed to add recipe "${recipe.title}" to database`);
     }
     const dbRecipe = await this._recipesTable.searchElementById<encodedRecipeElement>(
       dbRes,
@@ -669,18 +674,19 @@ export class RecipeDatabase {
         recipeTitle: recipeConverted.TITLE,
         dbResult: dbRes,
       });
-    } else {
-      const decodedRecipe = await this.decodeRecipe(dbRecipe);
-      this.add_recipes(decodedRecipe);
-      this._recipes = [...this._recipes];
-      this.notify('recipes');
-      databaseLogger.info('Recipe added to cache successfully', {
-        recipeTitle: decodedRecipe.title,
-        recipeId: decodedRecipe.id,
-        recipeCacheCountAfter: this._recipes.length,
-        cachedRecipeTitles: this._recipes.map(r => r.title),
-      });
+      throw new Error(`Failed to retrieve recipe "${recipe.title}" after insertion`);
     }
+    const decodedRecipe = await this.decodeRecipe(dbRecipe);
+    this.add_recipes(decodedRecipe);
+    this._recipes = [...this._recipes];
+    this.notify('recipes');
+    databaseLogger.info('Recipe added to cache successfully', {
+      recipeTitle: decodedRecipe.title,
+      recipeId: decodedRecipe.id,
+      recipeCacheCountAfter: this._recipes.length,
+      cachedRecipeTitles: this._recipes.map(r => r.title),
+    });
+    return decodedRecipe;
   }
 
   /**
@@ -691,7 +697,7 @@ export class RecipeDatabase {
    *
    * @param recs - Array of recipes to add
    */
-  public async addMultipleRecipes(recs: recipeTableElement[]): Promise<void> {
+  public async addMultipleRecipes(recs: RecipeDraft[]): Promise<void> {
     if (recs.length === 0) return;
 
     const prepareRecipeResult = await Promise.allSettled(recs.map(rec => this.prepareRecipe(rec)));
@@ -708,7 +714,7 @@ export class RecipeDatabase {
     });
 
     const prepared = prepareRecipeResult
-      .filter((r): r is PromiseFulfilledResult<recipeTableElement> => r.status === 'fulfilled')
+      .filter((r): r is PromiseFulfilledResult<PreparedRecipe> => r.status === 'fulfilled')
       .map(r => r.value);
 
     if (prepared.length === 0) {
@@ -728,16 +734,11 @@ export class RecipeDatabase {
    * temporary image to permanent storage before persisting the update, then
    * refreshes the in-memory cache and notifies `recipes` subscribers.
    *
-   * @param recipe - The recipe to update. Must have a valid `id`.
+   * @param recipe - The existing recipe to update, carrying its persisted `id`.
    * @returns The prepared recipe object with verified tags and ingredients.
-   * @throws Error if `recipe.id` is undefined.
    * @throws Error if any tags or ingredients are not found in the database.
    */
-  public async editRecipe(recipe: recipeTableElement) {
-    if (recipe.id === undefined) {
-      throw new Error(`Cannot edit recipe without ID: ${recipe.title}`);
-    }
-
+  public async editRecipe(recipe: RecipeDraft & { id: number }): Promise<recipeTableElement> {
     const preparedRecipe = await this.prepareRecipe(recipe);
 
     const updateMap = this.constructUpdateRecipeStructure(this.encodeRecipe(preparedRecipe));
@@ -772,12 +773,6 @@ export class RecipeDatabase {
    * @returns `true` if the update succeeded, `false` otherwise.
    */
   public async editIngredient(ingredient: ingredientTableElement) {
-    if (ingredient.id === undefined) {
-      databaseLogger.warn('Cannot edit ingredient - missing ID', {
-        ingredientName: ingredient.name,
-      });
-      return false;
-    }
     const updateMap = this.constructUpdateIngredientStructure(ingredient);
     const success = await this._ingredientsTable.editElementById(
       ingredient.id,
@@ -805,10 +800,6 @@ export class RecipeDatabase {
    * @returns `true` if the update succeeded, `false` otherwise.
    */
   public async editTag(tag: tagTableElement) {
-    if (tag.id === undefined) {
-      databaseLogger.warn('Cannot edit tag - missing ID', { tagName: tag.name });
-      return false;
-    }
     const updateMap = this.constructUpdateTagStructure(tag);
     const success = await this._tagsTable.editElementById(tag.id, updateMap, this._dbConnection);
     if (success) {
@@ -907,19 +898,11 @@ export class RecipeDatabase {
    * - Removes any corresponding menu entry.
    * - Removes the recipe URL from the seen-history if it originated from a provider.
    *
-   * @param recipe - The recipe to delete. Matched by `id` if present, otherwise by title/description/image.
+   * @param recipe - The persisted recipe to delete, matched by its `id`.
    * @returns `true` if the recipe was deleted, `false` otherwise.
    */
   public async deleteRecipe(recipe: recipeTableElement): Promise<boolean> {
-    let recipeDeleted: boolean;
-    if (recipe.id !== undefined) {
-      recipeDeleted = await this._recipesTable.deleteElementById(recipe.id, this._dbConnection);
-    } else {
-      recipeDeleted = await this._recipesTable.deleteElement(
-        this._dbConnection,
-        this.constructSearchRecipeStructure(recipe)
-      );
-    }
+    const recipeDeleted = await this._recipesTable.deleteElementById(recipe.id, this._dbConnection);
     if (recipeDeleted) {
       this.remove_recipe(recipe);
       this._recipes = [...this._recipes];
@@ -929,11 +912,9 @@ export class RecipeDatabase {
         deleteFile(recipe.image_Source);
       }
 
-      if (recipe.id !== undefined) {
-        const menuItem = this._menu.find(item => item.recipeId === recipe.id);
-        if (menuItem && menuItem.id !== undefined) {
-          await this.removeFromMenu(menuItem.id);
-        }
+      const menuItem = this._menu.find(item => item.recipeId === recipe.id);
+      if (menuItem) {
+        await this.removeFromMenu(menuItem.id);
       }
 
       if (recipe.sourceUrl && recipe.sourceProvider) {
@@ -954,18 +935,10 @@ export class RecipeDatabase {
    * @returns `true` if the ingredient was deleted, `false` otherwise.
    */
   public async deleteIngredient(ingredient: ingredientTableElement): Promise<boolean> {
-    let ingredientDeleted: boolean;
-    if (ingredient.id !== undefined) {
-      ingredientDeleted = await this._ingredientsTable.deleteElementById(
-        ingredient.id,
-        this._dbConnection
-      );
-    } else {
-      ingredientDeleted = await this._ingredientsTable.deleteElement(
-        this._dbConnection,
-        this.constructSearchIngredientStructure(ingredient)
-      );
-    }
+    const ingredientDeleted = await this._ingredientsTable.deleteElementById(
+      ingredient.id,
+      this._dbConnection
+    );
     if (ingredientDeleted) {
       this.remove_ingredient(ingredient);
       this._ingredients = [...this._ingredients];
@@ -1000,15 +973,7 @@ export class RecipeDatabase {
    * @returns `true` if the tag was deleted, `false` otherwise.
    */
   public async deleteTag(tag: tagTableElement): Promise<boolean> {
-    let tagDeleted: boolean;
-    if (tag.id !== undefined) {
-      tagDeleted = await this._tagsTable.deleteElementById(tag.id, this._dbConnection);
-    } else {
-      tagDeleted = await this._tagsTable.deleteElement(
-        this._dbConnection,
-        this.constructSearchTagStructure(tag)
-      );
-    }
+    const tagDeleted = await this._tagsTable.deleteElementById(tag.id, this._dbConnection);
     if (tagDeleted) {
       this.remove_tag(tag);
       this._tags = [...this._tags];
@@ -1108,11 +1073,10 @@ export class RecipeDatabase {
   /**
    * Removes a recipe from the in-memory cache without touching the database.
    *
-   * Matches by `id` when present, otherwise uses partial equality. Logs a warning
-   * if the recipe is not found in the cache. Prefer {@link deleteRecipe} for full
-   * persistence including cascaded cleanup.
+   * Matches by `id`. Logs a warning if the recipe is not found in the cache.
+   * Prefer {@link deleteRecipe} for full persistence including cascaded cleanup.
    *
-   * @param recipe - The recipe to remove from the cache.
+   * @param recipe - The persisted recipe to remove from the cache.
    */
   public remove_recipe(recipe: recipeTableElement) {
     const foundRecipe = this.find_recipe(recipe);
@@ -1227,22 +1191,13 @@ export class RecipeDatabase {
   }
 
   /**
-   * Looks up a recipe in the in-memory cache.
+   * Looks up a recipe in the in-memory cache by its `id`.
    *
-   * Uses strict `id` equality when the recipe has an `id`; falls back to
-   * partial structural equality ({@link isRecipePartiallyEqual}) otherwise.
-   *
-   * @param recipeToFind - Recipe to search for.
+   * @param recipeToFind - Persisted recipe to search for.
    * @returns The matching cached recipe, or `undefined` if not found.
    */
   public find_recipe(recipeToFind: recipeTableElement): recipeTableElement | undefined {
-    let findFunc: (element: recipeTableElement) => boolean;
-    if (recipeToFind.id !== undefined) {
-      findFunc = (element: recipeTableElement) => element.id === recipeToFind.id;
-    } else {
-      findFunc = (element: recipeTableElement) => isRecipePartiallyEqual(element, recipeToFind);
-    }
-    return this._recipes.find(element => findFunc(element));
+    return this._recipes.find(element => element.id === recipeToFind.id);
   }
 
   /**
@@ -1254,7 +1209,7 @@ export class RecipeDatabase {
    * @param ingToFind - Ingredient to search for.
    * @returns The matching cached ingredient, or `undefined` if not found.
    */
-  public find_ingredient(ingToFind: ingredientTableElement): ingredientTableElement | undefined {
+  public find_ingredient(ingToFind: IngredientDraft): ingredientTableElement | undefined {
     let findFunc: (element: ingredientTableElement) => boolean;
     if (ingToFind.id !== undefined) {
       findFunc = (element: ingredientTableElement) => element.id === ingToFind.id;
@@ -1273,7 +1228,7 @@ export class RecipeDatabase {
    * @param tagToSearch - Tag to search for.
    * @returns The matching cached tag, or `undefined` if not found.
    */
-  public find_tag(tagToSearch: tagTableElement): tagTableElement | undefined {
+  public find_tag(tagToSearch: TagDraft): tagTableElement | undefined {
     let findFunc: (element: tagTableElement) => boolean;
     if (tagToSearch.id !== undefined) {
       findFunc = (element: tagTableElement) => element.id === tagToSearch.id;
@@ -1308,18 +1263,11 @@ export class RecipeDatabase {
    * If the recipe is already in the menu, increments its count.
    * Otherwise, it adds the recipe to the menu table with count = 1.
    *
-   * @param recipe - The recipe to add to the menu
+   * @param recipe - The persisted recipe to add to the menu
    */
   public async addRecipeToMenu(recipe: recipeTableElement): Promise<void> {
-    if (!recipe.id) {
-      databaseLogger.warn('Cannot add recipe to menu - missing ID', {
-        recipeTitle: recipe.title,
-      });
-      return;
-    }
-
     const existingMenuItem = this._menu.find(item => item.recipeId === recipe.id);
-    if (existingMenuItem && existingMenuItem.id) {
+    if (existingMenuItem) {
       const newCount = existingMenuItem.count + 1;
       await this._menuTable.editElementById(
         existingMenuItem.id,
@@ -1336,7 +1284,7 @@ export class RecipeDatabase {
       return;
     }
 
-    const menuItem: menuTableElement = {
+    const menuItem: Draft<menuTableElement> = {
       recipeId: recipe.id,
       recipeTitle: recipe.title,
       imageSource: recipe.image_Source,
@@ -1513,8 +1461,11 @@ export class RecipeDatabase {
    * Takes a pre-scaled recipe object and updates it in the database.
    * This method is used for individual recipe updates during progressive scaling operations.
    *
-   * @param scaledRecipe - The recipe object that has already been scaled to target persons
-   * @throws Error if recipe doesn't have an ID or update fails
+   * @param scaledRecipe - The recipe to persist, already scaled to target
+   *   persons. Carries its database `id`; its embedded tags/ingredients are
+   *   normally already resolved, but any unresolved one causes {@link encodeRecipe}
+   *   to throw before the row is touched.
+   * @throws Error if a tag/ingredient cannot be resolved, or if the update fails
    *
    * @example
    * ```typescript
@@ -1523,14 +1474,7 @@ export class RecipeDatabase {
    * await db.scaleAndUpdateRecipe(scaledRecipe);
    * ```
    */
-  public async scaleAndUpdateRecipe(scaledRecipe: recipeTableElement): Promise<void> {
-    if (!scaledRecipe.id) {
-      databaseLogger.error('Cannot update recipe without ID', {
-        recipeTitle: scaledRecipe.title,
-      });
-      throw new Error('Recipe must have an ID to update');
-    }
-
+  public async scaleAndUpdateRecipe(scaledRecipe: RecipeDraft & { id: number }): Promise<void> {
     const updateMap = this.constructUpdateRecipeStructure(this.encodeRecipe(scaledRecipe));
     databaseLogger.debug('Updating scaled recipe', {
       recipeId: scaledRecipe.id,
@@ -1552,7 +1496,9 @@ export class RecipeDatabase {
       throw new Error(`Failed to update recipe ${scaledRecipe.id}`);
     }
 
-    this.update_recipe(scaledRecipe);
+    // Reached only after a successful encode, so every embedded tag/ingredient
+    // resolved to a persisted row; the scaled input itself comes from the cache.
+    this.update_recipe(scaledRecipe as recipeTableElement);
     this._recipes = [...this._recipes];
     this.notify('recipes');
     databaseLogger.debug('Recipe updated successfully', { recipeId: scaledRecipe.id });
@@ -1573,7 +1519,7 @@ export class RecipeDatabase {
    * console.log(`Found ${similar.length} similar recipes`);
    * ```
    */
-  public findSimilarRecipes(recipeToCompare: recipeTableElement): recipeTableElement[] {
+  public findSimilarRecipes(recipeToCompare: RecipeDraft): recipeTableElement[] {
     databaseLogger.info('findSimilarRecipes called', {
       recipeTitle: recipeToCompare.title,
       recipePersons: recipeToCompare.persons,
@@ -1587,7 +1533,7 @@ export class RecipeDatabase {
       ingredientType.oilAndFat,
     ];
 
-    const processIngredients = (recipe: recipeTableElement) => {
+    const processIngredients = (recipe: RecipeDraft) => {
       if (recipe.persons === undefined || recipe.persons === 0) {
         return [];
       }
@@ -1738,9 +1684,7 @@ export class RecipeDatabase {
     );
 
     if (success) {
-      for (const entry of newEntries) {
-        this._importHistory.push(entry as importHistoryTableElement);
-      }
+      this._importHistory.push(...newEntries);
     } else {
       databaseLogger.error('Failed to mark URLs as seen', { providerId, count: newEntries.length });
     }
@@ -1763,15 +1707,11 @@ export class RecipeDatabase {
       count: urls.length,
     });
 
-    for (const url of urls) {
-      const historyEntry = this._importHistory.find(
-        h => h.providerId === providerId && h.recipeUrl === url
-      );
-
-      if (historyEntry?.id) {
-        await this._importHistoryTable.deleteElementById(historyEntry.id, this._dbConnection);
-      }
-    }
+    const conditions = new Map<string, string | string[]>([
+      [importHistoryColumnsNames.providerId, providerId],
+      [importHistoryColumnsNames.recipeUrl, urls],
+    ]);
+    await this._importHistoryTable.deleteElement(this._dbConnection, conditions);
 
     this._importHistory = this._importHistory.filter(
       h => !(h.providerId === providerId && urls.includes(h.recipeUrl))
@@ -1852,9 +1792,7 @@ export class RecipeDatabase {
     );
 
     if (success) {
-      for (const entry of newEntries) {
-        this._dismissedRecipes.push(entry as dismissedRecipeTableElement);
-      }
+      this._dismissedRecipes.push(...newEntries);
     } else {
       databaseLogger.error('Failed to dismiss recipes', { providerId, count: newEntries.length });
     }
@@ -1900,12 +1838,13 @@ export class RecipeDatabase {
    * @returns Prepared recipe ready for encoding and insertion
    * @throws Error if any tags or ingredients are not found in the database
    */
-  private async prepareRecipe(rec: recipeTableElement): Promise<recipeTableElement> {
-    const recipe = { ...rec };
-    recipe.tags = this.verifyTagsExist(rec.tags);
-    recipe.ingredients = this.verifyIngredientsExist(rec.ingredients);
-    recipe.image_Source = await this.prepareRecipeImage(recipe.image_Source, recipe.title);
-    return recipe;
+  private async prepareRecipe<T extends RecipeDraft>(rec: T): Promise<PreparedRecipe<T>> {
+    return {
+      ...rec,
+      tags: this.verifyTagsExist(rec.tags),
+      ingredients: this.verifyIngredientsExist(rec.ingredients),
+      image_Source: await this.prepareRecipeImage(rec.image_Source, rec.title),
+    };
   }
 
   /**
@@ -1914,7 +1853,7 @@ export class RecipeDatabase {
    * @param recipes - Already-validated and prepared recipes to insert
    * @throws Error if the batch database insertion fails
    */
-  private async insertAndCacheRecipes(recipes: recipeTableElement[]): Promise<void> {
+  private async insertAndCacheRecipes(recipes: RecipeDraft[]): Promise<void> {
     const encodedRecipes = recipes.map(recipe => this.encodeRecipe(recipe));
     databaseLogger.debug('Batch adding recipes to database', { count: recipes.length });
 
@@ -2131,7 +2070,7 @@ export class RecipeDatabase {
    * @returns Array of tags with database IDs
    * @throws Error if any tags are not found in the database, listing all missing tags
    */
-  private verifyTagsExist(tags: tagTableElement[]): tagTableElement[] {
+  private verifyTagsExist(tags: TagDraft[]): tagTableElement[] {
     const result: tagTableElement[] = [];
     const missing: string[] = [];
 
@@ -2168,7 +2107,7 @@ export class RecipeDatabase {
    * @returns Array of ingredients with database IDs, recipe-specific quantities, and notes
    * @throws Error if any ingredients are not found in the database, listing all missing ingredients
    */
-  private verifyIngredientsExist(ingredients: ingredientTableElement[]): ingredientTableElement[] {
+  private verifyIngredientsExist(ingredients: IngredientDraft[]): ingredientTableElement[] {
     const result: ingredientTableElement[] = [];
     const missing: string[] = [];
 
@@ -2194,58 +2133,6 @@ export class RecipeDatabase {
   }
 
   /**
-   * Constructs a Map structure for searching recipes in the database
-   *
-   * Creates a search criteria Map using key recipe fields (title, description, image)
-   * for database query operations when searching without an ID.
-   *
-   * @private
-   * @param recipe - The recipe data to construct search criteria from
-   * @returns Map with column names as keys and search values
-   */
-  private constructSearchRecipeStructure(recipe: recipeTableElement): Map<string, string | number> {
-    return new Map<string, string | number>([
-      [recipeColumnsNames.title, recipe.title],
-      [recipeColumnsNames.description, recipe.description],
-      [recipeColumnsNames.image, extractFilenameFromUri(recipe.image_Source)],
-    ]);
-  }
-
-  /**
-   * Constructs a Map structure for searching ingredients in the database
-   *
-   * Creates a search criteria Map using key ingredient fields (name, unit, type)
-   * for database query operations when searching without an ID.
-   *
-   * @private
-   * @param ingredient - The ingredient data to construct search criteria from
-   * @returns Map with column names as keys and search values
-   */
-  private constructSearchIngredientStructure(
-    ingredient: ingredientTableElement
-  ): Map<string, string | number> {
-    return new Map<string, string>([
-      [ingredientsColumnsNames.ingredient, ingredient.name],
-      [ingredientsColumnsNames.unit, ingredient.unit],
-      [ingredientsColumnsNames.type, ingredient.type],
-    ]);
-  }
-
-  /**
-   * Constructs a Map structure for searching tags in the database
-   *
-   * Creates a search criteria Map using the tag name for database query
-   * operations when searching without an ID.
-   *
-   * @private
-   * @param tag - The tag data to construct search criteria from
-   * @returns Map with column names as keys and search values
-   */
-  private constructSearchTagStructure(tag: tagTableElement): Map<string, string | number> {
-    return new Map<string, string | number>([[tagsColumnsNames.name, tag.name]]);
-  }
-
-  /**
    * Encodes a recipe object for database storage
    *
    * Converts a recipe from the application format to the database storage format,
@@ -2256,7 +2143,7 @@ export class RecipeDatabase {
    * @param recToEncode - The recipe object to encode for database storage
    * @returns Encoded recipe element ready for database insertion/update
    */
-  private encodeRecipe(recToEncode: recipeTableElement): encodedRecipeElement {
+  private encodeRecipe(recToEncode: RecipeDraft): encodedRecipeElement {
     return {
       ID: recToEncode.id ? recToEncode.id : 0,
       IMAGE_SOURCE: extractFilenameFromUri(recToEncode.image_Source),
@@ -2387,7 +2274,7 @@ export class RecipeDatabase {
    * // With note
    * encodeIngredient({id: 1, quantity: "200", note: "For the sauce", ...}) // "1--200%%For the sauce"
    */
-  private encodeIngredient(ingredientToEncode: ingredientTableElement): string {
+  private encodeIngredient(ingredientToEncode: IngredientDraft): string {
     const quantity = ingredientToEncode.quantity ? ingredientToEncode.quantity.toString() : '';
     const note = ingredientToEncode.note || '';
     let idForEncoding = ingredientToEncode.id;
@@ -2493,7 +2380,7 @@ export class RecipeDatabase {
    * Input: {id: 1, name: "Flour", unit: "g", type: "grain", season: ["1","2","3","12"]}
    * Output: {"ID":1,"INGREDIENT":"Flour","UNIT":"g", "TYPE":"grain", "SEASON":"1__2__3__12"}
    */
-  private encodeIngredientForDb(ingredient: ingredientTableElement): encodedIngredientElement {
+  private encodeIngredientForDb(ingredient: IngredientDraft): encodedIngredientElement {
     return {
       ID: ingredient.id ? ingredient.id : 0,
       INGREDIENT: ingredient.name,
@@ -2517,7 +2404,7 @@ export class RecipeDatabase {
    * Input: {id: 1, name: "Dessert"}
    * Output: {"ID":1,"NAME":"Dessert"}
    */
-  private encodeTagForDb(tag: tagTableElement): encodedTagElement {
+  private encodeTagForDb(tag: TagDraft): encodedTagElement {
     return {
       ID: tag.id ? tag.id : 0,
       NAME: tag.name,
@@ -2599,7 +2486,7 @@ export class RecipeDatabase {
    * @returns String representation of the tag's database ID
    * @throws Error if the tag cannot be resolved in the database
    */
-  private encodeTagForRecipe(tag: tagTableElement): string {
+  private encodeTagForRecipe(tag: TagDraft): string {
     if (tag.id !== undefined) {
       return tag.id.toString();
     }
@@ -2696,7 +2583,8 @@ export class RecipeDatabase {
    */
   private encodeNutrition(nutrition: nutritionTableElement): string {
     return [
-      nutrition.id || 0,
+      // Leading slot preserves the historical encoding layout (was a row id).
+      0,
       nutrition.energyKcal,
       nutrition.energyKj,
       nutrition.fat,
@@ -2736,7 +2624,6 @@ export class RecipeDatabase {
     }
 
     return {
-      id: Number(parts[0]) || undefined,
       energyKcal: Number(parts[1]),
       energyKj: Number(parts[2]),
       fat: Number(parts[3]),
@@ -2853,9 +2740,9 @@ export class RecipeDatabase {
    * @param menu - The menu item in application format
    * @returns Encoded menu item ready for database storage
    */
-  private encodeMenu(menu: menuTableElement): encodedMenuElement {
+  private encodeMenu(menu: Draft<menuTableElement>): encodedMenuElement {
     return {
-      ID: menu.id ? menu.id : 0,
+      ID: 0,
       RECIPE_ID: menu.recipeId,
       RECIPE_TITLE: menu.recipeTitle,
       IMAGE_SOURCE: menu.imageSource,
@@ -2985,32 +2872,6 @@ export class RecipeDatabase {
   }
 
   /**
-   * Migrates wildcard '*' season values to explicit month lists in the ingredients table.
-   *
-   * Converts SEASON = '*' to '1__2__3__4__5__6__7__8__9__10__11__12'.
-   * Idempotent — safe to run on every startup.
-   *
-   * TODO: Remove this migration once all users have updated past this version.
-   *
-   * @private
-   */
-  private async migrateWildcardSeasons(): Promise<void> {
-    const result = await this._dbConnection.runAsync(
-      `UPDATE "${ingredientsTableName}"
-             SET "${ingredientsColumnsNames.season}" = ?
-             WHERE "${ingredientsColumnsNames.season}" = '*'`,
-      [ALL_MONTHS_ENCODED]
-    );
-    if (result.changes > 0) {
-      databaseLogger.info('Migrated wildcard seasons to explicit months', {
-        ingredientsUpdated: result.changes,
-      });
-    } else {
-      databaseLogger.debug('Wildcard season migration: no wildcards found');
-    }
-  }
-
-  /**
    * Retrieves all import history records from the database
    *
    * @private
@@ -3035,7 +2896,6 @@ export class RecipeDatabase {
    */
   private decodeImportHistory(encoded: encodedImportHistoryElement): importHistoryTableElement {
     return {
-      id: encoded.ID,
       providerId: encoded.PROVIDER_ID,
       recipeUrl: encoded.RECIPE_URL,
       lastSeenAt: encoded.LAST_SEEN_AT,
@@ -3049,7 +2909,7 @@ export class RecipeDatabase {
    */
   private encodeImportHistory(history: importHistoryTableElement): encodedImportHistoryElement {
     return {
-      ID: history.id || 0,
+      ID: 0,
       PROVIDER_ID: history.providerId,
       RECIPE_URL: history.recipeUrl,
       LAST_SEEN_AT: history.lastSeenAt,
@@ -3083,7 +2943,6 @@ export class RecipeDatabase {
     encoded: encodedDismissedRecipeElement
   ): dismissedRecipeTableElement {
     return {
-      id: encoded.ID,
       providerId: encoded.PROVIDER_ID,
       recipeUrl: encoded.RECIPE_URL,
       title: encoded.TITLE,
@@ -3101,7 +2960,7 @@ export class RecipeDatabase {
     dismissed: dismissedRecipeTableElement
   ): encodedDismissedRecipeElement {
     return {
-      ID: dismissed.id || 0,
+      ID: 0,
       PROVIDER_ID: dismissed.providerId,
       RECIPE_URL: dismissed.recipeUrl,
       TITLE: dismissed.title,

--- a/src/utils/RecipeFormHelpers.tsx
+++ b/src/utils/RecipeFormHelpers.tsx
@@ -17,8 +17,9 @@ import {
   extractTagsName,
   nutritionTableElement,
   recipeColumnsNames,
+  RecipeDraft,
   recipeTableElement,
-  tagTableElement,
+  TagDraft,
 } from '@customTypes/DatabaseElementTypes';
 import { RecipePropType } from '@customTypes/RecipeNavigationTypes';
 import { defaultValueNumber } from '@utils/Constants';
@@ -138,10 +139,7 @@ export function hasScrapedDataFromProps(
  * @param defaultPersons - The default person count for normalization
  * @returns Recipe with scaled ingredient quantities and normalized persons
  */
-export function scaleRecipeForSave(
-  recipe: recipeTableElement,
-  defaultPersons: number
-): recipeTableElement {
+export function scaleRecipeForSave(recipe: RecipeDraft, defaultPersons: number): RecipeDraft {
   if (recipe.persons === defaultPersons || recipe.persons <= 0) {
     return recipe;
   }
@@ -370,7 +368,7 @@ export function buildRecipeDescriptionProps({
  * @returns Props object for RecipeTags component
  */
 export interface RecipeTagsPropsInput extends BaseFieldInput {
-  recipeTags: tagTableElement[];
+  recipeTags: TagDraft[];
   randomTags: string[];
   addTag: (newTag: string) => void;
   removeTag: (tagName: string) => void;

--- a/src/utils/RecipeScraperConverter.ts
+++ b/src/utils/RecipeScraperConverter.ts
@@ -19,7 +19,7 @@ import {
   FormIngredientElement,
   nutritionTableElement,
   preparationStepElement,
-  tagTableElement,
+  TagDraft,
 } from '@customTypes/DatabaseElementTypes';
 import {
   IngredientGroup,
@@ -72,9 +72,10 @@ export type ConvertedIngredients = {
 
 export type ScrapedRecipeResult = Omit<
   Partial<import('@customTypes/DatabaseElementTypes').recipeTableElement>,
-  'ingredients' | 'nutrition'
+  'ingredients' | 'nutrition' | 'tags'
 > & {
   ingredients: FormIngredientElement[];
+  tags?: TagDraft[];
   skippedIngredients?: string[];
   nutrition?: nutritionTableElement;
 };
@@ -278,8 +279,8 @@ export function parseServings(yields: string | undefined, defaultPersons: number
   return extractFirstInteger(yields) ?? defaultPersons;
 }
 
-export function convertTags(keywords: string[], dietaryRestrictions: string[]): tagTableElement[] {
-  const tags: tagTableElement[] = [];
+export function convertTags(keywords: string[], dietaryRestrictions: string[]): TagDraft[] {
+  const tags: TagDraft[] = [];
 
   const addTagIfNotDuplicate = (name: string) => {
     const trimmed = name.trim();

--- a/src/utils/RecipeValidationHelpers.ts
+++ b/src/utils/RecipeValidationHelpers.ts
@@ -14,6 +14,7 @@
 import {
   FormIngredientElement,
   ingredientTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import { IngredientWithSimilarity, TagWithSimilarity } from '@customTypes/ValidationTypes';
@@ -93,7 +94,7 @@ export function removeIngredientByName(
  * Removes a tag from array by name (case-insensitive).
  * Used when user dismisses a tag during validation.
  */
-export function removeTagByName(tags: tagTableElement[], nameToRemove: string): tagTableElement[] {
+export function removeTagByName(tags: TagDraft[], nameToRemove: string): TagDraft[] {
   return tags.filter(tag => !namesMatch(tag.name, nameToRemove));
 }
 
@@ -169,9 +170,9 @@ export function addOrMergeIngredientMatches(
  * Used by scraper validation to update form tags with database matches.
  */
 export function replaceMatchingTags(
-  current: tagTableElement[],
+  current: TagDraft[],
   exactMatches: tagTableElement[]
-): tagTableElement[] {
+): TagDraft[] {
   const updated = [...current];
   for (const tag of exactMatches) {
     const idx = updated.findIndex(e => namesMatch(e.name, tag.name));
@@ -211,7 +212,7 @@ export function addNonDuplicateByName<T extends { name?: string }>(
  * @returns Object with exactMatches and needsValidation arrays (with similarity info)
  */
 export function processTagsForValidation(
-  tags: tagTableElement[],
+  tags: TagDraft[],
   findSimilarTags: (name: string) => tagTableElement[]
 ): {
   exactMatches: tagTableElement[];
@@ -451,7 +452,7 @@ export function sortAlphabetically<T extends { name?: string }>(items: T[]): T[]
  * @returns Tags with pre-computed similar items
  */
 export function computeTagSimilarity(
-  tags: tagTableElement[],
+  tags: TagDraft[],
   findSimilarTags: (name: string) => tagTableElement[]
 ): TagWithSimilarity[] {
   return tags.map(tag => ({

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -14,23 +14,22 @@ import {
 } from '@customTypes/DatabaseElementTypes';
 
 /**
- * Key extractor for recipe list items.
- * Prefers the database ID; falls back to the recipe title when no ID exists (new/unsaved recipes).
+ * Key extractor for recipe list items, keyed on the persisted database id.
  *
  * @param item - Recipe to extract a key from
  * @returns Unique string key for the item
  */
 export function getRecipeKey(item: recipeTableElement): string {
-  return item.id?.toString() ?? item.title;
+  return item.id.toString();
 }
 
 /**
- * Key extractor for settings list items (ingredients and tags).
- * Prefers the database ID; falls back to the item name when no ID exists (new/unsaved items).
+ * Key extractor for settings list items (ingredients and tags), keyed on the
+ * persisted database id. Settings lists only ever render persisted rows.
  *
  * @param item - Ingredient or tag to extract a key from
  * @returns Unique string key for the item
  */
 export function getSettingsItemKey(item: ingredientTableElement | tagTableElement): string {
-  return item.id?.toString() ?? item.name;
+  return item.id.toString();
 }

--- a/tests/integration/MenuAndShoppingPipeline.test.tsx
+++ b/tests/integration/MenuAndShoppingPipeline.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useMenu } from '@hooks/useMenu';
 import { useShopping } from '@hooks/useShopping';
 import RecipeDatabase from '@utils/RecipeDatabase';
-import { ingredientType, recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { ingredientType, RecipeDraft } from '@customTypes/DatabaseElementTypes';
 
 const catalogIngredients = [
   { name: 'Pasta', unit: 'g', type: ingredientType.cereal, season: [] },
@@ -12,7 +12,7 @@ const catalogIngredients = [
   { name: 'Onion', unit: 'g', type: ingredientType.vegetable, season: [] },
 ];
 
-const pastaRecipe: recipeTableElement = {
+const pastaRecipe: RecipeDraft = {
   title: 'Pasta Primavera',
   image_Source: '',
   description: '',
@@ -28,7 +28,7 @@ const pastaRecipe: recipeTableElement = {
   time: 20,
 };
 
-const saladRecipe: recipeTableElement = {
+const saladRecipe: RecipeDraft = {
   title: 'Garden Salad',
   image_Source: '',
   description: '',
@@ -44,7 +44,7 @@ const saladRecipe: recipeTableElement = {
   time: 10,
 };
 
-const soupRecipe: recipeTableElement = {
+const soupRecipe: RecipeDraft = {
   title: 'Tomato Soup',
   image_Source: '',
   description: '',

--- a/tests/integration/OCRIngredientQuantityBinding.test.tsx
+++ b/tests/integration/OCRIngredientQuantityBinding.test.tsx
@@ -10,6 +10,7 @@ import RecipeDatabase from '@utils/RecipeDatabase';
 import { normalizeKey } from '@utils/NutritionUtils';
 import {
   FormIngredientElement,
+  IngredientDraft,
   ingredientTableElement,
   ingredientType,
 } from '@customTypes/DatabaseElementTypes';
@@ -79,7 +80,7 @@ function FormDrivenApplyPatchRegistrar({ children }: { children: React.ReactNode
 
 const mockRecognize = TextRecognition.recognize as jest.Mock;
 
-const seededIngredients: ingredientTableElement[] = [
+const seededIngredients: IngredientDraft[] = [
   'Carotte',
   'Cumin',
   'Merguez',

--- a/tests/integration/RecipeFormIngredientsPipeline.test.tsx
+++ b/tests/integration/RecipeFormIngredientsPipeline.test.tsx
@@ -16,6 +16,7 @@ import {
 import RecipeDatabase from '@utils/RecipeDatabase';
 import {
   FormIngredientElement,
+  IngredientDraft,
   ingredientTableElement,
   ingredientType,
 } from '@customTypes/DatabaseElementTypes';
@@ -51,28 +52,28 @@ function makeFormApplyPatch(form: RecipeForm): ApplyIngredientEditPatch {
   };
 }
 
-const tomato: ingredientTableElement = {
+const tomato: IngredientDraft = {
   name: 'Tomato',
   unit: 'g',
   type: ingredientType.vegetable,
   season: [],
 };
 
-const onion: ingredientTableElement = {
+const onion: IngredientDraft = {
   name: 'Onion',
   unit: 'g',
   type: ingredientType.vegetable,
   season: [],
 };
 
-const garlic: ingredientTableElement = {
+const garlic: IngredientDraft = {
   name: 'Garlic',
   unit: 'clove',
   type: ingredientType.condiment,
   season: [],
 };
 
-const seededIngredients: ingredientTableElement[] = [tomato, onion, garlic];
+const seededIngredients: IngredientDraft[] = [tomato, onion, garlic];
 
 function FormDrivenApplyPatchRegistrar({ children }: { children: React.ReactNode }) {
   const { form } = useRecipeForm();
@@ -126,6 +127,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 1,
           name: 'Tomato',
           unit: 'g',
           quantity: '100',
@@ -144,6 +146,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 2,
           name: 'Onion',
           unit: 'g',
           quantity: '50',
@@ -154,6 +157,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 3,
           name: 'Onion',
           unit: 'g',
           quantity: '75',
@@ -171,6 +175,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 4,
           name: 'Garlic',
           unit: 'clove',
           quantity: '2',
@@ -181,6 +186,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 5,
           name: 'Garlic',
           unit: 'g',
           quantity: '10',
@@ -199,6 +205,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 6,
           name: 'Tomato',
           unit: 'g',
           quantity: '100',
@@ -210,6 +217,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 7,
           name: 'Tomato',
           unit: 'g',
           quantity: '50',
@@ -235,6 +243,7 @@ describe('RecipeFormIngredientsPipeline (real DB + FuzzyIndex, no internal mocks
 
       act(() => {
         result.current.ingredientOps.addOrMergeIngredient({
+          id: 8,
           name: 'Onion',
           unit: 'g',
           quantity: '100',

--- a/tests/integration/RecipeFormTagsPipeline.test.tsx
+++ b/tests/integration/RecipeFormTagsPipeline.test.tsx
@@ -5,12 +5,12 @@ import { RecipeFormProvider, useRecipeForm } from '@test-helpers/recipeFormTestP
 import { RecipeDialogsProvider, useRecipeDialogs } from '@context/RecipeDialogsContext';
 import { createMockRecipeProp } from '@test-helpers/recipeHookTestWrapper';
 import RecipeDatabase from '@utils/RecipeDatabase';
-import { tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { TagDraft } from '@customTypes/DatabaseElementTypes';
 
-const italianTag: tagTableElement = { name: 'Italian', id: undefined };
-const quickMealsTag: tagTableElement = { name: 'Quick Meals', id: undefined };
+const italianTag: TagDraft = { name: 'Italian' };
+const quickMealsTag: TagDraft = { name: 'Quick Meals' };
 
-const seededTags: tagTableElement[] = [italianTag, quickMealsTag];
+const seededTags: TagDraft[] = [italianTag, quickMealsTag];
 
 function createWrapper() {
   const props = createMockRecipeProp('addManually');

--- a/tests/integration/ValidationWorkflowRealDB.test.tsx
+++ b/tests/integration/ValidationWorkflowRealDB.test.tsx
@@ -4,8 +4,10 @@ import { useIngredients } from '@hooks/useIngredients';
 import { useTags } from '@hooks/useTags';
 import { RecipeDatabase } from '@utils/RecipeDatabase';
 import {
+  IngredientDraft,
   ingredientTableElement,
   ingredientType,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import { ConvertedImportRecipe } from '@customTypes/BulkImportTypes';
@@ -38,11 +40,11 @@ function buildRecipe(
   };
 }
 
-function buildIngredient(name: string): ingredientTableElement {
+function buildIngredient(name: string): IngredientDraft {
   return { name, unit: 'g', type: ingredientType.vegetable, season: [] };
 }
 
-function buildTag(name: string): tagTableElement {
+function buildTag(name: string): TagDraft {
   return { name };
 }
 

--- a/tests/mocks/components/organisms/ValidationReviewList-mock.tsx
+++ b/tests/mocks/components/organisms/ValidationReviewList-mock.tsx
@@ -20,7 +20,9 @@ export function validationReviewListMock({
       <Button
         testID={`${testId}::onImport`}
         onPress={() => {
-          const tagMappings = new Map(rawTags.map(t => [normalizeKey(t.name), t]));
+          const tagMappings = new Map(
+            rawTags.map(t => [normalizeKey(t.name), { id: t.id ?? 0, name: t.name }])
+          );
           const ingredientMappings = new Map(
             rawIngredients
               .filter(i => !!i.name)

--- a/tests/mocks/styles/typography-mock.tsx
+++ b/tests/mocks/styles/typography-mock.tsx
@@ -2,7 +2,6 @@ export const mockUseFetchFonts = jest.fn();
 
 export const EncodingSeparator = '__';
 export const ALL_MONTHS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const;
-export const ALL_MONTHS_ENCODED = ALL_MONTHS.join(EncodingSeparator);
 export const textSeparator = '--';
 export const unitySeparator = '@@';
 export const noteSeparator = '%%';
@@ -12,7 +11,6 @@ export function typographyMock() {
     useFetchFonts: mockUseFetchFonts,
     EncodingSeparator,
     ALL_MONTHS,
-    ALL_MONTHS_ENCODED,
     textSeparator,
     unitySeparator,
     noteSeparator,

--- a/tests/perf/Home.perf.tsx
+++ b/tests/perf/Home.perf.tsx
@@ -51,6 +51,7 @@ function HomeWrapper() {
 }
 
 const testRecipe: recipeTableElement = {
+  id: 1,
   title: 'Performance Test Recipe',
   description: 'A test recipe for performance testing',
   ingredients: [],

--- a/tests/perf/Parameters.perf.tsx
+++ b/tests/perf/Parameters.perf.tsx
@@ -255,7 +255,7 @@ describe('TagsSettings Screen Performance', () => {
       if (tags.length > 0) {
         const tag = tags[0];
         await database.editTag({
-          ...tag,
+          ...tag!,
           name: tag!.name + ' (edited)',
         });
       }

--- a/tests/perf/Search.perf.tsx
+++ b/tests/perf/Search.perf.tsx
@@ -32,6 +32,7 @@ function SearchWrapper() {
 }
 
 const testRecipe: recipeTableElement = {
+  id: 1,
   title: 'Performance Test Recipe',
   description: 'A test recipe for performance testing',
   ingredients: [],

--- a/tests/unit/components/SettingsItemList.test.tsx
+++ b/tests/unit/components/SettingsItemList.test.tsx
@@ -153,30 +153,6 @@ describe('SettingsItemList Component', () => {
         )
       ).toBeNull();
     });
-
-    test('uses item name as key when id is missing', () => {
-      const noIdIngredients: ingredientTableElement[] = [
-        { ...mockIngredients[0]!, id: undefined as any },
-        { ...mockIngredients[1]!, id: undefined as any },
-      ];
-      const props: SettingsItemListProps<ingredientTableElement> = {
-        ...defaultProps,
-        items: noIdIngredients,
-      };
-
-      const { getByTestId } = render(<SettingsItemList {...props} />);
-
-      expect(
-        getByTestId(
-          `${defaultProps.testIdPrefix}::${noIdIngredients[0]!.name}::SettingsItemCard::Item`
-        )
-      ).toBeTruthy();
-      expect(
-        getByTestId(
-          `${defaultProps.testIdPrefix}::${noIdIngredients[1]!.name}::SettingsItemCard::Item`
-        )
-      ).toBeTruthy();
-    });
   });
 
   describe('tag', () => {

--- a/tests/unit/components/dialogs/ItemDialog.test.tsx
+++ b/tests/unit/components/dialogs/ItemDialog.test.tsx
@@ -6,6 +6,7 @@ import {
   FormIngredientElement,
   ingredientTableElement,
   ingredientType,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 
@@ -463,7 +464,7 @@ describe('ItemDialog Component', () => {
     });
 
     test('enables confirm button when ingredient has empty unit in add mode', () => {
-      const ingredientWithoutUnit: ingredientTableElement = {
+      const ingredientWithoutUnit: FormIngredientElement = {
         name: 'Test Ingredient',
         type: ingredientType.fruit,
         unit: '',
@@ -548,7 +549,7 @@ describe('ItemDialog Component', () => {
     });
 
     test('disables confirm button when ingredient has empty name', () => {
-      const invalidIngredient: ingredientTableElement = {
+      const invalidIngredient: FormIngredientElement = {
         name: '',
         type: ingredientType.fruit,
         unit: 'kg',
@@ -575,7 +576,7 @@ describe('ItemDialog Component', () => {
     });
 
     test('enables confirm button when ingredient has valid data in add mode', () => {
-      const validIngredient: ingredientTableElement = {
+      const validIngredient: FormIngredientElement = {
         name: 'Test Ingredient',
         type: ingredientType.fruit,
         unit: 'kg',
@@ -647,7 +648,7 @@ describe('ItemDialog Component', () => {
     });
 
     test('enables confirm button in delete mode regardless of type or unit', () => {
-      const invalidIngredient: ingredientTableElement = {
+      const invalidIngredient: FormIngredientElement = {
         name: 'Test Ingredient',
         type: ingredientType.cereal,
         unit: '',
@@ -677,7 +678,7 @@ describe('ItemDialog Component', () => {
 
   describe('validation for tags', () => {
     test('disables confirm button when tag has empty name in add mode', () => {
-      const invalidTag: tagTableElement = {
+      const invalidTag: TagDraft = {
         name: '',
       };
 
@@ -701,7 +702,7 @@ describe('ItemDialog Component', () => {
     });
 
     test('enables confirm button when tag has valid name in add mode', () => {
-      const validTag: tagTableElement = {
+      const validTag: TagDraft = {
         name: 'Test Tag',
       };
 
@@ -811,14 +812,14 @@ describe('ItemDialog Component', () => {
     });
 
     test('updates ingredient state when dialog reopens with different ingredient', () => {
-      const firstIngredient: ingredientTableElement = {
+      const firstIngredient: FormIngredientElement = {
         name: 'First Ingredient',
         type: ingredientType.fruit,
         unit: 'kg',
         season: ['1', '2'],
       };
 
-      const secondIngredient: ingredientTableElement = {
+      const secondIngredient: FormIngredientElement = {
         name: 'Second Ingredient',
         type: ingredientType.vegetable,
         unit: 'pieces',

--- a/tests/unit/components/molecules/DismissedRecipeCard.test.tsx
+++ b/tests/unit/components/molecules/DismissedRecipeCard.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { dismissedRecipeTableElement } from '@customTypes/DatabaseElementTypes';
 
 const mockRecipe: dismissedRecipeTableElement = {
-  id: 1,
   providerId: 'hellofresh',
   recipeUrl: 'https://hellofresh.com/recipe-1',
   title: 'Dismissed Recipe',

--- a/tests/unit/components/molecules/MenuRecipeCard.test.tsx
+++ b/tests/unit/components/molecules/MenuRecipeCard.test.tsx
@@ -323,21 +323,9 @@ describe('MenuRecipeCard', () => {
       expect(getByTestId(`${testId}::Title`).props.children).toBe(specialCharMenuItem.recipeTitle);
     });
 
-    test('handles menu item without id', () => {
-      const menuItemWithoutId: menuTableElement = {
-        recipeId: 1,
-        recipeTitle: 'Test Recipe',
-        imageSource: 'test.jpg',
-        isCooked: false,
-        count: 1,
-      };
-      const { getByTestId } = renderMenuRecipeCard({ menuItem: menuItemWithoutId });
-
-      assertBasicElements(getByTestId, menuItemWithoutId);
-    });
-
     test('renders correctly with all edge case combinations', () => {
       const edgeCaseMenuItem: menuTableElement = {
+        id: 1,
         recipeId: 1,
         recipeTitle: '',
         imageSource: '',

--- a/tests/unit/components/molecules/NutritionTable.test.tsx
+++ b/tests/unit/components/molecules/NutritionTable.test.tsx
@@ -15,7 +15,6 @@ jest.mock('@components/dialogs/Alert', () => ({
 }));
 
 const mockNutrition: nutritionTableElement = {
-  id: 1,
   energyKcal: 250,
   energyKj: 1046,
   fat: 15.0,

--- a/tests/unit/components/organisms/RecipeNutrition.test.tsx
+++ b/tests/unit/components/organisms/RecipeNutrition.test.tsx
@@ -14,7 +14,6 @@ jest.mock('@components/molecules/NutritionEmptyState', () =>
 );
 
 const mockNutrition: nutritionTableElement = {
-  id: 1,
   energyKcal: 250,
   energyKj: 1046,
   fat: 15.0,

--- a/tests/unit/context/RecipeDatabaseContext.test.tsx
+++ b/tests/unit/context/RecipeDatabaseContext.test.tsx
@@ -625,16 +625,6 @@ describe('focused database hooks', () => {
       );
     });
 
-    test('propagates error thrown by db when recipe has no ID', async () => {
-      const { result } = renderHook(() => useAllHooks());
-
-      await waitFor(() => expect(result.current.recipes.length).toBeGreaterThan(0));
-
-      const recipe = result.current.recipes.find(r => r.id === testRecipes[0]!.id)!;
-
-      await expect(result.current.editRecipe({ ...recipe, id: undefined })).rejects.toThrow();
-    });
-
     test('deleteFile is called with the previous URI, not the new one', async () => {
       const { result } = renderHook(() => useAllHooks());
 

--- a/tests/unit/customTypes/DatabaseElementTypes.test.tsx
+++ b/tests/unit/customTypes/DatabaseElementTypes.test.tsx
@@ -7,12 +7,14 @@ import {
   ingredientTableElement,
   ingredientType,
   isIngredientEqual,
+  IngredientDraft,
   isRecipeEqual,
-  isRecipePartiallyEqual,
   isTagEqual,
   recipeTableElement,
+  TagDraft,
   tagTableElement,
-} from '@customTypes//DatabaseElementTypes';
+  withId,
+} from '@customTypes/DatabaseElementTypes';
 import { testRecipes } from '@test-data/recipesDataset';
 import { testIngredients } from '@test-data/ingredientsDataset';
 import { testTags } from '@test-data/tagsDataset';
@@ -21,6 +23,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
   test('arrayOfType filters ingredients by type', () => {
     const ingredients: ingredientTableElement[] = [
       {
+        id: 1,
         name: 'Sugar',
         unit: 'g',
         quantity: '100',
@@ -28,6 +31,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
         season: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
       },
       {
+        id: 2,
         name: 'Flour',
         unit: 'g',
         quantity: '200',
@@ -35,6 +39,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
         season: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
       },
       {
+        id: 3,
         name: 'Spaghetti',
         unit: 'g',
         quantity: '200',
@@ -101,6 +106,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
 
   test('extractIngredientsNameWithQuantity formats ingredient names correctly', () => {
     const monoIngredient = new Array<ingredientTableElement>({
+      id: 1,
       name: 'Sugar',
       unit: 'g',
       quantity: '100',
@@ -112,6 +118,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
 
     const multiIngredient = new Array<ingredientTableElement>(
       {
+        id: 1,
         name: 'Sugar',
         unit: 'g',
         quantity: '100',
@@ -119,6 +126,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
         season: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
       },
       {
+        id: 2,
         name: 'Flour',
         unit: 'g',
         quantity: '200',
@@ -126,6 +134,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
         season: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
       },
       {
+        id: 3,
         name: 'Spaghetti',
         unit: 'g',
         quantity: '200',
@@ -141,90 +150,8 @@ describe('DatabaseElementTypes Helper Functions', () => {
   });
 
   test('extractTagsName extracts tag names', () => {
-    const tags = new Array<tagTableElement>({ name: 'Dessert' }, { name: 'Vegan' });
+    const tags = new Array<TagDraft>({ name: 'Dessert' }, { name: 'Vegan' });
     expect(extractTagsName(tags)).toEqual(['Dessert', 'Vegan']);
-  });
-
-  test('isRecipePartiallyEqual correctly identifies closes enough recipes', () => {
-    expect(isRecipePartiallyEqual(testRecipes[0]!, testRecipes[1]!)).toBe(false);
-    expect(isRecipePartiallyEqual(testRecipes[0]!, testRecipes[0]!)).toBe(true);
-
-    let expected: recipeTableElement = { ...testRecipes[0]!, id: 9999 };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, image_Source: 'Different Image' };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(false);
-
-    expected = { ...testRecipes[1]!, image_Source: 'Different Image' };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(false);
-
-    expected = { ...testRecipes[0]!, description: 'Different description' };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(false);
-
-    expected = { ...testRecipes[0]!, tags: [] };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, tags: [{ name: 'One' }, { name: 'Two' }] };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, tags: [...testRecipes[0]!.tags, { name: 'Another one' }] };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = {
-      ...testRecipes[0]!,
-      ingredients: [
-        {
-          name: 'New Ingredient',
-          season: ['never mind'],
-          type: ingredientType.cereal,
-          quantity: '0',
-          unit: 'unit',
-        },
-      ],
-    };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, ingredients: [] };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = {
-      ...testRecipes[0]!,
-      ingredients: [
-        ...testRecipes[0]!.ingredients,
-        {
-          name: 'New Ingredient',
-          season: ['never mind'],
-          type: ingredientType.cereal,
-          quantity: '0',
-          unit: 'unit',
-        },
-      ],
-    };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, persons: -1 };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, season: ['not season'] };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = {
-      ...testRecipes[0]!,
-      preparation: [{ title: 'Different', description: 'A different preparation' }],
-    };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = { ...testRecipes[0]!, preparation: [] };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
-
-    expected = {
-      ...testRecipes[0]!,
-      preparation: [
-        ...testRecipes[0]!.preparation,
-        { title: 'New', description: 'A new element in preparation' },
-      ],
-    };
-    expect(isRecipePartiallyEqual(testRecipes[0]!, expected)).toBe(true);
   });
 
   test('isRecipeEqual correctly identifies equal recipes', () => {
@@ -246,16 +173,20 @@ describe('DatabaseElementTypes Helper Functions', () => {
     expected = { ...testRecipes[0]!, tags: [] };
     expect(isRecipeEqual(testRecipes[0]!, expected)).toBe(false);
 
-    expected = { ...testRecipes[0]!, tags: [{ name: 'One' }, { name: 'Two' }] };
+    expected = { ...testRecipes[0]!, tags: [{ id: 1, name: 'One' }, { id: 2, name: 'Two' }] };
     expect(isRecipeEqual(testRecipes[0]!, expected)).toBe(false);
 
-    expected = { ...testRecipes[0]!, tags: [...testRecipes[0]!.tags, { name: 'Another one' }] };
+    expected = {
+      ...testRecipes[0]!,
+      tags: [...testRecipes[0]!.tags, { id: 999, name: 'Another one' }],
+    };
     expect(isRecipeEqual(testRecipes[0]!, expected)).toBe(false);
 
     expected = {
       ...testRecipes[0]!,
       ingredients: [
         {
+          id: 1000,
           name: 'New Ingredient',
           season: ['never mind'],
           type: ingredientType.cereal,
@@ -274,6 +205,7 @@ describe('DatabaseElementTypes Helper Functions', () => {
       ingredients: [
         ...testRecipes[0]!.ingredients,
         {
+          id: 1001,
           name: 'New Ingredient',
           season: ['never mind'],
           type: ingredientType.cereal,
@@ -409,5 +341,36 @@ describe('DatabaseElementTypes Helper Functions', () => {
         'Ingredient "Flour" must have a type before saving'
       );
     });
+  });
+});
+
+describe('withId', () => {
+  test('attaches the id to a tag draft', () => {
+    const draft: TagDraft = { name: 'Dessert' };
+
+    expect(withId<tagTableElement>(draft, 5)).toEqual({ id: 5, name: 'Dessert' });
+  });
+
+  test('attaches the id to an ingredient draft', () => {
+    const draft: IngredientDraft = {
+      name: 'Flour',
+      unit: 'g',
+      type: ingredientType.baking,
+      season: [],
+    };
+
+    expect(withId<ingredientTableElement>(draft, 12)).toEqual({
+      id: 12,
+      name: 'Flour',
+      unit: 'g',
+      type: ingredientType.baking,
+      season: [],
+    });
+  });
+
+  test('overwrites an id already present on the draft', () => {
+    const draft: TagDraft = { id: 1, name: 'Vegan' };
+
+    expect(withId<tagTableElement>(draft, 9).id).toBe(9);
   });
 });

--- a/tests/unit/hooks/useIngredients.ocrMatching.test.tsx
+++ b/tests/unit/hooks/useIngredients.ocrMatching.test.tsx
@@ -1,16 +1,16 @@
 import { renderHook } from '@testing-library/react-native';
 import { useIngredients } from '@hooks/useIngredients';
 import RecipeDatabase from '@utils/RecipeDatabase';
-import { ingredientTableElement, ingredientType } from '@customTypes/DatabaseElementTypes';
+import { IngredientDraft, ingredientType } from '@customTypes/DatabaseElementTypes';
 
-const makeIngredient = (name: string): ingredientTableElement => ({
+const makeIngredient = (name: string): IngredientDraft => ({
   name,
   unit: 'g',
   type: ingredientType.vegetable,
   season: [],
 });
 
-const quitoqueIngredients: ingredientTableElement[] = [
+const quitoqueIngredients: IngredientDraft[] = [
   'Carotte',
   'Cumin',
   'Merguez',

--- a/tests/unit/hooks/useIngredients.test.tsx
+++ b/tests/unit/hooks/useIngredients.test.tsx
@@ -1,9 +1,9 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { useIngredients } from '@hooks/useIngredients';
 import RecipeDatabase from '@utils/RecipeDatabase';
-import { ingredientTableElement, ingredientType } from '@customTypes/DatabaseElementTypes';
+import { IngredientDraft, ingredientType } from '@customTypes/DatabaseElementTypes';
 
-const makeIngredient = (name: string): ingredientTableElement => ({
+const makeIngredient = (name: string): IngredientDraft => ({
   name,
   unit: 'g',
   type: ingredientType.vegetable,

--- a/tests/unit/hooks/useRecipeIngredients.test.tsx
+++ b/tests/unit/hooks/useRecipeIngredients.test.tsx
@@ -1980,7 +1980,7 @@ describe('useRecipeIngredients', () => {
         const recipeWithEmptyRow: recipeTableElement = {
           ...recipeWithIngredients,
           ingredients: [
-            { name: '', unit: '', quantity: '', type: ingredientType.cereal, season: [] },
+            { id: 1, name: '', unit: '', quantity: '', type: ingredientType.cereal, season: [] },
           ],
         };
 

--- a/tests/unit/screens/TagsSettings.test.tsx
+++ b/tests/unit/screens/TagsSettings.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import TagsSettings from '@screens/TagsSettings';
-import { isTagEqual, tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { isTagEqual, TagDraft, tagTableElement } from '@customTypes/DatabaseElementTypes';
 import { mockNavigationFunctions } from '@mocks/deps/react-navigation-mock';
 import RecipeDatabase from '@utils/RecipeDatabase';
 import { testIngredients } from '@test-data/ingredientsDataset';
@@ -50,7 +50,7 @@ function dialogIsNotOpen(queryByTestId: QueryByIdType) {
   expect(queryByTestId('TagsSettings::ItemDialog::IsVisible')).toBeNull();
 }
 
-function dialogIsOpen(item: tagTableElement, mode: DialogMode, getByTestId: GetByIdType) {
+function dialogIsOpen(item: TagDraft, mode: DialogMode, getByTestId: GetByIdType) {
   expect(getByTestId('TagsSettings::ItemDialog::IsVisible').props.children).toEqual(true);
   expect(getByTestId('TagsSettings::ItemDialog::Mode').props.children).toEqual(mode);
   expect(getByTestId('TagsSettings::ItemDialog::OnClose')).toBeTruthy();

--- a/tests/unit/screens/recipe/RecipeEdit.test.tsx
+++ b/tests/unit/screens/recipe/RecipeEdit.test.tsx
@@ -277,6 +277,7 @@ describe('RecipeEdit', () => {
       const newPropEdit: EditRecipeProp = {
         ...mockRouteEdit,
         recipe: {
+          id: mockRouteEdit.recipe.id,
           image_Source: mockRouteEdit.recipe.image_Source,
           title: 'New Recipe Title',
           description: 'New Recipe Description',

--- a/tests/unit/utils/FilterFunctions.test.tsx
+++ b/tests/unit/utils/FilterFunctions.test.tsx
@@ -812,6 +812,7 @@ describe('FilterFunctions', () => {
       const tags = database.get_tags();
 
       const nonExistingGrain: ingredientTableElement = {
+        id: 99999,
         name: 'NonExistentGrainCandidate',
         unit: 'g',
         type: ingredientType.cereal,

--- a/tests/unit/utils/OCR.test.tsx
+++ b/tests/unit/utils/OCR.test.tsx
@@ -6,7 +6,7 @@ import {
   WarningHandler,
 } from '@utils/OCR';
 import { nutritionObject } from '@customTypes/OCRTypes';
-import { recipeColumnsNames, tagTableElement } from '@customTypes/DatabaseElementTypes';
+import { recipeColumnsNames, TagDraft, tagTableElement } from '@customTypes/DatabaseElementTypes';
 import TextRecognition, {
   TextBlock,
   TextLine,
@@ -1134,7 +1134,7 @@ describe('OCR Utility Functions', () => {
         }),
       }),
     };
-    const expectedTags = new Array<tagTableElement>(
+    const expectedTags = new Array<TagDraft>(
       { name: '<650kcal' },
       { name: 'Familial' },
       { name: 'Rapido' }
@@ -1150,7 +1150,7 @@ describe('OCR Utility Functions', () => {
     describe('on extractFieldFromImage', () => {
       test('returns the correct value', async () => {
         mockRecognize.mockResolvedValue(mockResultTags);
-        const tagAlreadyPresent: tagTableElement = { name: 'Existing tags' };
+        const tagAlreadyPresent: tagTableElement = { id: 1, name: 'Existing tags' };
 
         const result = await extractFieldFromImage(
           uriForOCR,
@@ -1163,7 +1163,7 @@ describe('OCR Utility Functions', () => {
         );
 
         expect(result).toEqual({
-          recipeTags: new Array<tagTableElement>(tagAlreadyPresent, ...expectedTags),
+          recipeTags: new Array<TagDraft>(tagAlreadyPresent, ...expectedTags),
         });
       });
     });

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -3,10 +3,14 @@ import { testRecipes } from '@test-data/recipesDataset';
 import { testTags } from '@test-data/tagsDataset';
 import { testIngredients } from '@test-data/ingredientsDataset';
 import {
+  encodedImportHistoryElement,
+  IngredientDraft,
   ingredientTableElement,
   ingredientType,
   nutritionTableElement,
+  RecipeDraft,
   recipeTableElement,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import { getRandomRecipes } from '@utils/FilterFunctions';
@@ -324,10 +328,10 @@ describe('RecipeDatabase', () => {
 
       expect(await db.deleteTag(testTags[12]!)).toEqual(false);
 
-      expect(await db.deleteTag({ ...testTags[15]!, id: undefined })).toEqual(true);
+      expect(await db.deleteTag(testTags[15]!)).toEqual(true);
       expect(db.get_tags()).not.toContainEqual(testTags[15]);
 
-      expect(await db.deleteTag({ ...testTags[2]!, id: undefined, name: '' })).toEqual(false);
+      expect(await db.deleteTag({ ...testTags[2]!, id: 900001, name: '' })).toEqual(false);
 
       expect(db.get_tags()).toContainEqual(testTags[2]);
     });
@@ -338,41 +342,36 @@ describe('RecipeDatabase', () => {
 
       expect(await db.deleteIngredient(testIngredients[30]!)).toEqual(false);
 
-      expect(await db.deleteIngredient({ ...testIngredients[21]!, id: undefined })).toEqual(true);
+      expect(await db.deleteIngredient(testIngredients[21]!)).toEqual(true);
       expect(db.get_ingredients()).not.toContainEqual(testIngredients[21]);
 
       expect(
-        await db.deleteIngredient({ ...testIngredients[11]!, id: undefined, name: '' })
+        await db.deleteIngredient({ ...testIngredients[11]!, id: 900002, name: '' })
       ).toEqual(false);
       expect(
-        await db.deleteIngredient({ ...testIngredients[11]!, id: undefined, unit: '' })
+        await db.deleteIngredient({ ...testIngredients[11]!, id: 900003, unit: '' })
       ).toEqual(false);
       expect(
         await db.deleteIngredient({
           ...testIngredients[11]!,
-          id: undefined,
+          id: 900004,
           type: ingredientType.cereal,
         })
       ).toEqual(false);
       expect(
         await db.deleteIngredient({
           ...testIngredients[11]!,
-          id: undefined,
+          id: 900005,
           name: '',
           unit: '',
           type: ingredientType.cereal,
         })
       ).toEqual(false);
-      // Ingredient should still be in the list since delete returned false
 
-      expect(
-        await db.deleteIngredient({ ...testIngredients[11]!, id: undefined, quantity: '' })
-      ).toEqual(true);
+      expect(await db.deleteIngredient(testIngredients[11]!)).toEqual(true);
       expect(db.get_ingredients()).not.toContainEqual(testIngredients[11]);
 
-      expect(
-        await db.deleteIngredient({ ...testIngredients[32]!, id: undefined, season: [] })
-      ).toEqual(true);
+      expect(await db.deleteIngredient(testIngredients[32]!)).toEqual(true);
       expect(db.get_ingredients()).not.toContainEqual(testIngredients[32]);
     });
 
@@ -385,7 +384,7 @@ describe('RecipeDatabase', () => {
     });
 
     test('editTag with missing ID should return false and not update', async () => {
-      const tagToEdit = { ...testTags[0]!, id: undefined, name: 'ShouldNotUpdate' };
+      const tagToEdit = { ...testTags[0]!, id: 900010, name: 'ShouldNotUpdate' };
 
       expect(await db.editTag(tagToEdit)).toBe(false);
 
@@ -403,7 +402,7 @@ describe('RecipeDatabase', () => {
     });
 
     test('editIngredient with missing ID should return false and not update', async () => {
-      const ingredientToEdit = { ...testIngredients[0]!, id: undefined, name: 'ShouldNotUpdate' };
+      const ingredientToEdit = { ...testIngredients[0]!, id: 900011, name: 'ShouldNotUpdate' };
 
       expect(await db.editIngredient(ingredientToEdit)).toBe(false);
 
@@ -530,15 +529,6 @@ describe('RecipeDatabase', () => {
 
       const updated = db.get_recipes().find(r => r.id === recipeToEdit.id);
       expect(updated).toEqual(recipeToEdit);
-    });
-
-    test('editRecipe with missing ID throws and does not update', async () => {
-      const recipeToEdit = { ...testRecipes[0]!, id: undefined, title: 'ShouldNotUpdate' };
-
-      await expect(db.editRecipe(recipeToEdit)).rejects.toThrow();
-
-      const notUpdated = db.get_recipes().find(r => r.title === 'ShouldNotUpdate');
-      expect(notUpdated).toBeUndefined();
     });
 
     describe('update_multiple_recipes', () => {
@@ -693,14 +683,6 @@ describe('RecipeDatabase', () => {
 
           expect(updatedIng!.quantity).toBe(expectedQuantity);
         }
-      });
-
-      test('should throw error when recipe has no ID', async () => {
-        const recipeWithoutId = { ...testRecipes[0]!, id: undefined };
-
-        await expect(db.scaleAndUpdateRecipe(recipeWithoutId)).rejects.toThrow(
-          'Recipe must have an ID to update'
-        );
       });
 
       test('should update recipe in internal state', async () => {
@@ -1026,38 +1008,10 @@ describe('RecipeDatabase', () => {
       await db.closeAndReset();
     });
 
-    test('isRecipeExist return true if the recipe is in the database', () => {
-      expect(
-        db.isRecipeExist({
-          description: '',
-          image_Source: '',
-          ingredients: new Array(),
-          persons: 0,
-          preparation: new Array(),
-          season: new Array(),
-          tags: new Array(),
-          time: 0,
-          title: '',
-        })
-      ).toBe(false);
-      expect(
-        db.isRecipeExist({
-          description: 'A real description',
-          image_Source: '/path/to/an/image',
-          ingredients: new Array(),
-          persons: 2,
-          preparation: new Array(),
-          season: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
-          tags: new Array(testTags[3]!),
-          time: 20,
-          title: 'A real title',
-        })
-      ).toBe(false);
-
-      expect(db.isRecipeExist({ ...testRecipes[7]!, title: '', id: undefined })).toBe(false);
-
-      expect(db.isRecipeExist({ ...testRecipes[5]!, id: undefined })).toBe(true);
+    test('isRecipeExist matches a cached recipe by id', () => {
       expect(db.isRecipeExist(testRecipes[0]!)).toBe(true);
+      expect(db.isRecipeExist(testRecipes[5]!)).toBe(true);
+      expect(db.isRecipeExist({ ...testRecipes[0]!, id: 999999 })).toBe(false);
     });
 
     test('Reset database clears all data', async () => {
@@ -1074,41 +1028,8 @@ describe('RecipeDatabase', () => {
 
       expect(await db.deleteRecipe(testRecipes[4]!)).toEqual(false);
 
-      expect(await db.deleteRecipe({ ...testRecipes[9]!, id: undefined })).toEqual(true);
+      expect(await db.deleteRecipe(testRecipes[9]!)).toEqual(true);
       expect(db.get_recipes()).not.toContainEqual(testRecipes[9]);
-
-      expect(
-        await db.deleteRecipe({ ...testRecipes[2]!, id: undefined, image_Source: '' })
-      ).toEqual(false);
-      expect(await db.deleteRecipe({ ...testRecipes[2]!, id: undefined, title: '' })).toEqual(
-        false
-      );
-      expect(await db.deleteRecipe({ ...testRecipes[2]!, id: undefined, description: '' })).toEqual(
-        false
-      );
-      expect(db.get_recipes()).toContainEqual(testRecipes[2]);
-
-      expect(await db.deleteRecipe({ ...testRecipes[2]!, id: undefined, tags: [] })).toEqual(true);
-      expect(db.get_recipes()).not.toContainEqual(testRecipes[2]);
-
-      expect(await db.deleteRecipe({ ...testRecipes[3]!, id: undefined, persons: -1 })).toEqual(
-        true
-      );
-      expect(db.get_recipes()).not.toContainEqual(testRecipes[3]);
-      expect(await db.deleteRecipe({ ...testRecipes[5]!, id: undefined, ingredients: [] })).toEqual(
-        true
-      );
-      expect(db.get_recipes()).not.toContainEqual(testRecipes[5]);
-      expect(await db.deleteRecipe({ ...testRecipes[6]!, id: undefined, season: [] })).toEqual(
-        true
-      );
-      expect(db.get_recipes()).not.toContainEqual(testRecipes[6]);
-      expect(await db.deleteRecipe({ ...testRecipes[7]!, id: undefined, preparation: [] })).toEqual(
-        true
-      );
-      expect(db.get_recipes()).not.toContainEqual(testRecipes[7]);
-      expect(await db.deleteRecipe({ ...testRecipes[8]!, id: undefined, time: -1 })).toEqual(true);
-      expect(db.get_recipes()).not.toContainEqual(testRecipes[8]);
     });
 
     // TODO to be upgrade with database deleting (not implemented yet)
@@ -1403,6 +1324,41 @@ describe('RecipeDatabase', () => {
 
         const finalCallCount = FileGestionMock.saveRecipeImage.mock.calls.length;
         expect(finalCallCount).toBe(initialCallCount);
+      });
+
+      it('returns the persisted recipe with a database id', async () => {
+        const persisted = await db.addRecipe({ ...testRecipes[0]!, id: undefined });
+
+        expect(persisted).toBeDefined();
+        expect(typeof persisted!.id).toBe('number');
+        expect(persisted!.title).toBe(testRecipes[0]!.title);
+        expect(db.get_recipes()).toContainEqual(persisted);
+      });
+
+      it('throws and leaves cache untouched when insertion fails', async () => {
+        const recipesTable = db['_recipesTable'];
+        const originalInsertElement = recipesTable.insertElement;
+        recipesTable.insertElement = jest.fn().mockResolvedValue(undefined);
+
+        await expect(db.addRecipe({ ...testRecipes[0]!, id: undefined })).rejects.toThrow(
+          /Failed to add recipe/
+        );
+        expect(db.get_recipes()).toEqual([]);
+
+        recipesTable.insertElement = originalInsertElement;
+      });
+
+      it('throws and leaves cache untouched when lookup fails after insertion', async () => {
+        const recipesTable = db['_recipesTable'];
+        const originalSearchElementById = recipesTable.searchElementById;
+        recipesTable.searchElementById = jest.fn().mockResolvedValue(undefined);
+
+        await expect(db.addRecipe({ ...testRecipes[0]!, id: undefined })).rejects.toThrow(
+          /Failed to retrieve recipe/
+        );
+        expect(db.get_recipes()).toEqual([]);
+
+        recipesTable.searchElementById = originalSearchElementById;
       });
     });
 
@@ -1836,11 +1792,11 @@ describe('RecipeDatabase', () => {
 
     const getEncodeTagForRecipe = () =>
       (
-        db as unknown as { encodeTagForRecipe: (tag: tagTableElement) => string }
+        db as unknown as { encodeTagForRecipe: (tag: TagDraft) => string }
       ).encodeTagForRecipe.bind(db);
     const getEncodeIngredient = () =>
       (
-        db as unknown as { encodeIngredient: (ing: ingredientTableElement) => string }
+        db as unknown as { encodeIngredient: (ing: IngredientDraft) => string }
       ).encodeIngredient.bind(db);
 
     test('encodeTagForRecipe throws when the tag cannot be resolved', () => {
@@ -1885,6 +1841,34 @@ describe('RecipeDatabase', () => {
     });
   });
 
+  describe('Seen history', () => {
+    const db = RecipeDatabase.getInstance();
+
+    beforeEach(async () => {
+      await db.init();
+    });
+
+    afterEach(async () => {
+      await db.closeAndReset();
+    });
+
+    test('removeFromSeenHistory deletes the database row, not just the cache', async () => {
+      const provider = 'hellofresh';
+      const kept = 'https://hellofresh.com/keep';
+      const removed = 'https://hellofresh.com/remove';
+      await db.markUrlsAsSeen(provider, [kept, removed]);
+
+      await db.removeFromSeenHistory(provider, [removed]);
+
+      const rows = (await db['_importHistoryTable'].searchElement<encodedImportHistoryElement>(
+        db['_dbConnection']
+      )) as encodedImportHistoryElement[];
+      const urls = rows.map(row => row.RECIPE_URL);
+      expect(urls).toContain(kept);
+      expect(urls).not.toContain(removed);
+    });
+  });
+
   describe('Menu Operations', () => {
     const db = RecipeDatabase.getInstance();
 
@@ -1925,13 +1909,6 @@ describe('RecipeDatabase', () => {
         expect(menu[0]!.imageSource).toBe(recipe!.image_Source);
         expect(menu[0]!.isCooked).toBe(false);
         expect(menu[0]!.count).toBe(1);
-      });
-
-      test('does not add recipe without ID', async () => {
-        const recipeWithoutId: recipeTableElement = { ...testRecipes[0]!, id: undefined };
-        await db.addRecipeToMenu(recipeWithoutId);
-
-        expect(db.get_menu().length).toBe(0);
       });
 
       test('increments count when adding same recipe twice', async () => {
@@ -2211,7 +2188,7 @@ describe('RecipeDatabase', () => {
     });
 
     test('preserves ingredient notes when adding and retrieving recipe', async () => {
-      const recipeWithNotes: recipeTableElement = {
+      const recipeWithNotes: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2229,7 +2206,7 @@ describe('RecipeDatabase', () => {
     });
 
     test('handles multiple ingredients with mixed notes', async () => {
-      const recipeWithMixedNotes: recipeTableElement = {
+      const recipeWithMixedNotes: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2251,7 +2228,7 @@ describe('RecipeDatabase', () => {
     });
 
     test('handles empty string note (treated as no note)', async () => {
-      const recipeWithEmptyNote: recipeTableElement = {
+      const recipeWithEmptyNote: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2268,7 +2245,7 @@ describe('RecipeDatabase', () => {
 
     test('handles note with special characters', async () => {
       const specialNote = 'for the "special" sauce (organic)';
-      const recipeWithSpecialNote: recipeTableElement = {
+      const recipeWithSpecialNote: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2285,7 +2262,7 @@ describe('RecipeDatabase', () => {
 
     test('handles note with unicode characters', async () => {
       const unicodeNote = '🌶️ spicy à volonté';
-      const recipeWithUnicodeNote: recipeTableElement = {
+      const recipeWithUnicodeNote: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2302,7 +2279,7 @@ describe('RecipeDatabase', () => {
 
     test('preserves notes after database re-initialization', async () => {
       const noteValue = 'persistent note';
-      const recipeWithNote: recipeTableElement = {
+      const recipeWithNote: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2325,7 +2302,7 @@ describe('RecipeDatabase', () => {
 
     test('preserves notes when editing recipe', async () => {
       const initialNote = 'initial note';
-      const recipeWithNote: recipeTableElement = {
+      const recipeWithNote: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({
@@ -2353,7 +2330,7 @@ describe('RecipeDatabase', () => {
     });
 
     test('can remove note when editing recipe', async () => {
-      const recipeWithNote: recipeTableElement = {
+      const recipeWithNote: RecipeDraft = {
         ...testRecipes[0]!,
         id: undefined,
         ingredients: testRecipes[0]!.ingredients.map((ing, index) => ({

--- a/tests/unit/utils/RecipeValidationHelpers.test.tsx
+++ b/tests/unit/utils/RecipeValidationHelpers.test.tsx
@@ -21,6 +21,7 @@ import {
   FormIngredientElement,
   ingredientTableElement,
   ingredientType,
+  TagDraft,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 
@@ -41,7 +42,7 @@ describe('RecipeValidationHelpers', () => {
     test('returns exact match in exactMatches and empty needsValidation for exact match tag', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const inputTags: tagTableElement[] = [{ name: 'Vegetarian' }];
+      const inputTags: TagDraft[] = [{ name: 'Vegetarian' }];
       const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
       expect(result.exactMatches).toEqual([dbTags[0]]);
@@ -52,7 +53,7 @@ describe('RecipeValidationHelpers', () => {
     test('returns tag in needsValidation and empty exactMatches for non-exact match', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const inputTags: tagTableElement[] = [{ name: 'Vegan' }];
+      const inputTags: TagDraft[] = [{ name: 'Vegan' }];
       const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
       expect(result.exactMatches).toEqual([]);
@@ -65,7 +66,7 @@ describe('RecipeValidationHelpers', () => {
     test('handles exact match case-insensitively', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const inputTags: tagTableElement[] = [{ name: 'VEGETARIAN' }];
+      const inputTags: TagDraft[] = [{ name: 'VEGETARIAN' }];
       const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
       expect(result.exactMatches).toEqual([dbTags[0]]);
@@ -78,7 +79,7 @@ describe('RecipeValidationHelpers', () => {
         .mockReturnValueOnce([dbTags[1]])
         .mockReturnValueOnce([]);
 
-      const inputTags: tagTableElement[] = [
+      const inputTags: TagDraft[] = [
         { name: 'Vegetarian' },
         { name: 'Vegan' },
         { name: 'Gluten-Free' },
@@ -105,7 +106,7 @@ describe('RecipeValidationHelpers', () => {
     test('handles no similar tags found', () => {
       mockFindSimilarTags.mockReturnValue([]);
 
-      const inputTags: tagTableElement[] = [{ name: 'NewTag' }];
+      const inputTags: TagDraft[] = [{ name: 'NewTag' }];
       const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
       expect(result.exactMatches).toEqual([]);
@@ -117,7 +118,7 @@ describe('RecipeValidationHelpers', () => {
       test('attaches empty similarItems array when no similar tags found', () => {
         mockFindSimilarTags.mockReturnValue([]);
 
-        const inputTags: tagTableElement[] = [{ name: 'NewTag' }];
+        const inputTags: TagDraft[] = [{ name: 'NewTag' }];
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
         expect(result.needsValidation).toHaveLength(1);
@@ -128,7 +129,7 @@ describe('RecipeValidationHelpers', () => {
         const similarResults = [dbTags[0], dbTags[1]];
         mockFindSimilarTags.mockReturnValue(similarResults);
 
-        const inputTags: tagTableElement[] = [{ name: 'Veg' }];
+        const inputTags: TagDraft[] = [{ name: 'Veg' }];
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
         expect(result.needsValidation).toHaveLength(1);
@@ -140,7 +141,7 @@ describe('RecipeValidationHelpers', () => {
           .mockReturnValueOnce([dbTags[0]])
           .mockReturnValueOnce([dbTags[1], dbTags[2]]);
 
-        const inputTags: tagTableElement[] = [{ name: 'Veg' }, { name: 'Fast' }];
+        const inputTags: TagDraft[] = [{ name: 'Veg' }, { name: 'Fast' }];
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
         expect(result.needsValidation).toHaveLength(2);
@@ -151,7 +152,7 @@ describe('RecipeValidationHelpers', () => {
       test('preserves original tag properties alongside similarItems', () => {
         mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-        const inputTags: tagTableElement[] = [{ id: 99, name: 'CustomTag' }];
+        const inputTags: TagDraft[] = [{ id: 99, name: 'CustomTag' }];
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
         expect(result.needsValidation[0]!.id).toBe(99);
@@ -167,7 +168,7 @@ describe('RecipeValidationHelpers', () => {
           .mockReturnValueOnce([])
           .mockReturnValueOnce([dbTags[1]]);
 
-        const inputTags: tagTableElement[] = [
+        const inputTags: TagDraft[] = [
           { name: 'HasMatch1' },
           { name: 'NoMatch' },
           { name: 'HasMatch2' },
@@ -187,7 +188,7 @@ describe('RecipeValidationHelpers', () => {
       test('maintains relative order within same group (no matches)', () => {
         mockFindSimilarTags.mockReturnValue([]);
 
-        const inputTags: tagTableElement[] = [
+        const inputTags: TagDraft[] = [
           { name: 'First' },
           { name: 'Second' },
           { name: 'Third' },
@@ -203,7 +204,7 @@ describe('RecipeValidationHelpers', () => {
       test('maintains relative order within same group (with matches)', () => {
         mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-        const inputTags: tagTableElement[] = [
+        const inputTags: TagDraft[] = [
           { name: 'First' },
           { name: 'Second' },
           { name: 'Third' },
@@ -219,7 +220,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles all items having similar matches', () => {
         mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-        const inputTags: tagTableElement[] = [{ name: 'Tag1' }, { name: 'Tag2' }];
+        const inputTags: TagDraft[] = [{ name: 'Tag1' }, { name: 'Tag2' }];
 
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
@@ -230,7 +231,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles all items having no similar matches', () => {
         mockFindSimilarTags.mockReturnValue([]);
 
-        const inputTags: tagTableElement[] = [{ name: 'Tag1' }, { name: 'Tag2' }];
+        const inputTags: TagDraft[] = [{ name: 'Tag1' }, { name: 'Tag2' }];
 
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
@@ -245,7 +246,7 @@ describe('RecipeValidationHelpers', () => {
           .mockReturnValueOnce([])
           .mockReturnValueOnce([dbTags[2]]);
 
-        const inputTags: tagTableElement[] = [
+        const inputTags: TagDraft[] = [
           { name: 'Vegetarian' },
           { name: 'SimilarToItalian' },
           { name: 'BrandNew' },
@@ -265,7 +266,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles single item without similar matches', () => {
         mockFindSimilarTags.mockReturnValue([]);
 
-        const inputTags: tagTableElement[] = [{ name: 'SingleTag' }];
+        const inputTags: TagDraft[] = [{ name: 'SingleTag' }];
 
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
@@ -277,7 +278,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles single item with similar matches', () => {
         mockFindSimilarTags.mockReturnValue([dbTags[0], dbTags[1]]);
 
-        const inputTags: tagTableElement[] = [{ name: 'SingleTag' }];
+        const inputTags: TagDraft[] = [{ name: 'SingleTag' }];
 
         const result = processTagsForValidation(inputTags, mockFindSimilarTags);
 
@@ -317,7 +318,7 @@ describe('RecipeValidationHelpers', () => {
     test('returns exact match in exactMatches with merged quantity/unit', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Tomato Sauce',
           quantity: '300',
@@ -342,7 +343,7 @@ describe('RecipeValidationHelpers', () => {
     test('preserves OCR quantity and unit for exact match', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[1]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Parmesan',
           quantity: '100',
@@ -370,7 +371,7 @@ describe('RecipeValidationHelpers', () => {
     test('uses database defaults when OCR quantity/unit are missing', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[1]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Parmesan',
           quantity: '',
@@ -395,7 +396,7 @@ describe('RecipeValidationHelpers', () => {
     test('returns ingredient in needsValidation for non-exact match', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Tomato',
           quantity: '100',
@@ -416,7 +417,7 @@ describe('RecipeValidationHelpers', () => {
     test('handles exact match case-insensitively', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'TOMATO SAUCE',
           quantity: '250',
@@ -444,7 +445,7 @@ describe('RecipeValidationHelpers', () => {
         .mockReturnValueOnce([dbIngredients[1]])
         .mockReturnValueOnce([]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Tomato Sauce',
           quantity: '150',
@@ -495,7 +496,7 @@ describe('RecipeValidationHelpers', () => {
     test('handles no similar ingredients found', () => {
       mockFindSimilarIngredients.mockReturnValue([]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'NewIngredient',
           quantity: '100',
@@ -516,7 +517,7 @@ describe('RecipeValidationHelpers', () => {
       test('attaches empty similarItems array when no similar ingredients found', () => {
         mockFindSimilarIngredients.mockReturnValue([]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             name: 'NewIngredient',
             quantity: '100',
@@ -538,7 +539,7 @@ describe('RecipeValidationHelpers', () => {
       test('attaches similar ingredients to needsValidation items', () => {
         mockFindSimilarIngredients.mockReturnValue([dbIngredients[0], dbIngredients[1]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             name: 'Tom',
             quantity: '100',
@@ -565,7 +566,7 @@ describe('RecipeValidationHelpers', () => {
           .mockReturnValueOnce([dbIngredients[0]])
           .mockReturnValueOnce([dbIngredients[1]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           { name: 'Tom', quantity: '100', unit: 'ml', type: ingredientType.vegetable, season: [] },
           { name: 'Parm', quantity: '50', unit: 'g', type: ingredientType.cheese, season: [] },
         ];
@@ -583,7 +584,7 @@ describe('RecipeValidationHelpers', () => {
       test('preserves original ingredient properties alongside similarItems', () => {
         mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             id: 99,
             name: 'CustomIng',
@@ -617,7 +618,7 @@ describe('RecipeValidationHelpers', () => {
           .mockReturnValueOnce([])
           .mockReturnValueOnce([dbIngredients[1]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             name: 'HasMatch1',
             quantity: '1',
@@ -652,7 +653,7 @@ describe('RecipeValidationHelpers', () => {
       test('maintains relative order within same group (no matches)', () => {
         mockFindSimilarIngredients.mockReturnValue([]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           { name: 'First', quantity: '1', unit: 'g', type: ingredientType.vegetable, season: [] },
           { name: 'Second', quantity: '2', unit: 'g', type: ingredientType.vegetable, season: [] },
           { name: 'Third', quantity: '3', unit: 'g', type: ingredientType.vegetable, season: [] },
@@ -671,7 +672,7 @@ describe('RecipeValidationHelpers', () => {
       test('maintains relative order within same group (with matches)', () => {
         mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           { name: 'First', quantity: '1', unit: 'g', type: ingredientType.vegetable, season: [] },
           { name: 'Second', quantity: '2', unit: 'g', type: ingredientType.vegetable, season: [] },
           { name: 'Third', quantity: '3', unit: 'g', type: ingredientType.vegetable, season: [] },
@@ -690,7 +691,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles all items having similar matches', () => {
         mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           { name: 'Ing1', quantity: '1', unit: 'g', type: ingredientType.vegetable, season: [] },
           { name: 'Ing2', quantity: '2', unit: 'g', type: ingredientType.vegetable, season: [] },
         ];
@@ -707,7 +708,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles all items having no similar matches', () => {
         mockFindSimilarIngredients.mockReturnValue([]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           { name: 'Ing1', quantity: '1', unit: 'g', type: ingredientType.vegetable, season: [] },
           { name: 'Ing2', quantity: '2', unit: 'g', type: ingredientType.vegetable, season: [] },
         ];
@@ -728,7 +729,7 @@ describe('RecipeValidationHelpers', () => {
           .mockReturnValueOnce([])
           .mockReturnValueOnce([dbIngredients[0]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             name: 'Tomato Sauce',
             quantity: '100',
@@ -775,7 +776,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles single item without similar matches', () => {
         mockFindSimilarIngredients.mockReturnValue([]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             name: 'SingleIng',
             quantity: '100',
@@ -798,7 +799,7 @@ describe('RecipeValidationHelpers', () => {
       test('handles single item with similar matches', () => {
         mockFindSimilarIngredients.mockReturnValue([dbIngredients[0], dbIngredients[1]]);
 
-        const inputIngredients: ingredientTableElement[] = [
+        const inputIngredients: FormIngredientElement[] = [
           {
             name: 'SingleIng',
             quantity: '100',
@@ -827,7 +828,7 @@ describe('RecipeValidationHelpers', () => {
         .mockReturnValueOnce([dbIngredients[0]])
         .mockReturnValueOnce([dbIngredients[1]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Tomato Sauce',
           quantity: '150',
@@ -864,7 +865,7 @@ describe('RecipeValidationHelpers', () => {
     test('skips ingredients with empty names', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: '',
           quantity: '100',
@@ -884,7 +885,7 @@ describe('RecipeValidationHelpers', () => {
     test('preserves note from scraped ingredient in exact match', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Tomato Sauce',
           quantity: '300',
@@ -905,7 +906,7 @@ describe('RecipeValidationHelpers', () => {
     test('preserves note as undefined when not provided', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[0]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Tomato Sauce',
           quantity: '300',
@@ -924,7 +925,7 @@ describe('RecipeValidationHelpers', () => {
     test('uses database unit instead of scraped unit', () => {
       mockFindSimilarIngredients.mockReturnValue([dbIngredients[1]]);
 
-      const inputIngredients: ingredientTableElement[] = [
+      const inputIngredients: FormIngredientElement[] = [
         {
           name: 'Parmesan',
           quantity: '2',
@@ -944,16 +945,22 @@ describe('RecipeValidationHelpers', () => {
 
   describe('filterOutExistingTags', () => {
     test('filters out tags that exist in current list', () => {
-      const newTags: tagTableElement[] = [{ name: 'Vegan' }, { name: 'Quick' }];
+      const newTags: tagTableElement[] = [
+        { id: 2, name: 'Vegan' },
+        { id: 3, name: 'Quick' },
+      ];
       const existingTags: tagTableElement[] = [{ id: 1, name: 'Quick' }];
 
       const result = filterOutExistingTags(newTags, existingTags);
 
-      expect(result).toEqual([{ name: 'Vegan' }]);
+      expect(result).toEqual([{ id: 2, name: 'Vegan' }]);
     });
 
     test('returns all tags when none exist', () => {
-      const newTags: tagTableElement[] = [{ name: 'Vegan' }, { name: 'Quick' }];
+      const newTags: tagTableElement[] = [
+        { id: 2, name: 'Vegan' },
+        { id: 3, name: 'Quick' },
+      ];
       const existingTags: tagTableElement[] = [];
 
       const result = filterOutExistingTags(newTags, existingTags);
@@ -962,7 +969,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('returns empty array when all tags exist', () => {
-      const newTags: tagTableElement[] = [{ name: 'Vegan' }];
+      const newTags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
       const existingTags: tagTableElement[] = [{ id: 1, name: 'Vegan' }];
 
       const result = filterOutExistingTags(newTags, existingTags);
@@ -971,7 +978,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('handles case-insensitive comparison', () => {
-      const newTags: tagTableElement[] = [{ name: 'VEGAN' }];
+      const newTags: tagTableElement[] = [{ id: 2, name: 'VEGAN' }];
       const existingTags: tagTableElement[] = [{ id: 1, name: 'vegan' }];
 
       const result = filterOutExistingTags(newTags, existingTags);
@@ -1195,7 +1202,7 @@ describe('RecipeValidationHelpers', () => {
 
   describe('addOrMergeIngredientMatches — different unit branch', () => {
     test('preserves existing quantity when incoming has no quantity (different unit)', () => {
-      const current: ingredientTableElement[] = [
+      const current: FormIngredientElement[] = [
         {
           name: 'riz basmati  Bio',
           quantity: '200',
@@ -1206,6 +1213,7 @@ describe('RecipeValidationHelpers', () => {
       ];
       const incoming: ingredientTableElement[] = [
         {
+          id: 1,
           name: 'Riz basmati Bio',
           quantity: '',
           unit: 'g',
@@ -1223,7 +1231,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('preserves existing quantity when incoming quantity is undefined (different unit)', () => {
-      const current: ingredientTableElement[] = [
+      const current: FormIngredientElement[] = [
         {
           name: 'Carotte',
           quantity: '3',
@@ -1234,6 +1242,7 @@ describe('RecipeValidationHelpers', () => {
       ];
       const incoming: ingredientTableElement[] = [
         {
+          id: 1,
           name: 'Carotte',
           unit: 'g',
           type: ingredientType.vegetable,
@@ -1249,7 +1258,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('uses incoming quantity when provided (different unit)', () => {
-      const current: ingredientTableElement[] = [
+      const current: FormIngredientElement[] = [
         {
           name: 'Sugar',
           quantity: '100',
@@ -1260,6 +1269,7 @@ describe('RecipeValidationHelpers', () => {
       ];
       const incoming: ingredientTableElement[] = [
         {
+          id: 1,
           name: 'Sugar',
           quantity: '2',
           unit: 'tbsp',
@@ -1276,7 +1286,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('replaces by namesMatch (whitespace + NFC normalized)', () => {
-      const current: ingredientTableElement[] = [
+      const current: FormIngredientElement[] = [
         {
           name: 'riz basmati  Bio',
           quantity: '200',
@@ -1287,6 +1297,7 @@ describe('RecipeValidationHelpers', () => {
       ];
       const incoming: ingredientTableElement[] = [
         {
+          id: 1,
           name: 'Riz basmati Bio',
           quantity: '50',
           unit: 'g',
@@ -1511,7 +1522,7 @@ describe('RecipeValidationHelpers', () => {
     const currentTags: tagTableElement[] = [{ id: 1, name: 'Italian' }];
 
     test('adds tag when not duplicate', () => {
-      const newTags: tagTableElement[] = [{ name: 'Vegan' }];
+      const newTags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
 
       const result = addNonDuplicateByName(currentTags, newTags);
 
@@ -1520,7 +1531,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('does not add duplicate tag', () => {
-      const newTags: tagTableElement[] = [{ name: 'Italian' }];
+      const newTags: tagTableElement[] = [{ id: 2, name: 'Italian' }];
 
       const result = addNonDuplicateByName(currentTags, newTags);
 
@@ -1528,7 +1539,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('handles case-insensitive duplicate detection', () => {
-      const newTags: tagTableElement[] = [{ name: 'ITALIAN' }];
+      const newTags: tagTableElement[] = [{ id: 2, name: 'ITALIAN' }];
 
       const result = addNonDuplicateByName(currentTags, newTags);
 
@@ -1536,7 +1547,10 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('adds multiple non-duplicate tags', () => {
-      const newTags: tagTableElement[] = [{ name: 'Vegan' }, { name: 'Quick' }];
+      const newTags: tagTableElement[] = [
+        { id: 2, name: 'Vegan' },
+        { id: 3, name: 'Quick' },
+      ];
 
       const result = addNonDuplicateByName(currentTags, newTags);
 
@@ -1545,9 +1559,9 @@ describe('RecipeValidationHelpers', () => {
 
     test('filters out duplicates from batch', () => {
       const newTags: tagTableElement[] = [
-        { name: 'Vegan' },
-        { name: 'Italian' },
-        { name: 'Quick' },
+        { id: 2, name: 'Vegan' },
+        { id: 3, name: 'Italian' },
+        { id: 4, name: 'Quick' },
       ];
 
       const result = addNonDuplicateByName(currentTags, newTags);
@@ -1558,7 +1572,7 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('handles empty current array', () => {
-      const newTags: tagTableElement[] = [{ name: 'Vegan' }];
+      const newTags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
 
       const result = addNonDuplicateByName([], newTags);
 
@@ -1958,11 +1972,11 @@ describe('RecipeValidationHelpers', () => {
 
   describe('addOrMergeIngredientMatches — string conversion when quantities are undefined', () => {
     test('converts summed quantity to string when existing quantity is undefined', () => {
-      const current: ingredientTableElement[] = [
+      const current: FormIngredientElement[] = [
         { name: 'Salt', unit: 'tsp', type: ingredientType.spice, season: [] },
       ];
       const incoming: ingredientTableElement[] = [
-        { name: 'Salt', quantity: '2', unit: 'tsp', type: ingredientType.spice, season: [] },
+        { id: 1, name: 'Salt', quantity: '2', unit: 'tsp', type: ingredientType.spice, season: [] },
       ];
 
       const result = addOrMergeIngredientMatches(current, incoming);
@@ -1972,11 +1986,11 @@ describe('RecipeValidationHelpers', () => {
     });
 
     test('converts summed quantity to string when incoming quantity is undefined', () => {
-      const current: ingredientTableElement[] = [
+      const current: FormIngredientElement[] = [
         { name: 'Pepper', quantity: '3', unit: 'tsp', type: ingredientType.spice, season: [] },
       ];
       const incoming: ingredientTableElement[] = [
-        { name: 'Pepper', unit: 'tsp', type: ingredientType.spice, season: [] },
+        { id: 1, name: 'Pepper', unit: 'tsp', type: ingredientType.spice, season: [] },
       ];
 
       const result = addOrMergeIngredientMatches(current, incoming);
@@ -2004,7 +2018,7 @@ describe('RecipeValidationHelpers', () => {
     test('calls onMatch for each exact match', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegetarian' }];
+      const tags: tagTableElement[] = [{ id: 1, name: 'Vegetarian' }];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       expect(mockOnMatch).toHaveBeenCalledTimes(1);
@@ -2014,7 +2028,7 @@ describe('RecipeValidationHelpers', () => {
     test('does not call setQueue when all items are exact matches', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegetarian' }];
+      const tags: tagTableElement[] = [{ id: 1, name: 'Vegetarian' }];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       expect(mockSetQueue).not.toHaveBeenCalled();
@@ -2023,7 +2037,7 @@ describe('RecipeValidationHelpers', () => {
     test('calls setQueue with fuzzy matches when findSimilarTags returns similar but not exact', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegan' }];
+      const tags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       expect(mockSetQueue).toHaveBeenCalledTimes(1);
@@ -2036,7 +2050,10 @@ describe('RecipeValidationHelpers', () => {
     test('does not call setQueue when no items need validation', () => {
       mockFindSimilarTags.mockReturnValueOnce([dbTags[0]]).mockReturnValueOnce([dbTags[1]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegetarian' }, { name: 'Italian' }];
+      const tags: tagTableElement[] = [
+        { id: 1, name: 'Vegetarian' },
+        { id: 2, name: 'Italian' },
+      ];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       expect(mockSetQueue).not.toHaveBeenCalled();
@@ -2046,7 +2063,7 @@ describe('RecipeValidationHelpers', () => {
     test('passes onDismissed to queue config when provided', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegan' }];
+      const tags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue, mockOnDismissed);
 
       const queueConfig = mockSetQueue.mock.calls[0][0];
@@ -2056,7 +2073,7 @@ describe('RecipeValidationHelpers', () => {
     test('does not include onDismissed in queue config when not provided', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegan' }];
+      const tags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       const queueConfig = mockSetQueue.mock.calls[0][0];
@@ -2066,7 +2083,7 @@ describe('RecipeValidationHelpers', () => {
     test('queue onValidated callback calls onMatch with the validated tag', () => {
       mockFindSimilarTags.mockReturnValue([dbTags[0]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegan' }];
+      const tags: tagTableElement[] = [{ id: 2, name: 'Vegan' }];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       const queueConfig = mockSetQueue.mock.calls[0][0];
@@ -2087,7 +2104,10 @@ describe('RecipeValidationHelpers', () => {
     test('calls onMatch for exact matches and queues fuzzy matches', () => {
       mockFindSimilarTags.mockReturnValueOnce([dbTags[0]]).mockReturnValueOnce([dbTags[1]]);
 
-      const tags: tagTableElement[] = [{ name: 'Vegetarian' }, { name: 'Vegan' }];
+      const tags: tagTableElement[] = [
+        { id: 1, name: 'Vegetarian' },
+        { id: 2, name: 'Vegan' },
+      ];
       validateAndQueueTags(tags, mockFindSimilarTags, mockOnMatch, mockSetQueue);
 
       expect(mockOnMatch).toHaveBeenCalledTimes(1);

--- a/tests/unit/utils/ShoppingComputation.test.ts
+++ b/tests/unit/utils/ShoppingComputation.test.ts
@@ -5,12 +5,15 @@ import {
   recipeTableElement,
 } from '@customTypes/DatabaseElementTypes';
 
+let nextIngredientId = 1;
+
 const makeIngredient = (
   name: string,
   quantity: string,
   unit: string,
   type = ingredientType.vegetable
 ) => ({
+  id: nextIngredientId++,
   name,
   quantity,
   unit,
@@ -39,6 +42,7 @@ const makeMenuItem = (
   recipeId: number,
   options: { count?: number; isCooked?: boolean } = {}
 ): menuTableElement => ({
+  id: recipeId,
   recipeId,
   recipeTitle: '',
   imageSource: '',

--- a/tests/unit/utils/listUtils.test.ts
+++ b/tests/unit/utils/listUtils.test.ts
@@ -19,18 +19,6 @@ const recipeWithId: recipeTableElement = {
   preparation: [],
 };
 
-const recipeWithoutId: recipeTableElement = {
-  title: 'Pasta',
-  description: '',
-  image_Source: '',
-  persons: 2,
-  time: 0,
-  season: [],
-  tags: [],
-  ingredients: [],
-  preparation: [],
-};
-
 const ingredientWithId: ingredientTableElement = {
   id: 7,
   name: 'Tomato',
@@ -39,40 +27,20 @@ const ingredientWithId: ingredientTableElement = {
   season: [],
 };
 
-const ingredientWithoutId: ingredientTableElement = {
-  name: 'Tomato',
-  type: ingredientType.vegetable,
-  unit: 'g',
-  season: [],
-};
-
 const tagWithId: tagTableElement = { id: 3, name: 'Italian' };
-const tagWithoutId: tagTableElement = { name: 'Italian' };
 
 describe('getRecipeKey', () => {
-  it('returns id as string when id is defined', () => {
+  it('returns id as string', () => {
     expect(getRecipeKey(recipeWithId)).toBe('42');
-  });
-
-  it('returns title when id is undefined', () => {
-    expect(getRecipeKey(recipeWithoutId)).toBe('Pasta');
   });
 });
 
 describe('getSettingsItemKey', () => {
-  it('returns id as string for ingredient with id', () => {
+  it('returns id as string for ingredient', () => {
     expect(getSettingsItemKey(ingredientWithId)).toBe('7');
   });
 
-  it('returns name for ingredient without id', () => {
-    expect(getSettingsItemKey(ingredientWithoutId)).toBe('Tomato');
-  });
-
-  it('returns id as string for tag with id', () => {
+  it('returns id as string for tag', () => {
     expect(getSettingsItemKey(tagWithId)).toBe('3');
-  });
-
-  it('returns name for tag without id', () => {
-    expect(getSettingsItemKey(tagWithoutId)).toBe('Italian');
   });
 });


### PR DESCRIPTION
## Summary

Code-hygiene refactor (#319) separating in-memory records from persisted DB rows via a `Draft` type layer.

- Add `Draft<T>` / `withId()` plus per-entity draft types: `RecipeDraft`, `IngredientDraft`, `TagDraft`.
- Make persisted `id` **required** on `recipeTableElement`, `ingredientTableElement`, `tagTableElement`, `menuTableElement`; insert/snapshot/import inputs now use the draft shapes.
- Drop the id-optional fallback paths this made dead:
  - search-by-fields `delete`/`find` helpers (`constructSearch*`) — now id-only.
  - missing-id guards in `edit*`/`delete*`/`addRecipeToMenu`.
  - `getRecipeKey` / `getSettingsItemKey` title/name fallbacks — id-only.
- `addRecipe` now returns the decoded persisted recipe (throws on insert/lookup failure) instead of returning `void`; `RecipeFormScreen` uses the returned row for `onSaveSuccess`.
- Remove dead exports: `ALL_MONTHS_ENCODED`, `isRecipePartiallyEqual`.
- Remove the shipped `migrateWildcardSeasons` startup migration.

## ⚠️ Note before merge

Removing `migrateWildcardSeasons` means any DB installed **before** that migration shipped and never launched the migrated build keeps `SEASON='*'`, decoded as `season: ['*']` which never matches month filters — seasonal availability silently breaks for that ingredient. Safe **iff** all active installs already ran the migration. Confirm before merging.

## Verification

- `npm run typecheck` — pass
- `npm run test:unit` — 3865 passed
- `npm run test:integration` — 77 passed

Refs #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)