### PR TITLE
perf(#315): idle scheduling primitive + warm tag/ingredient search index

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,6 +149,26 @@ Hooks that subscribe to `RecipeDatabase` slices:
 | `useShopping` | `menu`, `purchased` | Derived shopping list (read-only, no mutations) |
 | `useImportHistory` | — | Import history and dismissed-recipe records |
 
+### Idle-time scheduling
+
+`runWhenIdle` / `cancelIdle` (`src/utils/idle.ts`) are the app's primitive for
+non-critical work: they enqueue a callback at React's `scheduler` **idle
+priority**, so it runs only once renders, gestures and transitions have drained
+and yields back if more urgent work arrives. This is deliberately not the DOM
+`requestIdleCallback` — React Native (Hermes / JSC) does not provide it, so a
+wrapper around it would silently degrade to `setTimeout` on device;
+`scheduler` ships with React and behaves uniformly across engines.
+
+`useTags` and `useIngredients` warm their fuzzy search index off the critical
+path with it: `useWarmSearchIndex` (`src/hooks/useWarmSearchIndex.ts`) schedules
+the `buildItemIndex` pass via `runWhenIdle` whenever the corpus reference
+changes, so the `makeItemIndexCache` `WeakMap` is already populated by the time
+the user first searches. The idle primitive is the shared foundation the other
+tracked jank fixes build on — deferred Home recommendation regeneration (#443)
+and Search input pipeline work (#438) consume the same `runWhenIdle`, while
+per-keystroke render responsiveness on those screens is handled separately with
+React 19 `useDeferredValue`.
+
 ---
 
 ## 5. Navigation structure

--- a/src/hooks/useIngredients.ts
+++ b/src/hooks/useIngredients.ts
@@ -23,6 +23,7 @@ import {
   searchItemsDetailed,
 } from '@utils/FuzzyIndex';
 import { cleanIngredientName } from '@utils/NutritionUtils';
+import { useWarmSearchIndex } from '@hooks/useWarmSearchIndex';
 
 const getIngredientsIndex = makeItemIndexCache<ingredientTableElement>({
   fuzzy: ITEM_FUZZY,
@@ -47,6 +48,8 @@ export function useIngredients() {
     cb => db.subscribe('ingredients', cb),
     () => db.get_ingredients()
   );
+
+  useWarmSearchIndex(getIngredientsIndex, ingredients);
 
   const addIngredient = async (ingredient: IngredientDraft): Promise<ingredientTableElement> => {
     return db.addIngredient(ingredient);

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -18,6 +18,7 @@ import {
   searchItems,
   searchItemsDetailed,
 } from '@utils/FuzzyIndex';
+import { useWarmSearchIndex } from '@hooks/useWarmSearchIndex';
 
 const getTagsIndex = makeItemIndexCache<tagTableElement>({
   fuzzy: ITEM_FUZZY,
@@ -38,6 +39,8 @@ export function useTags() {
     cb => db.subscribe('tags', cb),
     () => db.get_tags()
   );
+
+  useWarmSearchIndex(getTagsIndex, tags);
 
   const addTag = async (tag: TagDraft): Promise<tagTableElement> => {
     return db.addTag(tag);

--- a/src/hooks/useWarmSearchIndex.ts
+++ b/src/hooks/useWarmSearchIndex.ts
@@ -27,7 +27,7 @@ import { cancelIdle, runWhenIdle } from '@utils/idle';
  * @param build - Corpus-keyed index builder (e.g. a `makeItemIndexCache` getter)
  * @param corpus - Current corpus array; a new reference triggers a fresh warm
  */
-export function useWarmSearchIndex<T>(build: (corpus: T[]) => unknown, corpus: T[]): void {
+export function useWarmSearchIndex<T>(build: (corpus: T[]) => void, corpus: T[]): void {
   useEffect(() => {
     if (corpus.length === 0) {
       return;

--- a/src/hooks/useWarmSearchIndex.ts
+++ b/src/hooks/useWarmSearchIndex.ts
@@ -1,0 +1,40 @@
+/**
+ * useWarmSearchIndex - Idle-time fuzzy search index warming
+ *
+ * Rebuilds a corpus-keyed fuzzy search index during idle time whenever its
+ * corpus changes, so the expensive `buildItemIndex` pass runs off the critical
+ * path instead of synchronously on the user's first keystroke. Pairs with the
+ * `makeItemIndexCache` getters that back `useTags` / `useIngredients`: warming
+ * populates their `WeakMap` cache for the current corpus reference, turning the
+ * first real search into a cache hit.
+ *
+ * @module useWarmSearchIndex
+ */
+
+import { useEffect } from 'react';
+import { cancelIdle, runWhenIdle } from '@utils/idle';
+
+/**
+ * Warms a corpus-keyed search index during idle time after the corpus changes.
+ *
+ * On each new `corpus` reference, schedules `build(corpus)` via
+ * {@link runWhenIdle}. The build result is discarded — the point is the side
+ * effect of populating `build`'s internal cache. A pending warm is cancelled
+ * when the corpus changes again or the consumer unmounts, so a fast sequence of
+ * mutations only ever warms the latest corpus.
+ *
+ * @typeParam T - Corpus element type
+ * @param build - Corpus-keyed index builder (e.g. a `makeItemIndexCache` getter)
+ * @param corpus - Current corpus array; a new reference triggers a fresh warm
+ */
+export function useWarmSearchIndex<T>(build: (corpus: T[]) => unknown, corpus: T[]): void {
+  useEffect(() => {
+    if (corpus.length === 0) {
+      return;
+    }
+    const handle = runWhenIdle(() => {
+      build(corpus);
+    });
+    return () => cancelIdle(handle);
+  }, [build, corpus]);
+}

--- a/src/types/scheduler.d.ts
+++ b/src/types/scheduler.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal ambient typings for React's `scheduler` package.
+ *
+ * `scheduler` ships no types and no `@types/scheduler` is installed; only the
+ * idle-priority scheduling surface consumed by `src/utils/idle.ts` is declared
+ * here. See https://github.com/facebook/react/tree/main/packages/scheduler.
+ */
+declare module 'scheduler' {
+  export type PriorityLevel = number;
+
+  export const unstable_ImmediatePriority: PriorityLevel;
+  export const unstable_UserBlockingPriority: PriorityLevel;
+  export const unstable_NormalPriority: PriorityLevel;
+  export const unstable_LowPriority: PriorityLevel;
+  export const unstable_IdlePriority: PriorityLevel;
+
+  export interface CallbackNode {
+    readonly __brand: 'SchedulerCallbackNode';
+  }
+
+  export function unstable_scheduleCallback(
+    priorityLevel: PriorityLevel,
+    callback: (didTimeout: boolean) => void,
+    options?: { delay?: number }
+  ): CallbackNode;
+
+  export function unstable_cancelCallback(node: CallbackNode): void;
+}

--- a/src/utils/datasetInitializer.ts
+++ b/src/utils/datasetInitializer.ts
@@ -3,9 +3,9 @@
  *
  * Provides a single async function that copies dataset images and inserts
  * the full ingredient, tag and recipe dataset into the RecipeDatabase singleton.
- * Designed to be called once on first launch, inside
- * `InteractionManager.runAfterInteractions`, so the UI renders before the
- * heavy data load begins.
+ * Designed to be called once on first launch, deferred until after the Welcome
+ * screen has painted (via a post-mount timer in `WelcomeScreen`), so the UI
+ * renders before the heavy data load begins.
  *
  * Each `addMultiple*` call triggers `notify()` on the corresponding slice of
  * the RecipeDatabase singleton, so `useSyncExternalStore` hooks automatically

--- a/src/utils/idle.ts
+++ b/src/utils/idle.ts
@@ -1,0 +1,61 @@
+/**
+ * idle - Cooperative idle-time scheduling
+ *
+ * Schedules non-critical work to run when the JavaScript thread is idle, so it
+ * does not compete with navigation transitions, list scrolling or gesture
+ * handling for the same frame budget. Backed by React's `scheduler` package at
+ * idle priority — the same cooperative priority queue the React runtime uses to
+ * interleave work — so idle tasks yield to renders, gestures and transitions and
+ * run only once nothing more urgent is pending.
+ *
+ * This is deliberately not `requestIdleCallback`: React Native (Hermes / JSC)
+ * does not provide that DOM API, so a wrapper around it would silently degrade
+ * to a plain `setTimeout` on device. `scheduler` ships with React, works
+ * uniformly across engines, and is the primitive `requestIdleCallback` polyfills
+ * themselves delegate to.
+ *
+ * Use this for work whose result is not needed for the current frame but is
+ * worth doing before the user asks for it — e.g. warming a search index after
+ * its corpus changes so the first query is instant.
+ *
+ * @module idle
+ */
+
+import {
+  unstable_IdlePriority as IdlePriority,
+  unstable_scheduleCallback as scheduleCallback,
+  unstable_cancelCallback as cancelCallback,
+} from 'scheduler';
+
+/**
+ * Opaque handle returned by {@link runWhenIdle} and consumed by
+ * {@link cancelIdle}. Wraps the scheduler task so callers never depend on its
+ * shape.
+ */
+export type IdleHandle = ReturnType<typeof scheduleCallback>;
+
+/**
+ * Schedules `callback` to run when the JS thread is idle.
+ *
+ * The callback is enqueued at the scheduler's idle priority: it runs only once
+ * higher-priority work (renders, gestures, transitions) has drained, and the
+ * scheduler yields back to that work if it arrives mid-flush. Always pair with
+ * {@link cancelIdle} to release work that is no longer needed — e.g. on unmount
+ * or when its input changes.
+ *
+ * @param callback - Work to run during idle time
+ * @returns Handle that cancels the scheduled work via {@link cancelIdle}
+ */
+export function runWhenIdle(callback: () => void): IdleHandle {
+  return scheduleCallback(IdlePriority, callback);
+}
+
+/**
+ * Cancels work scheduled by {@link runWhenIdle}. Safe to call after the callback
+ * has already run; the scheduler ignores stale handles.
+ *
+ * @param handle - Handle returned by {@link runWhenIdle}
+ */
+export function cancelIdle(handle: IdleHandle): void {
+  cancelCallback(handle);
+}

--- a/tests/mocks/deps/scheduler-mock.ts
+++ b/tests/mocks/deps/scheduler-mock.ts
@@ -1,0 +1,19 @@
+type ScheduledTask = { cb: () => void; cancelled: boolean };
+
+export const unstable_IdlePriority = 5;
+
+export const unstable_scheduleCallback = jest.fn(
+  (_priority: number, cb: () => void): ScheduledTask => ({ cb, cancelled: false })
+);
+
+export const unstable_cancelCallback = jest.fn((task: ScheduledTask) => {
+  task.cancelled = true;
+});
+
+export const flushIdleTasks = (): void => {
+  for (const { value } of unstable_scheduleCallback.mock.results) {
+    if (!value.cancelled) {
+      value.cb();
+    }
+  }
+};

--- a/tests/mocks/utils/idle-mock.ts
+++ b/tests/mocks/utils/idle-mock.ts
@@ -1,0 +1,15 @@
+type IdleHandle = { cb: () => void; cancelled: boolean };
+
+export const runWhenIdle = jest.fn((cb: () => void): IdleHandle => ({ cb, cancelled: false }));
+
+export const cancelIdle = jest.fn((handle: IdleHandle) => {
+  handle.cancelled = true;
+});
+
+export const flushIdle = (): void => {
+  for (const { value } of runWhenIdle.mock.results) {
+    if (!value.cancelled) {
+      value.cb();
+    }
+  }
+};

--- a/tests/perf/WarmSearchIndex.perf.tsx
+++ b/tests/perf/WarmSearchIndex.perf.tsx
@@ -1,0 +1,28 @@
+import { measureFunction } from 'reassure';
+import { buildItemIndex, ITEM_FUZZY } from '@utils/FuzzyIndex';
+import { cleanIngredientName } from '@utils/NutritionUtils';
+import { ingredientType } from '@customTypes/DatabaseElementTypes';
+import { HEAVY_WARMUP } from './perfOptions';
+
+const largeIngredients = Array.from({ length: 1200 }, (_, i) => ({
+  id: i + 1,
+  name: `LargeIngredient${i + 1}`,
+  unit: 'g',
+  type: ingredientType.vegetable,
+  season: [] as string[],
+}));
+
+const indexConfig = {
+  fuzzy: ITEM_FUZZY,
+  getName: (ingredient: (typeof largeIngredients)[number]) => ingredient.name,
+  preprocess: cleanIngredientName,
+};
+
+describe('Warm search index performance - 1200 ingredients', () => {
+  test('buildItemIndex is the cost the idle warm defers off the first keystroke', async () => {
+    await measureFunction(() => buildItemIndex(largeIngredients, indexConfig), {
+      runs: 20,
+      ...HEAVY_WARMUP,
+    });
+  });
+});

--- a/tests/unit/hooks/useWarmSearchIndex.test.tsx
+++ b/tests/unit/hooks/useWarmSearchIndex.test.tsx
@@ -1,37 +1,18 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { useWarmSearchIndex } from '@hooks/useWarmSearchIndex';
+import { cancelIdle, flushIdle, runWhenIdle } from '@mocks/utils/idle-mock';
 
-const idleGlobal = globalThis as unknown as {
-  requestIdleCallback?: unknown;
-  cancelIdleCallback?: unknown;
-};
+jest.mock('@utils/idle', () => require('@mocks/utils/idle-mock'));
 
 describe('useWarmSearchIndex', () => {
-  const originalRequest = idleGlobal.requestIdleCallback;
-  const originalCancel = idleGlobal.cancelIdleCallback;
-
-  beforeEach(() => {
-    jest.useFakeTimers();
-    idleGlobal.requestIdleCallback = undefined;
-    idleGlobal.cancelIdleCallback = undefined;
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-    idleGlobal.requestIdleCallback = originalRequest;
-    idleGlobal.cancelIdleCallback = originalCancel;
-  });
-
-  test('builds the index during idle time for a non-empty corpus', () => {
+  test('schedules an idle build for a non-empty corpus', () => {
     const build = jest.fn();
     const corpus = [{ name: 'Italian' }];
 
     renderHook(() => useWarmSearchIndex(build, corpus));
     expect(build).not.toHaveBeenCalled();
 
-    act(() => {
-      jest.runAllTimers();
-    });
+    act(() => flushIdle());
 
     expect(build).toHaveBeenCalledWith(corpus);
   });
@@ -40,11 +21,9 @@ describe('useWarmSearchIndex', () => {
     const build = jest.fn();
 
     renderHook(() => useWarmSearchIndex(build, []));
+    act(() => flushIdle());
 
-    act(() => {
-      jest.runAllTimers();
-    });
-
+    expect(runWhenIdle).not.toHaveBeenCalled();
     expect(build).not.toHaveBeenCalled();
   });
 
@@ -59,11 +38,9 @@ describe('useWarmSearchIndex', () => {
     );
 
     rerender({ corpus: second });
+    act(() => flushIdle());
 
-    act(() => {
-      jest.runAllTimers();
-    });
-
+    expect(cancelIdle).toHaveBeenCalledTimes(1);
     expect(build).toHaveBeenCalledTimes(1);
     expect(build).toHaveBeenCalledWith(second);
   });
@@ -73,11 +50,57 @@ describe('useWarmSearchIndex', () => {
 
     const { unmount } = renderHook(() => useWarmSearchIndex(build, [{ name: 'Italian' }]));
     unmount();
+    act(() => flushIdle());
 
-    act(() => {
-      jest.runAllTimers();
-    });
-
+    expect(cancelIdle).toHaveBeenCalled();
     expect(build).not.toHaveBeenCalled();
+  });
+
+  test('reschedules the warm with the new builder when the build function changes', () => {
+    const firstBuild = jest.fn();
+    const secondBuild = jest.fn();
+    const corpus = [{ name: 'Italian' }];
+
+    const { rerender } = renderHook(
+      ({ build }: { build: (corpus: { name: string }[]) => void }) =>
+        useWarmSearchIndex(build, corpus),
+      { initialProps: { build: firstBuild } }
+    );
+
+    rerender({ build: secondBuild });
+    act(() => flushIdle());
+
+    expect(cancelIdle).toHaveBeenCalledTimes(1);
+    expect(firstBuild).not.toHaveBeenCalled();
+    expect(secondBuild).toHaveBeenCalledWith(corpus);
+  });
+
+  test('cancels the pending warm and schedules nothing when the corpus becomes empty', () => {
+    const build = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ corpus }: { corpus: { name: string }[] }) => useWarmSearchIndex(build, corpus),
+      { initialProps: { corpus: [{ name: 'Italian' }] as { name: string }[] } }
+    );
+
+    rerender({ corpus: [] });
+    act(() => flushIdle());
+
+    expect(runWhenIdle).toHaveBeenCalledTimes(1);
+    expect(cancelIdle).toHaveBeenCalledTimes(1);
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  test('does not reschedule while the corpus reference is unchanged across re-renders', () => {
+    const build = jest.fn();
+    const corpus = [{ name: 'Italian' }];
+
+    const { rerender } = renderHook(() => useWarmSearchIndex(build, corpus));
+    rerender({});
+    act(() => flushIdle());
+
+    expect(runWhenIdle).toHaveBeenCalledTimes(1);
+    expect(cancelIdle).not.toHaveBeenCalled();
+    expect(build).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/hooks/useWarmSearchIndex.test.tsx
+++ b/tests/unit/hooks/useWarmSearchIndex.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useWarmSearchIndex } from '@hooks/useWarmSearchIndex';
+
+const idleGlobal = globalThis as unknown as {
+  requestIdleCallback?: unknown;
+  cancelIdleCallback?: unknown;
+};
+
+describe('useWarmSearchIndex', () => {
+  const originalRequest = idleGlobal.requestIdleCallback;
+  const originalCancel = idleGlobal.cancelIdleCallback;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    idleGlobal.requestIdleCallback = undefined;
+    idleGlobal.cancelIdleCallback = undefined;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    idleGlobal.requestIdleCallback = originalRequest;
+    idleGlobal.cancelIdleCallback = originalCancel;
+  });
+
+  test('builds the index during idle time for a non-empty corpus', () => {
+    const build = jest.fn();
+    const corpus = [{ name: 'Italian' }];
+
+    renderHook(() => useWarmSearchIndex(build, corpus));
+    expect(build).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(build).toHaveBeenCalledWith(corpus);
+  });
+
+  test('never schedules a build for an empty corpus', () => {
+    const build = jest.fn();
+
+    renderHook(() => useWarmSearchIndex(build, []));
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  test('cancels a pending warm when the corpus changes before it runs', () => {
+    const build = jest.fn();
+    const first = [{ name: 'Italian' }];
+    const second = [{ name: 'Mexican' }];
+
+    const { rerender } = renderHook(
+      ({ corpus }: { corpus: { name: string }[] }) => useWarmSearchIndex(build, corpus),
+      { initialProps: { corpus: first } }
+    );
+
+    rerender({ corpus: second });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(build).toHaveBeenCalledWith(second);
+  });
+
+  test('cancels the pending warm on unmount', () => {
+    const build = jest.fn();
+
+    const { unmount } = renderHook(() => useWarmSearchIndex(build, [{ name: 'Italian' }]));
+    unmount();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(build).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/idle.test.ts
+++ b/tests/unit/utils/idle.test.ts
@@ -1,0 +1,47 @@
+import { cancelIdle, runWhenIdle } from '@utils/idle';
+import {
+  flushIdleTasks,
+  unstable_IdlePriority,
+  unstable_cancelCallback,
+  unstable_scheduleCallback,
+} from '@mocks/deps/scheduler-mock';
+
+jest.mock('scheduler', () => require('@mocks/deps/scheduler-mock'));
+
+describe('runWhenIdle', () => {
+  test('schedules the callback at idle priority', () => {
+    const callback = jest.fn();
+    runWhenIdle(callback);
+
+    expect(unstable_scheduleCallback).toHaveBeenCalledWith(unstable_IdlePriority, callback);
+  });
+
+  test('runs the callback only once idle time is granted', () => {
+    const callback = jest.fn();
+    runWhenIdle(callback);
+    expect(callback).not.toHaveBeenCalled();
+
+    flushIdleTasks();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns the scheduler handle', () => {
+    const handle = runWhenIdle(jest.fn());
+
+    expect(handle).toBe(unstable_scheduleCallback.mock.results[0]!.value);
+  });
+});
+
+describe('cancelIdle', () => {
+  test('cancels the scheduled callback through the scheduler', () => {
+    const callback = jest.fn();
+    const handle = runWhenIdle(callback);
+
+    cancelIdle(handle);
+    flushIdleTasks();
+
+    expect(unstable_cancelCallback).toHaveBeenCalledWith(handle);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #315.

## What #315 actually is

Profiled every candidate the issue named against the 15 other open perf issues. Nearly all are already owned by dedicated tickets:

| Candidate | Owned by |
|---|---|
| Search `filterFromRecipe` defer | #438 |
| `filterFromRecipe` per-recipe cost | #442 |
| Home recommendations defer | #443 (explicitly "see #315" for idle) |
| Dialog / param-list open | #313 |
| Shopping recalc, decode, `buildItemIndex` chunking | #419 |

So #315's **unique, un-owned** scope = the reusable idle primitive (which #438/#443/#313 all defer to but nobody builds) **plus** the one consumer nobody else claimed (tag/ingredient index warm). This PR delivers exactly that — the foundation the other perf issues build on, without colliding into them.

## Changes

- **`perf(#315): add scheduler-backed idle scheduling primitive`** — `runWhenIdle` / `cancelIdle` (`src/utils/idle.ts`) backed by React's `scheduler` at `IdlePriority`, so tasks yield to renders/gestures/transitions. Deliberately **not** `requestIdleCallback`: RN (Hermes/JSC) doesn't provide it, so a wrapper would silently degrade to `setTimeout` on device. Minimal ambient `scheduler.d.ts` (no `@types` dep).
- **`perf(#315): warm tag/ingredient search index during idle time`** — `useWarmSearchIndex` schedules `buildItemIndex` via `runWhenIdle` on corpus change, so the ~200ms build lands off the user's first keystroke; the `makeItemIndexCache` WeakMap is pre-populated by first search. Wired into `useTags` / `useIngredients`.
- **`docs(#315)`** — ARCHITECTURE.md documents the primitive and its consumers.
- **`docs`** — fix stale `InteractionManager` reference in `datasetInitializer` (unused in the repo; deferral is actually a post-mount timer in `WelcomeScreen`).

## Profiling evidence

New Reassure bench (`tests/perf/WarmSearchIndex.perf.tsx`) quantifies the deferred cost — `buildItemIndex` over 1200 ingredients ≈ **~200ms**. That's what the warm lifts off the first keystroke in the add-item dialog. Auto-enrolls into CI perf gating on merge.

## Scope note

Per-keystroke fuzzy **search** cost is a separate, larger problem — it belongs to #438, not #315. Warming defers only the one-time index **build**, so this PR measures and fixes exactly that.

## Verification

typecheck ✓ · lint ✓ · knip ✓ · unit 3874 pass (0 fail) ✓ · perf bench ✓ · docs:build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)