### PR TITLE
feat(recipe): non-blocking OCR feedback via global snackbar (#316)

### DIFF
--- a/src/context/RecipeDialogsContext.tsx
+++ b/src/context/RecipeDialogsContext.tsx
@@ -43,6 +43,19 @@ export interface SimilarityDialogState {
   item: SimilarityDialogProps['item'];
 }
 
+/**
+ * State object for the non-blocking feedback snackbar.
+ */
+export interface SnackbarState {
+  visible: boolean;
+  message: string;
+}
+
+const defaultSnackbarState: SnackbarState = {
+  visible: false,
+  message: '',
+};
+
 const defaultSimilarityDialogState: SimilarityDialogState = {
   isVisible: false,
   item: {
@@ -73,6 +86,10 @@ export interface RecipeDialogsContextType {
     React.SetStateAction<TagValidationProps | IngredientValidationProps | null>
   >;
   clearValidationQueue: () => void;
+
+  snackbar: SnackbarState;
+  showSnackbar: (message: string) => void;
+  hideSnackbar: () => void;
 }
 
 const RecipeDialogsContext = createContext<RecipeDialogsContextType | undefined>(undefined);
@@ -94,6 +111,7 @@ export function RecipeDialogsProvider({ children }: { children: ReactNode }) {
   const [validationQueue, setValidationQueue] = useState<
     TagValidationProps | IngredientValidationProps | null
   >(null);
+  const [snackbar, setSnackbar] = useState<SnackbarState>(defaultSnackbarState);
 
   const showValidationDialog = (props: ValidationDialogProps) => {
     setValidationDialogProp(props);
@@ -131,6 +149,14 @@ export function RecipeDialogsProvider({ children }: { children: ReactNode }) {
     setValidationQueue(null);
   };
 
+  const showSnackbar = (message: string) => {
+    setSnackbar({ visible: true, message });
+  };
+
+  const hideSnackbar = () => {
+    setSnackbar(prev => ({ ...prev, visible: false }));
+  };
+
   return (
     <RecipeDialogsContext.Provider
       value={{
@@ -147,6 +173,10 @@ export function RecipeDialogsProvider({ children }: { children: ReactNode }) {
         validationQueue,
         setValidationQueue,
         clearValidationQueue,
+
+        snackbar,
+        showSnackbar,
+        hideSnackbar,
       }}
     >
       {children}

--- a/src/hooks/useRecipeOCR.ts
+++ b/src/hooks/useRecipeOCR.ts
@@ -16,7 +16,12 @@ import {
   preparationStepElement,
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
-import { extractFieldFromImage, OcrModalTarget } from '@utils/OCR';
+import {
+  computeOcrFieldStatus,
+  extractFieldFromImage,
+  OcrFieldStatus,
+  OcrModalTarget,
+} from '@utils/OCR';
 import {
   addNonDuplicateByName,
   addOrMergeIngredientMatches,
@@ -51,8 +56,12 @@ type OcrIngredientList = (ingredientTableElement | FormIngredientElement)[];
 export interface UseRecipeOCRReturn {
   /** Whether OCR extraction is currently in progress */
   isProcessingOcrExtraction: boolean;
-  /** Extracts data from an image for a specific recipe field and updates recipe state */
-  fillOneField: (uri: string, field: OcrModalTarget) => Promise<void>;
+  /**
+   * Extracts data from an image for a specific recipe field, updates recipe
+   * state, and resolves with a non-blocking feedback status the caller can
+   * surface as a snackbar.
+   */
+  fillOneField: (uri: string, field: OcrModalTarget) => Promise<OcrFieldStatus>;
 }
 
 /**
@@ -243,8 +252,10 @@ export function useRecipeOCR(): UseRecipeOCRReturn {
    *
    * @param uri - The image URI to extract data from
    * @param field - The recipe field type to extract
+   * @returns Feedback status (`empty` / `mismatch` / `success`) for the caller
+   *   to surface a snackbar.
    */
-  const fillOneField = async (uri: string, field: OcrModalTarget) => {
+  const fillOneField = async (uri: string, field: OcrModalTarget): Promise<OcrFieldStatus> => {
     ocrLogger.info('OCR extraction started', { field, uri });
     setIsProcessingOcrExtraction(true);
     try {
@@ -293,7 +304,9 @@ export function useRecipeOCR(): UseRecipeOCRReturn {
       }
       if (newFieldData.recipeNutrition) writeNutrition(newFieldData.recipeNutrition);
 
-      ocrLogger.info('OCR extraction completed', { field });
+      const status = computeOcrFieldStatus(field, newFieldData, recipeIngredients.length);
+      ocrLogger.info('OCR extraction completed', { field, status });
+      return status;
     } catch (error) {
       ocrLogger.error('OCR extraction failed', {
         field,

--- a/src/screens/recipe/RecipeAddOcr.tsx
+++ b/src/screens/recipe/RecipeAddOcr.tsx
@@ -24,6 +24,7 @@ import { StackScreenParamList } from '@customTypes/ScreenTypes';
 import type { AddFromPicProp } from '@customTypes/RecipeNavigationTypes';
 import { useRecipeOCR } from '@hooks/useRecipeOCR';
 import { useRandomTagSuggestions } from '@hooks/useRandomTagSuggestions';
+import { useRecipeDialogs } from '@context/RecipeDialogsContext';
 import { useI18n } from '@utils/i18n';
 import { LoadingOverlay } from '@components/dialogs/LoadingOverlay';
 import { FeatureHookSlotProps, RecipeFormScreen } from '@screens/recipe/RecipeFormScreen';
@@ -39,6 +40,7 @@ export type RecipeAddOcrProps = NativeStackScreenProps<StackScreenParamList, 'Re
 function OcrFeatureSlot({ setOnSelectOcrField }: FeatureHookSlotProps) {
   const { t } = useI18n();
   const ocr = useRecipeOCR();
+  const { showSnackbar } = useRecipeDialogs();
 
   // setOnSelectOcrField is a stable ref-backed setter. Listing it in deps
   // does not cause re-runs; the effect re-runs only when the OCR hook
@@ -46,9 +48,15 @@ function OcrFeatureSlot({ setOnSelectOcrField }: FeatureHookSlotProps) {
   // the latest `fillOneField` closure is registered.
   useEffect(() => {
     setOnSelectOcrField((croppedUri, target) => {
-      void ocr.fillOneField(croppedUri, target);
+      void ocr
+        .fillOneField(croppedUri, target)
+        .then(status => {
+          if (status === 'empty') showSnackbar(t('ocrFeedback.noData'));
+          else if (status === 'mismatch') showSnackbar(t('ocrFeedback.quantityMismatch'));
+        })
+        .catch(() => undefined);
     });
-  }, [setOnSelectOcrField, ocr]);
+  }, [setOnSelectOcrField, ocr, showSnackbar, t]);
 
   return (
     <LoadingOverlay

--- a/src/screens/recipe/RecipeFormScreen.tsx
+++ b/src/screens/recipe/RecipeFormScreen.tsx
@@ -30,7 +30,7 @@
 import React, { ReactNode, useRef, useState } from 'react';
 import { Keyboard, KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useTheme } from 'react-native-paper';
+import { Snackbar, useTheme } from 'react-native-paper';
 import { FieldErrors, FormProvider, useForm, useFormContext } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -623,6 +623,15 @@ function RecipeFormBody({
       )}
 
       {FeatureHookSlot ? <FeatureHookSlot {...slotProps} /> : null}
+
+      <Snackbar
+        visible={dialogs.snackbar.visible}
+        onDismiss={dialogs.hideSnackbar}
+        duration={Snackbar.DURATION_LONG}
+        testID={`${RECIPE_TEST_ID}::OcrSnackbar`}
+      >
+        {dialogs.snackbar.message}
+      </Snackbar>
     </ScreenWrapper>
   );
 }

--- a/src/translations/en/recipe.ts
+++ b/src/translations/en/recipe.ts
@@ -54,6 +54,11 @@ export default {
 
   extractingRecipeData: 'Extracting recipe data...',
 
+  ocrFeedback: {
+    noData: 'No recipe data found in the image.',
+    quantityMismatch: "Scanned quantities don't match your ingredients. Please check the values.",
+  },
+
   editRecipe: 'Edit Recipe',
   deleteRecipe: 'Delete Recipe',
   recommendation: 'Recommendation',

--- a/src/translations/fr/recipe.ts
+++ b/src/translations/fr/recipe.ts
@@ -54,6 +54,12 @@ export default {
 
   extractingRecipeData: 'Extraction des données de la recette...',
 
+  ocrFeedback: {
+    noData: 'Aucune donnée de recette trouvée dans l’image.',
+    quantityMismatch:
+      'Les quantités scannées ne correspondent pas à vos ingrédients. Vérifiez les valeurs.',
+  },
+
   editRecipe: 'Modifier la recette',
   deleteRecipe: 'Supprimer la recette',
   recommendation: 'Recommandation',

--- a/src/utils/OCR.tsx
+++ b/src/utils/OCR.tsx
@@ -151,6 +151,75 @@ export type WarningHandler = (message: string) => void;
 export type OcrModalTarget = recipeColumnsNames | 'ingredientNames' | 'ingredientQuantities';
 
 /**
+ * Partial recipe slice returned by {@link extractFieldFromImage}, keyed by the
+ * field(s) a given extraction produced. Absent keys mean the field was not
+ * targeted or yielded nothing usable.
+ */
+export type ExtractedFieldData = Partial<{
+  recipeImage: string;
+  recipeTitle: string;
+  recipeDescription: string;
+  recipeTags: tagTableElement[];
+  recipePreparation: preparationStepElement[];
+  recipePersons: number;
+  recipeTime: number;
+  recipeIngredients: FormIngredientElement[];
+  recipeNutrition: nutritionObject;
+  ingredientNames: { name: string; unit: string }[];
+  ingredientQuantities: string[];
+}>;
+
+/**
+ * Non-blocking feedback outcome of an OCR field extraction, so the UI can
+ * surface a snackbar without inspecting the raw payload.
+ *
+ * - `success`: usable data was extracted for the field.
+ * - `empty`: the image yielded no usable data for the requested field.
+ * - `mismatch`: a quantity-only scan whose extracted count does not line up
+ *   with the ingredient rows already on the form, so quantities cannot be
+ *   paired one-to-one.
+ */
+export type OcrFieldStatus = 'empty' | 'mismatch' | 'success';
+
+function hasUsableOcrData(result: ExtractedFieldData): boolean {
+  return Object.values(result).some(value => {
+    if (value === undefined || value === null) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'string') return value.length > 0;
+    return true;
+  });
+}
+
+/**
+ * Derives a non-blocking feedback status from an OCR extraction result.
+ *
+ * `ingredientQuantities` scans are special-cased: an empty payload is `empty`,
+ * and a non-empty payload whose length differs from the ingredient rows
+ * already on the form is `mismatch` (the quantities cannot be paired
+ * one-to-one, including when no rows exist yet). Every other field is `success`
+ * when the payload carries any usable value and `empty` otherwise.
+ *
+ * @param field - The OCR target that was extracted.
+ * @param result - The payload returned by {@link extractFieldFromImage}.
+ * @param currentIngredientCount - Ingredient rows currently on the form, used
+ *   only to validate `ingredientQuantities` alignment.
+ * @returns The feedback status for the extraction.
+ */
+export function computeOcrFieldStatus(
+  field: OcrModalTarget,
+  result: ExtractedFieldData,
+  currentIngredientCount: number
+): OcrFieldStatus {
+  if (field === 'ingredientQuantities') {
+    const quantities = result.ingredientQuantities ?? [];
+    if (quantities.length === 0) return 'empty';
+    if (quantities.length !== currentIngredientCount) return 'mismatch';
+    return 'success';
+  }
+  return hasUsableOcrData(result) ? 'success' : 'empty';
+}
+
+/**
  * Recognizes and extracts text from an image based on the specified recipe field type
  *
  * Uses ML Kit text recognition to extract text from images and processes it according
@@ -1122,21 +1191,7 @@ export async function extractFieldFromImage(
     recipeIngredients: FormIngredientElement[];
   },
   onWarn: WarningHandler = msg => ocrLogger.warn('OCR extraction warning', { message: msg })
-): Promise<
-  Partial<{
-    recipeImage: string;
-    recipeTitle: string;
-    recipeDescription: string;
-    recipeTags: tagTableElement[];
-    recipePreparation: preparationStepElement[];
-    recipePersons: number;
-    recipeTime: number;
-    recipeIngredients: FormIngredientElement[];
-    recipeNutrition: nutritionObject;
-    ingredientNames: { name: string; unit: string }[];
-    ingredientQuantities: string[];
-  }>
-> {
+): Promise<ExtractedFieldData> {
   if (field === 'ingredientNames') {
     const names = await recognizeIngredientNames(uri);
     return { ingredientNames: names };

--- a/tests/e2e/cases/ocr/7_ocr_feedback_snackbar.yaml
+++ b/tests/e2e/cases/ocr/7_ocr_feedback_snackbar.yaml
@@ -1,0 +1,26 @@
+name: "7 - OCR Feedback Snackbar Flow"
+appId: "com.recipedia"
+tags:
+  - ocr
+---
+# Verifies the non-blocking OCR feedback snackbar, cross-platform:
+# - no-data: scanning a text-free photo into the title yields no OCR text, so
+#   fillOneField returns "empty" and the snackbar shows the no-data message.
+# - mismatch: scanning the quantities image against more rows than it can fill
+#   yields a quantity count that never matches the rows, so fillOneField returns
+#   "mismatch" and the snackbar shows the mismatch message.
+- evalScript: ${output.modalImageCounter = 0}
+
+- runFlow:
+    file: "../../flows/recipe/adding/ocr/gallery/ocrImage.yaml"
+    env:
+      RECIPE_NAME: quitoqueV1
+    label: "Setup - Enter OCR add screen with an initial image"
+
+- runFlow:
+    file: "../../flows/recipe/adding/ocr/gallery/ocrNoDataFeedback.yaml"
+    label: "Action - Scan text-free photo into title, expect no-data snackbar"
+
+- runFlow:
+    file: "../../flows/recipe/adding/ocr/gallery/ocrQuantityMismatchFeedback.yaml"
+    label: "Action - Scan quantities against extra rows, expect mismatch snackbar"

--- a/tests/e2e/cases/ocr/ci/7_ocr_feedback_snackbar.yaml
+++ b/tests/e2e/cases/ocr/ci/7_ocr_feedback_snackbar.yaml
@@ -1,0 +1,17 @@
+name: "7 - OCR Feedback Snackbar Flow"
+appId: "com.recipedia"
+tags:
+  - ocr
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/recipe/adding/ocr/checkIfCleanIsNeeded.yaml"
+          label: "Setup - Check if clean is needed"
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../7_ocr_feedback_snackbar.yaml"
+          label: "Run 7 - OCR Feedback Snackbar Flow"

--- a/tests/e2e/flows/recipe/adding/ocr/gallery/ocrNoDataFeedback.yaml
+++ b/tests/e2e/flows/recipe/adding/ocr/gallery/ocrNoDataFeedback.yaml
@@ -1,0 +1,36 @@
+appId: "com.recipedia"
+---
+# Scans a text-free dish photo (reused tajineMerguez/image.jpg) into the title
+# target. OCR finds no text, so fillOneField returns "empty" and the root
+# snackbar surfaces the no-data message.
+- tapOn:
+    id: "RecipeTitle::OpenModal::RoundButton"
+    label: "Tap on OCR button of recipe title"
+
+- addMedia:
+    - "../../../../../../assets/tajineMerguez/image.jpg"
+
+- runFlow:
+    file: "../android/selectMostRecentFromModal.yaml"
+    label: "Select text-free photo from modal for OCR"
+    when:
+      platform: Android
+- runFlow:
+    file: "../iOS/selectMostRecentFromModal.yaml"
+    label: "Select text-free photo from modal for OCR"
+    when:
+      platform: iOS
+
+- extendedWaitUntil:
+    visible:
+      id: "Recipe::OcrSnackbar"
+    timeout: 120000
+    label: "Wait for OCR no-data snackbar to appear"
+
+- assertVisible:
+    text: "No recipe data found in the image."
+    label: "Assert - no-data snackbar message is shown"
+
+- runFlow:
+    file: "../cleanAndResume.yaml"
+    label: "Delete photo from gallery and return to Recipedia"

--- a/tests/e2e/flows/recipe/adding/ocr/gallery/ocrQuantityMismatchFeedback.yaml
+++ b/tests/e2e/flows/recipe/adding/ocr/gallery/ocrQuantityMismatchFeedback.yaml
@@ -1,0 +1,80 @@
+appId: "com.recipedia"
+---
+# Verifies the quantity-mismatch feedback snackbar, cross-platform.
+#
+# Adds 2 empty ingredient rows, then scans the quantities image (reused
+# tajineMerguez/ingredients_quantities.jpeg, which holds 5 quantities). The
+# extracted quantity count never equals 2 — iOS reads all 5, Android ML Kit
+# under-reads to ~1 — so fillOneField returns "mismatch" and the root snackbar
+# surfaces (verified on both platforms). Only 2 rows are added: the fixed bottom
+# action bar obscures the add button once the list grows, so more rows cannot be
+# added reliably.
+- waitForAnimationToEnd
+
+- scrollUntilVisible:
+    element:
+      id: "RecipeIngredients::AddButton::RoundButton"
+    direction: DOWN
+    speed: 40
+    centerElement: true
+    label: "Scroll to the add-ingredient button"
+
+- tapOn:
+    id: "RecipeIngredients::AddButton::RoundButton"
+    label: "Add first empty ingredient row"
+- waitForAnimationToEnd
+
+- scrollUntilVisible:
+    element:
+      id: "RecipeIngredients::AddButton::RoundButton"
+    direction: DOWN
+    speed: 40
+    centerElement: true
+    label: "Re-center the add-ingredient button"
+
+- tapOn:
+    id: "RecipeIngredients::AddButton::RoundButton"
+    label: "Add second empty ingredient row"
+- waitForAnimationToEnd
+
+- scrollUntilVisible:
+    element:
+      id: "RecipeIngredients::OpenModalQuantities::RoundButton"
+    direction: DOWN
+    speed: 40
+    centerElement: true
+    label: "Scroll to ingredient quantities OCR button"
+
+- waitForAnimationToEnd
+
+- tapOn:
+    id: "RecipeIngredients::OpenModalQuantities::RoundButton"
+    label: "Tap on ingredient quantities OCR button"
+
+- addMedia:
+    - "../../../../../../assets/tajineMerguez/ingredients_quantities.jpeg"
+
+- runFlow:
+    file: ../android/selectMostRecentFromModal.yaml
+    label: "Select quantities image from modal for OCR"
+    when:
+      platform: Android
+- runFlow:
+    file: ../iOS/selectMostRecentFromModal.yaml
+    label: "Select quantities image from modal for OCR"
+    when:
+      platform: iOS
+
+- extendedWaitUntil:
+    visible:
+      id: "Recipe::OcrSnackbar"
+    timeout: 120000
+    label: "Wait for OCR quantity-mismatch snackbar to appear"
+
+- assertVisible:
+    text: "Scanned quantities don't match your ingredients. Please check the values."
+    label: "Assert - quantity-mismatch snackbar message is shown"
+
+- runFlow:
+    file: ../cleanAndResume.yaml
+    label: "Delete quantities image from gallery and return to Recipedia"

--- a/tests/e2e/ocr.yaml
+++ b/tests/e2e/ocr.yaml
@@ -15,3 +15,4 @@ executionOrder:
     - "4 - OCR Quitoque V2 French Flow"
     - "5 - OCR Inline Field Errors Flow"
     - "6 - OCR Image Target Flow"
+    - "7 - OCR Feedback Snackbar Flow"

--- a/tests/mocks/utils/OCR-mock.tsx
+++ b/tests/mocks/utils/OCR-mock.tsx
@@ -1,5 +1,6 @@
 export function ocrMock() {
   return {
     extractFieldFromImage: jest.fn().mockResolvedValue({ recipeImage: '/path/to/cropped/img' }),
+    computeOcrFieldStatus: jest.fn().mockReturnValue('success'),
   };
 }

--- a/tests/unit/context/RecipeDialogsContext.test.tsx
+++ b/tests/unit/context/RecipeDialogsContext.test.tsx
@@ -253,6 +253,44 @@ describe('RecipeDialogsContext', () => {
     });
   });
 
+  describe('snackbar', () => {
+    test('starts hidden with empty message', () => {
+      const wrapper = createDialogsWrapper();
+      const { result } = renderHook(() => useRecipeDialogs(), { wrapper });
+
+      expect(result.current.snackbar.visible).toBe(false);
+      expect(result.current.snackbar.message).toBe('');
+    });
+
+    test('showSnackbar sets message and makes it visible', () => {
+      const wrapper = createDialogsWrapper();
+      const { result } = renderHook(() => useRecipeDialogs(), { wrapper });
+
+      act(() => {
+        result.current.showSnackbar('No data found');
+      });
+
+      expect(result.current.snackbar.visible).toBe(true);
+      expect(result.current.snackbar.message).toBe('No data found');
+    });
+
+    test('hideSnackbar hides while keeping the message', () => {
+      const wrapper = createDialogsWrapper();
+      const { result } = renderHook(() => useRecipeDialogs(), { wrapper });
+
+      act(() => {
+        result.current.showSnackbar('No data found');
+      });
+
+      act(() => {
+        result.current.hideSnackbar();
+      });
+
+      expect(result.current.snackbar.visible).toBe(false);
+      expect(result.current.snackbar.message).toBe('No data found');
+    });
+  });
+
   describe('error handling', () => {
     test('throws error when useRecipeDialogs is used outside provider', () => {
       const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/unit/hooks/useRecipeOCR.test.tsx
+++ b/tests/unit/hooks/useRecipeOCR.test.tsx
@@ -69,6 +69,7 @@ function FormDrivenApplyPatchRegistrar({ children }: { children: React.ReactNode
 const mockExtractFieldFromImage = jest.fn();
 
 jest.mock('@utils/OCR', () => ({
+  ...jest.requireActual('@utils/OCR'),
   extractFieldFromImage: (...args: unknown[]) => mockExtractFieldFromImage(...args),
 }));
 
@@ -1110,5 +1111,95 @@ describe('useRecipeOCR', () => {
         expect(result.current.form.form.getValues('recipeIngredients')![0]!.quantity).toBe('');
       }
     );
+  });
+
+  describe('fillOneField feedback status', () => {
+    test('returns success when a field is populated', async () => {
+      mockExtractFieldFromImage.mockResolvedValue({ recipeTitle: 'Extracted Title' });
+
+      const wrapper = createOcrWrapper(createMockRecipeProp('addFromPic', undefined, 'test.jpg'));
+      const { result } = renderHook(() => useTestRecipeOCR(), { wrapper });
+
+      let status;
+      await act(async () => {
+        status = await result.current.fillOneField('image.jpg', recipeColumnsNames.title);
+      });
+
+      expect(status).toBe('success');
+    });
+
+    test('returns empty when extraction yields nothing', async () => {
+      mockExtractFieldFromImage.mockResolvedValue({});
+
+      const wrapper = createOcrWrapper(createMockRecipeProp('addFromPic', undefined, 'test.jpg'));
+      const { result } = renderHook(() => useTestRecipeOCR(), { wrapper });
+
+      let status;
+      await act(async () => {
+        status = await result.current.fillOneField('image.jpg', recipeColumnsNames.title);
+      });
+
+      expect(status).toBe('empty');
+    });
+
+    test('returns empty when no quantities extracted', async () => {
+      mockExtractFieldFromImage.mockResolvedValue({ ingredientQuantities: [] });
+
+      const wrapper = createOcrWrapper(createMockRecipeProp('edit', recipeForOcr));
+      const { result } = renderHook(() => ({ ocr: useTestRecipeOCR(), form: useRecipeForm() }), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.form.form.getValues('recipeIngredients')).toHaveLength(1);
+      });
+
+      let status;
+      await act(async () => {
+        status = await result.current.ocr.fillOneField('image.jpg', 'ingredientQuantities');
+      });
+
+      expect(status).toBe('empty');
+    });
+
+    test('returns mismatch when quantity count differs from ingredient rows', async () => {
+      mockExtractFieldFromImage.mockResolvedValue({ ingredientQuantities: ['100', '200'] });
+
+      const wrapper = createOcrWrapper(createMockRecipeProp('edit', recipeForOcr));
+      const { result } = renderHook(() => ({ ocr: useTestRecipeOCR(), form: useRecipeForm() }), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.form.form.getValues('recipeIngredients')).toHaveLength(1);
+      });
+
+      let status;
+      await act(async () => {
+        status = await result.current.ocr.fillOneField('image.jpg', 'ingredientQuantities');
+      });
+
+      expect(status).toBe('mismatch');
+    });
+
+    test('returns success when quantity count matches ingredient rows', async () => {
+      mockExtractFieldFromImage.mockResolvedValue({ ingredientQuantities: ['350'] });
+
+      const wrapper = createOcrWrapper(createMockRecipeProp('edit', recipeForOcr));
+      const { result } = renderHook(() => ({ ocr: useTestRecipeOCR(), form: useRecipeForm() }), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.form.form.getValues('recipeIngredients')).toHaveLength(1);
+      });
+
+      let status;
+      await act(async () => {
+        status = await result.current.ocr.fillOneField('image.jpg', 'ingredientQuantities');
+      });
+
+      expect(status).toBe('success');
+    });
   });
 });

--- a/tests/unit/screens/recipe/RecipeAddOcr.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddOcr.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import RecipeDatabase from '@utils/RecipeDatabase';
 import { AddFromPicProp } from '@customTypes/RecipeNavigationTypes';
+import { computeOcrFieldStatus } from '@utils/OCR';
 
 import {
   checkAppbarButtons,
@@ -147,6 +148,61 @@ describe('RecipeAddOcr', () => {
       fireEvent.press(getByTestId('ModalImageSelect::Select'));
 
       await waitFor(() => expect(queryByTestId('ModalImageSelect')).toBeNull());
+    });
+  });
+
+  describe('OCR feedback snackbar', () => {
+    async function selectImageForTitleTarget(getByTestId: (id: string) => unknown) {
+      fireEvent.press(getByTestId('RecipeTitle::OpenModal') as never);
+      await waitFor(() => expect(getByTestId('ModalImageSelect')).toBeTruthy());
+      fireEvent.press(getByTestId('ModalImageSelect::Select') as never);
+    }
+
+    test('shows the no-data snackbar when extraction yields empty', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddOCR);
+      (computeOcrFieldStatus as jest.Mock).mockReturnValueOnce('empty');
+
+      await selectImageForTitleTarget(getByTestId);
+
+      await waitFor(() => {
+        expect(getByTestId('Recipe::OcrSnackbar::Text').props.children).toBe('ocrFeedback.noData');
+      });
+    });
+
+    test('shows the quantity-mismatch snackbar when counts differ', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddOCR);
+      (computeOcrFieldStatus as jest.Mock).mockReturnValueOnce('mismatch');
+
+      await selectImageForTitleTarget(getByTestId);
+
+      await waitFor(() => {
+        expect(getByTestId('Recipe::OcrSnackbar::Text').props.children).toBe(
+          'ocrFeedback.quantityMismatch'
+        );
+      });
+    });
+
+    test('shows no snackbar when extraction succeeds', async () => {
+      const { getByTestId, queryByTestId } = await renderRoute(mockRouteAddOCR);
+      (computeOcrFieldStatus as jest.Mock).mockReturnValueOnce('success');
+
+      await selectImageForTitleTarget(getByTestId);
+
+      await waitFor(() => expect(queryByTestId('ModalImageSelect')).toBeNull());
+      expect(queryByTestId('Recipe::OcrSnackbar')).toBeNull();
+    });
+
+    test('dismissing the snackbar hides it', async () => {
+      const { getByTestId, queryByTestId } = await renderRoute(mockRouteAddOCR);
+      (computeOcrFieldStatus as jest.Mock).mockReturnValueOnce('empty');
+
+      await selectImageForTitleTarget(getByTestId);
+
+      await waitFor(() => expect(getByTestId('Recipe::OcrSnackbar')).toBeTruthy());
+
+      fireEvent.press(getByTestId('Recipe::OcrSnackbar::Dismiss'));
+
+      await waitFor(() => expect(queryByTestId('Recipe::OcrSnackbar')).toBeNull());
     });
   });
 });

--- a/tests/unit/utils/OCR.fieldStatus.test.tsx
+++ b/tests/unit/utils/OCR.fieldStatus.test.tsx
@@ -1,0 +1,80 @@
+import { computeOcrFieldStatus } from '@utils/OCR';
+import { recipeColumnsNames } from '@customTypes/DatabaseElementTypes';
+
+describe('computeOcrFieldStatus', () => {
+  describe('ingredientQuantities', () => {
+    test('empty when no quantities extracted', () => {
+      expect(computeOcrFieldStatus('ingredientQuantities', { ingredientQuantities: [] }, 3)).toBe(
+        'empty'
+      );
+    });
+
+    test('empty when quantities key absent', () => {
+      expect(computeOcrFieldStatus('ingredientQuantities', {}, 3)).toBe('empty');
+    });
+
+    test('mismatch when count differs from ingredient rows', () => {
+      expect(
+        computeOcrFieldStatus('ingredientQuantities', { ingredientQuantities: ['1', '2'] }, 3)
+      ).toBe('mismatch');
+    });
+
+    test('success when count matches ingredient rows', () => {
+      expect(
+        computeOcrFieldStatus('ingredientQuantities', { ingredientQuantities: ['1', '2', '3'] }, 3)
+      ).toBe('success');
+    });
+
+    test('mismatch when quantities scanned but no ingredient rows exist', () => {
+      expect(
+        computeOcrFieldStatus('ingredientQuantities', { ingredientQuantities: ['1', '2'] }, 0)
+      ).toBe('mismatch');
+    });
+  });
+
+  describe('non-quantity fields', () => {
+    test('empty for empty payload', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.title, {}, 0)).toBe('empty');
+    });
+
+    test('empty for blank string value', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.title, { recipeTitle: '' }, 0)).toBe('empty');
+    });
+
+    test('empty for empty array value', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.tags, { recipeTags: [] }, 0)).toBe('empty');
+    });
+
+    test('empty when the only value is undefined', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.title, { recipeTitle: undefined }, 0)).toBe(
+        'empty'
+      );
+    });
+
+    test('success for populated string value', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.title, { recipeTitle: 'Cake' }, 0)).toBe(
+        'success'
+      );
+    });
+
+    test('success for numeric value', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.persons, { recipePersons: 4 }, 0)).toBe(
+        'success'
+      );
+    });
+
+    test('success for zero numeric value', () => {
+      expect(computeOcrFieldStatus(recipeColumnsNames.time, { recipeTime: 0 }, 0)).toBe('success');
+    });
+
+    test('success for non-empty array value', () => {
+      expect(
+        computeOcrFieldStatus(
+          recipeColumnsNames.preparation,
+          { recipePreparation: [{ title: 'Step', description: 'Mix' }] },
+          0
+        )
+      ).toBe('success');
+    });
+  });
+});


### PR DESCRIPTION
Closes #316.

Replaces blocking dialog feedback in the OCR add flow with a non-blocking React Native Paper `Snackbar`.

## What changed
- **Snackbar context**: extend `RecipeDialogsContext` with snackbar state (`showSnackbar` / `hideSnackbar`) and mount a root `Snackbar` in `RecipeFormScreen` (`DURATION_LONG` for CI robustness).
- **OCR status**: `useRecipeOCR.fillOneField` now returns an `OcrFieldStatus` (`empty` | `mismatch` | `success`), derived by a new pure `computeOcrFieldStatus` in `utils/OCR`. `RecipeAddOcr` surfaces the `empty` and `mismatch` cases as snackbar messages; `success` stays silent.
- **i18n**: add `ocrFeedback` strings (en/fr).

## Why
`Alert.alert()` / blocking dialogs are inappropriate for hook / non-UI feedback. A snackbar gives non-blocking contextual feedback when OCR returns nothing (`empty`) or a quantity count that doesn't match the ingredient rows (`mismatch`).

## Tests
- **Unit**: `computeOcrFieldStatus` (all branches), snackbar context, `fillOneField` status returns, `RecipeAddOcr` snackbar wiring. New `OCR.fieldStatus.test.tsx`.
- **E2E** (`7 - OCR Feedback Snackbar Flow`, cross-platform): no-data (text-free photo → title) + quantity-mismatch (2 rows vs 5-quantity scan). **Verified live on Android + iOS dev builds.**

## Commits
- `feat(recipe): non-blocking OCR feedback via global snackbar (#316)`
- `test(e2e): cover OCR feedback snackbar cross-platform (#316)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)