### PR TITLE
test: cover zero-coverage hooks/utils and raise overall unit coverage (#362)

### DIFF
--- a/tests/e2e/flows/recipe/adding/ocr/iOS/selectFromGallery.yaml
+++ b/tests/e2e/flows/recipe/adding/ocr/iOS/selectFromGallery.yaml
@@ -1,5 +1,15 @@
 appId: "com.recipedia"
 ---
+- extendedWaitUntil:
+    visible:
+      text: "Recents"
+    timeout: 5000
+    label: "Wait for the native photo picker to present"
+
+- waitForAnimationToEnd:
+    timeout: 3000
+    label: "Let the picker presentation animation settle before tapping"
+
 - tapOn:
     text: "Recents"
     label: "Go to recents photos"
@@ -8,11 +18,19 @@ appId: "com.recipedia"
     visible:
       text: "\\d+ Photo.*"
     timeout: 3000
-    label: "Wait for gallery to load"
+    label: "Wait for gallery grid to load"
+
+- waitForAnimationToEnd:
+    timeout: 3000
+    label: "Let the album grid finish sliding in before tapping a cell"
 
 - tapOn:
     point: "12%,18%"
-    label: "Select any photos of the gallery"
+    label: "Select first photo of the gallery"
+
+- waitForAnimationToEnd:
+    timeout: 3000
+    label: "Let the selection register before asserting the picker dismissed"
 
 - extendedWaitUntil:
     notVisible:

--- a/tests/unit/components/atomic/TagButton.test.tsx
+++ b/tests/unit/components/atomic/TagButton.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { Chip } from 'react-native-paper';
+import { TagButton } from '@components/atomic/TagButton';
+
+describe('TagButton', () => {
+  const testID = 'TagButton';
+
+  test('renders the tag text', () => {
+    const { getByTestId } = render(<TagButton text='Vegetarian' testID={testID} />);
+
+    expect(getByTestId(`${testID}::Chip::Children`)).toHaveTextContent('Vegetarian');
+  });
+
+  test('calls onPressFunction when pressed', () => {
+    const onPressFunction = jest.fn();
+    const { getByTestId } = render(
+      <TagButton text='Breakfast' testID={testID} onPressFunction={onPressFunction} />
+    );
+
+    fireEvent.press(getByTestId(`${testID}::Chip`));
+
+    expect(onPressFunction).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not throw when pressed without an onPressFunction', () => {
+    const { getByTestId } = render(<TagButton text='Lunch' testID={testID} />);
+
+    expect(() => fireEvent.press(getByTestId(`${testID}::Chip`))).not.toThrow();
+  });
+
+  test('passes rightIcon as closeIcon and wires onClose to onPressFunction', () => {
+    const onPressFunction = jest.fn();
+    const { UNSAFE_getByType } = render(
+      <TagButton
+        text='Gluten-Free'
+        rightIcon='close'
+        testID={testID}
+        onPressFunction={onPressFunction}
+      />
+    );
+
+    const chip = UNSAFE_getByType(Chip);
+
+    expect(chip.props.closeIcon).toBe('close');
+    expect(chip.props.onClose).toBe(onPressFunction);
+  });
+
+  test('leaves onClose undefined when no rightIcon is provided', () => {
+    const { UNSAFE_getByType } = render(<TagButton text='No Icon' testID={testID} />);
+
+    const chip = UNSAFE_getByType(Chip);
+
+    expect(chip.props.closeIcon).toBeUndefined();
+    expect(chip.props.onClose).toBeUndefined();
+  });
+
+  test('does not pass an icon function when no leftIcon is provided', () => {
+    const { UNSAFE_getByType } = render(<TagButton text='No Left Icon' testID={testID} />);
+
+    const chip = UNSAFE_getByType(Chip);
+
+    expect(chip.props.icon).toBeUndefined();
+  });
+
+  test('builds a left icon element with the theme color and Chip-provided size', () => {
+    const { UNSAFE_getByType } = render(
+      <TagButton text='Breakfast' leftIcon='coffee' testID={testID} />
+    );
+
+    const chip = UNSAFE_getByType(Chip);
+    const iconElement = chip.props.icon({ size: 24 });
+
+    expect(iconElement.props.source).toBe('coffee');
+    expect(iconElement.props.size).toBe(24);
+  });
+});

--- a/tests/unit/components/organisms/FiltersSelection.test.tsx
+++ b/tests/unit/components/organisms/FiltersSelection.test.tsx
@@ -10,6 +10,10 @@ import {
 } from '@mocks/deps/react-native-copilot-mock';
 import { mockUseReducedMotion } from '@mocks/hooks/useReducedMotion-mock';
 import { TUTORIAL_DEMO_INTERVAL, TUTORIAL_STEPS } from '@utils/Constants';
+import { listFilter, prepTimeValues } from '@customTypes/RecipeFiltersTypes';
+
+const MockNativeMethodsModule = require('@react-native/jest-preset/jest/MockNativeMethods');
+const MockNativeMethods = MockNativeMethodsModule.default || MockNativeMethodsModule;
 
 jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
 
@@ -18,7 +22,11 @@ jest.mock('@hooks/useReducedMotion', () =>
 );
 
 describe('FiltersSelection Component', () => {
-  const mockSetAddingAFilter = jest.fn();
+  const mockSetAddingAFilter = jest.fn((updater: boolean | ((prev: boolean) => boolean)) => {
+    if (typeof updater === 'function') {
+      updater(false);
+    }
+  });
   const mockOnRemoveFilter = jest.fn();
 
   const defaultProps: FiltersSelectionProps = {
@@ -106,6 +114,147 @@ describe('FiltersSelection Component', () => {
     expect(getByTestId('FiltersSelection::FiltersToggleButtons')).toHaveTextContent('addFilter');
   });
 
+  test('translates preparation time filter values for display', () => {
+    const props = { ...defaultProps, filters: [prepTimeValues[0]!] };
+    const { getByTestId } = render(<FiltersSelection {...props} />);
+
+    expect(getByTestId('FiltersSelection::FiltersSelection::0::Chip::Children')).toHaveTextContent(
+      '0-10 min'
+    );
+  });
+
+  test('translates the in-season filter value for display', () => {
+    const props = { ...defaultProps, filters: [listFilter.inSeason] };
+    const { getByTestId } = render(<FiltersSelection {...props} />);
+
+    expect(getByTestId('FiltersSelection::FiltersSelection::0::Chip::Children')).toHaveTextContent(
+      listFilter.inSeason
+    );
+  });
+
+  describe('Toggle button position measurement', () => {
+    afterEach(() => {
+      MockNativeMethods.measureInWindow.mockReset();
+    });
+
+    test('reports the settled window top once two consecutive measurements match', async () => {
+      MockNativeMethods.measureInWindow.mockImplementation(
+        (cb: (x: number, y: number, width: number, height: number) => void) => {
+          cb(0, 42, 100, 50);
+        }
+      );
+      setMockCopilotState({ isActive: true, currentStep: null });
+      const onToggleButtonTop = jest.fn();
+
+      render(
+        <FiltersSelection
+          {...defaultProps}
+          screenFocused={true}
+          onToggleButtonTop={onToggleButtonTop}
+        />
+      );
+
+      await waitFor(() => expect(onToggleButtonTop).toHaveBeenCalledWith(42));
+    });
+
+    test('caps measurement attempts and reports the last value when layout never stabilizes', async () => {
+      let measurement = 0;
+      MockNativeMethods.measureInWindow.mockImplementation(
+        (cb: (x: number, y: number, width: number, height: number) => void) => {
+          measurement += 1;
+          cb(0, measurement, 100, 50);
+        }
+      );
+      setMockCopilotState({ isActive: true, currentStep: null });
+      const onToggleButtonTop = jest.fn();
+
+      render(
+        <FiltersSelection
+          {...defaultProps}
+          screenFocused={true}
+          onToggleButtonTop={onToggleButtonTop}
+        />
+      );
+
+      await waitFor(() => expect(onToggleButtonTop).toHaveBeenCalledWith(31), { timeout: 5000 });
+    });
+
+    test('does not measure when the screen is not focused', () => {
+      const measureInWindow = jest.fn();
+      MockNativeMethods.measureInWindow.mockImplementation(measureInWindow);
+      setMockCopilotState({ isActive: true, currentStep: null });
+      const onToggleButtonTop = jest.fn();
+
+      render(
+        <FiltersSelection
+          {...defaultProps}
+          screenFocused={false}
+          onToggleButtonTop={onToggleButtonTop}
+        />
+      );
+
+      expect(measureInWindow).not.toHaveBeenCalled();
+      expect(onToggleButtonTop).not.toHaveBeenCalled();
+    });
+
+    test('does not measure when copilot is not available', () => {
+      const measureInWindow = jest.fn();
+      MockNativeMethods.measureInWindow.mockImplementation(measureInWindow);
+      setMockCopilotState({ isActive: false });
+      const onToggleButtonTop = jest.fn();
+
+      render(
+        <FiltersSelection
+          {...defaultProps}
+          screenFocused={true}
+          onToggleButtonTop={onToggleButtonTop}
+        />
+      );
+
+      expect(measureInWindow).not.toHaveBeenCalled();
+      expect(onToggleButtonTop).not.toHaveBeenCalled();
+    });
+
+    test('ignores a measurement callback that resolves after the effect is cleaned up', () => {
+      const frames: FrameRequestCallback[] = [];
+      const rafSpy = jest
+        .spyOn(global, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          frames.push(cb);
+          return frames.length;
+        });
+      const cafSpy = jest.spyOn(global, 'cancelAnimationFrame').mockImplementation(() => {});
+      MockNativeMethods.measureInWindow.mockImplementation(
+        (cb: (x: number, y: number, width: number, height: number) => void) => {
+          cb(0, 42, 100, 50);
+        }
+      );
+      setMockCopilotState({ isActive: true, currentStep: null });
+      const onToggleButtonTop = jest.fn();
+
+      const { rerender } = render(
+        <FiltersSelection
+          {...defaultProps}
+          screenFocused={true}
+          onToggleButtonTop={onToggleButtonTop}
+        />
+      );
+
+      const staleFrame = frames[0]!;
+
+      rerender(
+        <FiltersSelection {...defaultProps} screenFocused={true} onToggleButtonTop={() => {}} />
+      );
+
+      staleFrame(0);
+
+      expect(onToggleButtonTop).not.toHaveBeenCalled();
+
+      rafSpy.mockRestore();
+      cafSpy.mockRestore();
+    });
+  });
+
   describe('In Tutorial Mode', () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -167,7 +316,29 @@ describe('FiltersSelection Component', () => {
         expect(mockEvents.on).toHaveBeenCalledWith('stop', expect.any(Function));
       });
 
-      // Simulate timer to check demo behavior
+      jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL);
+      expect(mockSetAddingAFilter).toHaveBeenCalled();
+    });
+
+    test('restarts the demo interval when a duplicate stepChange arrives on the same step', async () => {
+      const mockEvents = getMockCopilotEvents();
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: TUTORIAL_STEPS.Search.order, name: 'Search', text: 'Search step' },
+      });
+
+      render(<FiltersSelection {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockEvents.on).toHaveBeenCalledWith('stepChange', expect.any(Function));
+      });
+
+      triggerStepChangeEvent({
+        order: TUTORIAL_STEPS.Search.order,
+        name: 'Search',
+        text: 'Search step',
+      });
+
       jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL);
       expect(mockSetAddingAFilter).toHaveBeenCalled();
     });

--- a/tests/unit/components/organisms/VerticalBottomButtons.test.tsx
+++ b/tests/unit/components/organisms/VerticalBottomButtons.test.tsx
@@ -6,10 +6,21 @@ import {
   getMockCopilotEvents,
   resetMockCopilot,
   setMockCopilotState,
+  triggerStepChangeEvent,
 } from '@mocks/deps/react-native-copilot-mock';
 import { mockUseReducedMotion } from '@mocks/hooks/useReducedMotion-mock';
 import { TUTORIAL_DEMO_INTERVAL } from '@utils/Constants';
 import { DefaultPersonsProvider } from '@context/DefaultPersonsContext';
+import {
+  createEmptyScrapedRecipe,
+  mockScrapeRecipeAuthenticated,
+  mockScrapeRecipeAuthenticatedError,
+  mockScrapeRecipeAuthenticatedSuccess,
+  mockScrapeRecipeFromHtmlError,
+  mockScrapeRecipeFromHtmlSuccess,
+} from '@mocks/modules/recipe-scraper-mock';
+import { mockFetchHtmlSuccess } from '@mocks/deps/fetch-mock';
+import { pickImage } from '@utils/ImagePicker';
 
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 
@@ -26,13 +37,21 @@ jest.mock(
   () => require('@mocks/modules/recipe-scraper-mock').recipeScraperMock
 );
 
+jest.mock('react-i18next', () => require('@mocks/utils/i18n-mock').i18nMock());
+
 function renderWithProvider(component: React.ReactElement) {
   return render(<DefaultPersonsProvider>{component}</DefaultPersonsProvider>);
+}
+
+function openUrlDialog(getByTestId: (id: string) => any) {
+  fireEvent.press(getByTestId('ExpandButton'));
+  fireEvent.press(getByTestId('UrlButton'));
 }
 
 describe('VerticalBottomButtons Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFetchHtmlSuccess();
   });
 
   test('renders expand button in collapsed state', () => {
@@ -121,6 +140,18 @@ describe('VerticalBottomButtons Component', () => {
     });
   });
 
+  test('does not navigate when the gallery selection is cancelled', async () => {
+    (pickImage as jest.Mock).mockResolvedValueOnce('');
+    const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+    fireEvent.press(getByTestId('ExpandButton'));
+    fireEvent.press(getByTestId('GalleryButton'));
+
+    await waitFor(() => expect(pickImage).toHaveBeenCalled());
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   test('handles state transitions correctly', () => {
     const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
 
@@ -140,6 +171,188 @@ describe('VerticalBottomButtons Component', () => {
     expect(queryByTestId('RecipeEdit')).toBeNull();
     expect(queryByTestId('GalleryButton')).toBeNull();
     expect(queryByTestId('CameraButton')).toBeNull();
+  });
+
+  describe('URL import flow', () => {
+    test('opens the URL dialog when the URL button is pressed', () => {
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      openUrlDialog(getByTestId);
+
+      expect(getByTestId('VerticalBottomButtons::UrlDialog::Title')).toBeTruthy();
+    });
+
+    test('closes the URL dialog and clears the error when cancel is pressed', () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      openUrlDialog(getByTestId);
+      fireEvent.press(getByTestId('VerticalBottomButtons::UrlDialog::CancelButton'));
+
+      expect(queryByTestId('VerticalBottomButtons::UrlDialog::Title')).toBeNull();
+    });
+
+    test('navigates to scrape results and closes the dialog on successful submit', async () => {
+      mockScrapeRecipeFromHtmlSuccess(createEmptyScrapedRecipe({ title: 'Pasta' }));
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      openUrlDialog(getByTestId);
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::UrlDialog::Input::CustomTextInput'),
+        'https://example.com/recipe'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::UrlDialog::SubmitButton'));
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          'RecipeAddScrape',
+          expect.objectContaining({ sourceUrl: 'https://example.com/recipe' })
+        )
+      );
+      expect(queryByTestId('VerticalBottomButtons::UrlDialog::Title')).toBeNull();
+    });
+
+    test('keeps the URL dialog open and shows an error when scraping fails', async () => {
+      mockScrapeRecipeFromHtmlError('No recipe found', 'NoRecipeFoundError');
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      openUrlDialog(getByTestId);
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::UrlDialog::Input::CustomTextInput'),
+        'https://example.com/recipe'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::UrlDialog::SubmitButton'));
+
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::UrlDialog::HelperText')).toHaveTextContent(
+          'urlDialog.errorNoRecipeFound'
+        )
+      );
+      expect(getByTestId('VerticalBottomButtons::UrlDialog::Title')).toBeTruthy();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    test('opens the authentication dialog and hides the URL dialog when scraping requires auth', async () => {
+      mockScrapeRecipeFromHtmlError('Login required', 'AuthenticationRequired', 'quitoque.fr');
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      openUrlDialog(getByTestId);
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::UrlDialog::Input::CustomTextInput'),
+        'https://quitoque.fr/recipe'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::UrlDialog::SubmitButton'));
+
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeTruthy()
+      );
+      expect(queryByTestId('VerticalBottomButtons::UrlDialog::Title')).toBeNull();
+    });
+  });
+
+  describe('Authentication flow', () => {
+    function triggerAuthRequired(getByTestId: (id: string) => any) {
+      mockScrapeRecipeFromHtmlError('Login required', 'AuthenticationRequired', 'quitoque.fr');
+      openUrlDialog(getByTestId);
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::UrlDialog::Input::CustomTextInput'),
+        'https://quitoque.fr/recipe'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::UrlDialog::SubmitButton'));
+    }
+
+    test('navigates to scrape results and closes the dialog on successful credentials', async () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      triggerAuthRequired(getByTestId);
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeTruthy()
+      );
+
+      mockScrapeRecipeAuthenticatedSuccess(createEmptyScrapedRecipe({ title: 'Secured Recipe' }));
+      fireEvent.changeText(getByTestId('VerticalBottomButtons::AuthDialog::UsernameInput'), 'chef');
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::AuthDialog::PasswordInput'),
+        'secret'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::AuthDialog::SubmitButton'));
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          'RecipeAddScrape',
+          expect.objectContaining({ sourceUrl: 'https://quitoque.fr/recipe' })
+        )
+      );
+      expect(queryByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeNull();
+    });
+
+    test('keeps the auth dialog open and shows an error on failed credentials', async () => {
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      triggerAuthRequired(getByTestId);
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeTruthy()
+      );
+
+      mockScrapeRecipeAuthenticatedError('Invalid credentials', 'AuthenticationFailed');
+      fireEvent.changeText(getByTestId('VerticalBottomButtons::AuthDialog::UsernameInput'), 'chef');
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::AuthDialog::PasswordInput'),
+        'wrong'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::AuthDialog::SubmitButton'));
+
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::AuthDialog::HelperText')).toHaveTextContent(
+          'urlDialog.errorAuthFailed'
+        )
+      );
+      expect(getByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeTruthy();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    test('closes the auth dialog and clears auth state when cancel is pressed', async () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      triggerAuthRequired(getByTestId);
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeTruthy()
+      );
+
+      fireEvent.press(getByTestId('VerticalBottomButtons::AuthDialog::CancelButton'));
+
+      expect(queryByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeNull();
+    });
+
+    test('ignores auth submit once authRequired has already been cleared', async () => {
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      triggerAuthRequired(getByTestId);
+      await waitFor(() =>
+        expect(getByTestId('VerticalBottomButtons::AuthDialog::Title')).toBeTruthy()
+      );
+
+      mockScrapeRecipeFromHtmlSuccess(createEmptyScrapedRecipe({ title: 'Pasta' }));
+      fireEvent.press(getByTestId('ExpandButton'));
+      fireEvent.press(getByTestId('UrlButton'));
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::UrlDialog::Input::CustomTextInput'),
+        'https://example.com/recipe'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::UrlDialog::SubmitButton'));
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+      mockNavigate.mockClear();
+
+      fireEvent.changeText(getByTestId('VerticalBottomButtons::AuthDialog::UsernameInput'), 'chef');
+      fireEvent.changeText(
+        getByTestId('VerticalBottomButtons::AuthDialog::PasswordInput'),
+        'secret'
+      );
+      fireEvent.press(getByTestId('VerticalBottomButtons::AuthDialog::SubmitButton'));
+
+      expect(mockScrapeRecipeAuthenticated).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('In Tutorial Mode', () => {
@@ -168,6 +381,60 @@ describe('VerticalBottomButtons Component', () => {
       });
 
       expect(getByTestId('ReduceButton')).toBeTruthy();
+    });
+
+    test('does not start the demo on mount when the current step does not match Home', () => {
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: 2, name: 'Search', text: 'Search step' },
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      act(() => {
+        jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL);
+      });
+
+      expect(getByTestId('ExpandButton')).toBeTruthy();
+      expect(queryByTestId('ReduceButton')).toBeNull();
+    });
+
+    test('restarts the demo interval when a duplicate stepChange arrives on the same step', () => {
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: 1, name: 'Home', text: 'Home step' },
+      });
+
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      triggerStepChangeEvent({ order: 1, name: 'Home', text: 'Home step' });
+
+      act(() => {
+        jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL);
+      });
+
+      expect(getByTestId('ReduceButton')).toBeTruthy();
+    });
+
+    test('stops the demo and collapses the FAB when stepChange moves to a different step', () => {
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: 1, name: 'Home', text: 'Home step' },
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      act(() => {
+        jest.advanceTimersByTime(TUTORIAL_DEMO_INTERVAL);
+      });
+      expect(getByTestId('ReduceButton')).toBeTruthy();
+
+      act(() => {
+        triggerStepChangeEvent({ order: 2, name: 'Search', text: 'Search step' });
+      });
+
+      expect(getByTestId('ExpandButton')).toBeTruthy();
+      expect(queryByTestId('ReduceButton')).toBeNull();
     });
 
     test('does not auto-run the demo when reduced motion is enabled', () => {

--- a/tests/unit/hooks/useMenu.test.tsx
+++ b/tests/unit/hooks/useMenu.test.tsx
@@ -1,0 +1,179 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useMenu } from '@hooks/useMenu';
+import RecipeDatabase from '@utils/RecipeDatabase';
+import { ingredientType, RecipeDraft } from '@customTypes/DatabaseElementTypes';
+
+const catalogIngredients = [
+  { name: 'Pasta', unit: 'g', type: ingredientType.cereal, season: [] },
+  { name: 'Tomato', unit: 'g', type: ingredientType.vegetable, season: [] },
+];
+
+const pastaRecipe: RecipeDraft = {
+  title: 'Pasta Primavera',
+  image_Source: '',
+  description: '',
+  tags: [],
+  persons: 2,
+  ingredients: [
+    { name: 'Pasta', unit: 'g', quantity: '200', type: ingredientType.cereal, season: [] },
+    { name: 'Tomato', unit: 'g', quantity: '150', type: ingredientType.vegetable, season: [] },
+  ],
+  season: [],
+  preparation: [],
+  time: 20,
+};
+
+describe('useMenu', () => {
+  let database: RecipeDatabase;
+
+  beforeEach(async () => {
+    database = RecipeDatabase.getInstance();
+    await database.init();
+    await database.addMultipleIngredients(catalogIngredients);
+    await database.addRecipe(pastaRecipe);
+  });
+
+  afterEach(async () => {
+    await database.closeAndReset();
+  });
+
+  function addedRecipe() {
+    return database.get_recipes()[0]!;
+  }
+
+  test('menu starts empty', () => {
+    const { result } = renderHook(() => useMenu());
+    expect(result.current.menu).toEqual([]);
+  });
+
+  test('addRecipeToMenu inserts a menu entry for the recipe', async () => {
+    const { result } = renderHook(() => useMenu());
+
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+    });
+
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(1);
+    });
+    expect(result.current.menu[0]!.recipeId).toBe(addedRecipe().id);
+  });
+
+  test('isRecipeInMenu tracks presence before and after adding', async () => {
+    const { result } = renderHook(() => useMenu());
+    expect(result.current.isRecipeInMenu(addedRecipe().id)).toBe(false);
+
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+    });
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(1);
+    });
+
+    expect(result.current.isRecipeInMenu(addedRecipe().id)).toBe(true);
+  });
+
+  test('toggleMenuItemCooked flips the cooked flag on the menu item', async () => {
+    const { result } = renderHook(() => useMenu());
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+    });
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(1);
+    });
+
+    const menuId = result.current.menu[0]!.id!;
+    await act(async () => {
+      await result.current.toggleMenuItemCooked(menuId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.menu[0]!.isCooked).toBe(true);
+    });
+  });
+
+  test('removeFromMenu deletes the menu entry', async () => {
+    const { result } = renderHook(() => useMenu());
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+    });
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(1);
+    });
+
+    const menuId = result.current.menu[0]!.id!;
+    await act(async () => {
+      await result.current.removeFromMenu(menuId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(0);
+    });
+  });
+
+  test('togglePurchased sets a false ingredient to purchased then back to unpurchased', async () => {
+    const { result } = renderHook(() => useMenu());
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+    });
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await result.current.togglePurchased('Tomato');
+    });
+    await waitFor(() => {
+      expect(database.get_purchasedIngredients().get('Tomato')).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.togglePurchased('Tomato');
+    });
+    await waitFor(() => {
+      expect(database.get_purchasedIngredients().get('Tomato')).toBe(false);
+    });
+  });
+
+  test('clearPurchased resets every purchased flag', async () => {
+    const { result } = renderHook(() => useMenu());
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+      await result.current.togglePurchased('Tomato');
+      await result.current.togglePurchased('Pasta');
+    });
+    await waitFor(() => {
+      expect(database.get_purchasedIngredients().get('Tomato')).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.clearPurchased();
+    });
+
+    await waitFor(() => {
+      const purchased = database.get_purchasedIngredients();
+      expect(purchased.get('Tomato')).toBeFalsy();
+      expect(purchased.get('Pasta')).toBeFalsy();
+    });
+  });
+
+  test('clearMenu empties the menu and clears purchased state', async () => {
+    const { result } = renderHook(() => useMenu());
+    await act(async () => {
+      await result.current.addRecipeToMenu(addedRecipe());
+      await result.current.togglePurchased('Tomato');
+    });
+    await waitFor(() => {
+      expect(database.get_purchasedIngredients().get('Tomato')).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.clearMenu();
+    });
+
+    await waitFor(() => {
+      expect(result.current.menu).toHaveLength(0);
+    });
+    expect(database.get_purchasedIngredients().get('Tomato')).toBeFalsy();
+  });
+});

--- a/tests/unit/hooks/useRecipes.test.tsx
+++ b/tests/unit/hooks/useRecipes.test.tsx
@@ -1,0 +1,239 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useRecipes } from '@hooks/useRecipes';
+import RecipeDatabase from '@utils/RecipeDatabase';
+import { deleteFile, isTemporaryImageUri } from '@utils/FileGestion';
+import { ingredientType, RecipeDraft } from '@customTypes/DatabaseElementTypes';
+
+jest.mock('@utils/FileGestion', () => require('@mocks/utils/FileGestion-mock').fileGestionMock());
+
+const deleteFileMock = deleteFile as jest.Mock;
+const isTemporaryImageUriMock = isTemporaryImageUri as jest.Mock;
+
+const catalogIngredients = [
+  { name: 'Pasta', unit: 'g', type: ingredientType.cereal, season: [] },
+  { name: 'Tomato', unit: 'g', type: ingredientType.vegetable, season: [] },
+];
+
+function makeRecipe(overrides: Partial<RecipeDraft> = {}): RecipeDraft {
+  return {
+    title: 'Pasta Primavera',
+    image_Source: '',
+    description: '',
+    tags: [],
+    persons: 2,
+    ingredients: [
+      { name: 'Pasta', unit: 'g', quantity: '200', type: ingredientType.cereal, season: [] },
+      { name: 'Tomato', unit: 'g', quantity: '150', type: ingredientType.vegetable, season: [] },
+    ],
+    season: [],
+    preparation: [],
+    time: 20,
+    ...overrides,
+  };
+}
+
+describe('useRecipes', () => {
+  let database: RecipeDatabase;
+
+  beforeEach(async () => {
+    database = RecipeDatabase.getInstance();
+    await database.init();
+    await database.addMultipleIngredients(catalogIngredients);
+  });
+
+  afterEach(async () => {
+    await database.closeAndReset();
+  });
+
+  test('exposes the reactive recipes array and an undefined scaling progress', () => {
+    const { result } = renderHook(() => useRecipes());
+    expect(result.current.recipes).toEqual([]);
+    expect(result.current.scalingProgress).toBeUndefined();
+  });
+
+  test('addRecipe inserts a recipe into the database', async () => {
+    const { result } = renderHook(() => useRecipes());
+
+    await act(async () => {
+      await result.current.addRecipe(makeRecipe({ title: 'Added' }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.recipes.map(r => r.title)).toContain('Added');
+    });
+  });
+
+  test('addMultipleRecipes inserts every recipe', async () => {
+    const { result } = renderHook(() => useRecipes());
+
+    await act(async () => {
+      await result.current.addMultipleRecipes([
+        makeRecipe({ title: 'First' }),
+        makeRecipe({ title: 'Second' }),
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.recipes).toHaveLength(2);
+    });
+    const titles = result.current.recipes.map(r => r.title);
+    expect(titles).toEqual(expect.arrayContaining(['First', 'Second']));
+  });
+
+  test('deleteRecipe removes the recipe', async () => {
+    await database.addRecipe(makeRecipe());
+    const { result } = renderHook(() => useRecipes());
+
+    await act(async () => {
+      await result.current.deleteRecipe(database.get_recipes()[0]!);
+    });
+
+    await waitFor(() => {
+      expect(result.current.recipes).toHaveLength(0);
+    });
+  });
+
+  test('findSimilarRecipes returns recipes matching the given draft', async () => {
+    await database.addRecipe(makeRecipe());
+    const { result } = renderHook(() => useRecipes());
+
+    const similar = result.current.findSimilarRecipes(makeRecipe());
+    expect(similar.map(r => r.title)).toContain('Pasta Primavera');
+  });
+
+  describe('editRecipe', () => {
+    test('updates the recipe fields', async () => {
+      await database.addRecipe(makeRecipe({ title: 'Before' }));
+      const stored = database.get_recipes()[0]!;
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.editRecipe({ ...makeRecipe({ title: 'After' }), id: stored.id });
+      });
+
+      await waitFor(() => {
+        expect(result.current.recipes[0]!.title).toBe('After');
+      });
+    });
+
+    test('deletes the previous image when it changed and is not temporary', async () => {
+      await database.addRecipe(makeRecipe({ image_Source: 'perm://old.jpg' }));
+      const stored = database.get_recipes()[0]!;
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.editRecipe({
+          ...makeRecipe({ image_Source: 'perm://new.jpg' }),
+          id: stored.id,
+        });
+      });
+
+      expect(deleteFileMock).toHaveBeenCalledWith('perm://old.jpg');
+    });
+
+    test('keeps the old image when the image is unchanged', async () => {
+      await database.addRecipe(makeRecipe({ image_Source: 'perm://same.jpg' }));
+      const stored = database.get_recipes()[0]!;
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.editRecipe({
+          ...makeRecipe({ image_Source: 'perm://same.jpg' }),
+          id: stored.id,
+        });
+      });
+
+      expect(deleteFileMock).not.toHaveBeenCalled();
+    });
+
+    test('deletes no image when the edited recipe is absent from the current list', async () => {
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.editRecipe({
+          ...makeRecipe({ image_Source: 'perm://new.jpg' }),
+          id: 9999,
+        });
+      });
+
+      expect(deleteFileMock).not.toHaveBeenCalled();
+    });
+
+    test('keeps the old image when the previous image is temporary', async () => {
+      await database.addRecipe(makeRecipe({ image_Source: 'perm://old.jpg' }));
+      const stored = database.get_recipes()[0]!;
+      const { result } = renderHook(() => useRecipes());
+
+      isTemporaryImageUriMock.mockReturnValueOnce(true);
+      await act(async () => {
+        await result.current.editRecipe({
+          ...makeRecipe({ image_Source: '' }),
+          id: stored.id,
+        });
+      });
+
+      expect(deleteFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scaleAllRecipesForNewDefaultPersons', () => {
+    test('rescales recipes whose serving count differs from the new default', async () => {
+      await database.addRecipe(makeRecipe({ persons: 2 }));
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.scaleAllRecipesForNewDefaultPersons(4);
+      });
+
+      await waitFor(() => {
+        expect(result.current.recipes[0]!.persons).toBe(4);
+      });
+      expect(result.current.scalingProgress).toBeUndefined();
+    });
+
+    test('rescales every recipe whose serving count differs from the new default', async () => {
+      await database.addMultipleRecipes([
+        makeRecipe({ title: 'A', persons: 2 }),
+        makeRecipe({ title: 'B', persons: 3 }),
+      ]);
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.scaleAllRecipesForNewDefaultPersons(5);
+      });
+
+      await waitFor(() => {
+        expect(result.current.recipes.every(r => r.persons === 5)).toBe(true);
+      });
+      expect(result.current.scalingProgress).toBeUndefined();
+    });
+
+    test('does nothing when no recipe needs rescaling', async () => {
+      await database.addRecipe(makeRecipe({ persons: 4 }));
+      const { result } = renderHook(() => useRecipes());
+
+      const before = result.current.recipes[0];
+      await act(async () => {
+        await result.current.scaleAllRecipesForNewDefaultPersons(4);
+      });
+
+      expect(result.current.recipes[0]).toBe(before);
+      expect(result.current.scalingProgress).toBeUndefined();
+    });
+
+    test('swallows a scaling failure and resets progress', async () => {
+      await database.addRecipe(makeRecipe({ persons: 2 }));
+      const spy = jest
+        .spyOn(database, 'scaleAndUpdateRecipe')
+        .mockRejectedValue(new Error('scale failed'));
+      const { result } = renderHook(() => useRecipes());
+
+      await act(async () => {
+        await result.current.scaleAllRecipesForNewDefaultPersons(6);
+      });
+
+      expect(result.current.scalingProgress).toBeUndefined();
+      spy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/hooks/useShopping.test.tsx
+++ b/tests/unit/hooks/useShopping.test.tsx
@@ -1,0 +1,101 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useShopping } from '@hooks/useShopping';
+import RecipeDatabase from '@utils/RecipeDatabase';
+import { ingredientType, RecipeDraft } from '@customTypes/DatabaseElementTypes';
+
+const catalogIngredients = [
+  { name: 'Pasta', unit: 'g', type: ingredientType.cereal, season: [] },
+  { name: 'Tomato', unit: 'g', type: ingredientType.vegetable, season: [] },
+];
+
+const pastaRecipe: RecipeDraft = {
+  title: 'Pasta Primavera',
+  image_Source: '',
+  description: '',
+  tags: [],
+  persons: 2,
+  ingredients: [
+    { name: 'Pasta', unit: 'g', quantity: '200', type: ingredientType.cereal, season: [] },
+    { name: 'Tomato', unit: 'g', quantity: '150', type: ingredientType.vegetable, season: [] },
+  ],
+  season: [],
+  preparation: [],
+  time: 20,
+};
+
+describe('useShopping', () => {
+  let database: RecipeDatabase;
+
+  beforeEach(async () => {
+    database = RecipeDatabase.getInstance();
+    await database.init();
+    await database.addMultipleIngredients(catalogIngredients);
+    await database.addRecipe(pastaRecipe);
+  });
+
+  afterEach(async () => {
+    await database.closeAndReset();
+  });
+
+  function addedRecipe() {
+    return database.get_recipes()[0]!;
+  }
+
+  test('returns an empty shopping list when the menu is empty', () => {
+    const { result } = renderHook(() => useShopping());
+    expect(result.current.shopping).toEqual([]);
+  });
+
+  test('derives one aggregated item per ingredient of the menu recipes', async () => {
+    const { result } = renderHook(() => useShopping());
+
+    await act(async () => {
+      await database.addRecipeToMenu(addedRecipe());
+    });
+
+    await waitFor(() => {
+      expect(result.current.shopping).toHaveLength(2);
+    });
+    const names = result.current.shopping.map(item => item.name);
+    expect(names).toEqual(expect.arrayContaining(['Pasta', 'Tomato']));
+  });
+
+  test('reflects purchased state on the derived item', async () => {
+    const { result } = renderHook(() => useShopping());
+
+    await act(async () => {
+      await database.addRecipeToMenu(addedRecipe());
+    });
+    await waitFor(() => {
+      expect(result.current.shopping).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await database.setPurchased('Tomato', true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.shopping.find(item => item.name === 'Tomato')?.purchased).toBe(true);
+    });
+  });
+
+  test('excludes ingredients of a recipe once it is marked cooked', async () => {
+    const { result } = renderHook(() => useShopping());
+
+    await act(async () => {
+      await database.addRecipeToMenu(addedRecipe());
+    });
+    await waitFor(() => {
+      expect(result.current.shopping).toHaveLength(2);
+    });
+
+    const menuId = database.get_menu()[0]!.id!;
+    await act(async () => {
+      await database.toggleMenuItemCooked(menuId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.shopping).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/providers/BaseRecipeProvider.test.ts
+++ b/tests/unit/providers/BaseRecipeProvider.test.ts
@@ -157,6 +157,194 @@ describe('BaseRecipeProvider', () => {
     });
   });
 
+  describe('canHandleUrl', () => {
+    it('returns false by default', () => {
+      expect(provider.canHandleUrl('https://www.test-provider.com/recipe1')).toBe(false);
+    });
+  });
+
+  describe('multi-batch category scanning', () => {
+    it('delays between batches and scans all categories when there are more than the concurrency limit', async () => {
+      jest.useRealTimers();
+      jest.spyOn(provider as any, 'delay').mockResolvedValue(undefined);
+
+      provider.setTestCategoryUrls([
+        'https://www.test-provider.com/cat1',
+        'https://www.test-provider.com/cat2',
+        'https://www.test-provider.com/cat3',
+        'https://www.test-provider.com/cat4',
+      ]);
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls()) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress).toMatchObject({
+        phase: 'complete',
+        isComplete: true,
+        totalCategories: 4,
+        categoriesScanned: 4,
+      });
+      expect((provider as any).delay).toHaveBeenCalled();
+    });
+  });
+
+  describe('failed category pages', () => {
+    it('marks the page empty and logs when fetch rejects with an Error', async () => {
+      jest.useRealTimers();
+      jest.spyOn(provider as any, 'delay').mockResolvedValue(undefined);
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls()) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress?.recipesFound).toBe(2);
+    });
+
+    it('marks the page empty and logs when fetch rejects with a non-Error value', async () => {
+      jest.useRealTimers();
+      jest.spyOn(provider as any, 'delay').mockResolvedValue(undefined);
+      mockFetch.mockRejectedValueOnce('boom');
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls()) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress?.recipesFound).toBe(2);
+    });
+  });
+
+  describe('empty category pages', () => {
+    it('adds a page with zero links to emptyPages instead of recipes', async () => {
+      jest.useRealTimers();
+
+      provider.setTestCategoryUrls(['https://www.test-provider.com/cat1']);
+      provider.setTestRecipeLinks([]);
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls()) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress?.recipesFound).toBe(0);
+    });
+  });
+
+  describe('retryEmptyPages', () => {
+    it('recovers some empty pages and warns about pages still empty after exhausting retries', async () => {
+      jest.useRealTimers();
+      jest.spyOn(provider as any, 'delay').mockResolvedValue(undefined);
+
+      const cat1 = 'https://www.test-provider.com/cat1';
+      const cat2 = 'https://www.test-provider.com/cat2';
+      const cat3 = 'https://www.test-provider.com/cat3';
+      provider.setTestCategoryUrls([cat1, cat2, cat3]);
+
+      const cat1Responses = ['empty', 'links'];
+      const cat2Responses = ['empty', 'empty', 'empty', 'empty'];
+      const responsesByUrl: Record<string, string[]> = {
+        [cat1]: cat1Responses,
+        [cat2]: cat2Responses,
+        [cat3]: ['links'],
+      };
+
+      mockFetch.mockImplementation((url: string) => {
+        const queue = responsesByUrl[url]!;
+        const html = queue.length > 1 ? queue.shift()! : queue[0]!;
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(html) });
+      });
+
+      (provider as any).extractRecipeLinksFromHtml = (html: string) =>
+        html === 'links'
+          ? [{ url: `https://www.test-provider.com/recipe-${html}-${Math.random()}` }]
+          : [];
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls()) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress?.phase).toBe('complete');
+      expect(lastProgress?.recipesFound).toBe(2);
+    });
+
+    it('stops retrying when the abort signal fires mid-retry', async () => {
+      jest.useRealTimers();
+
+      const controller = new AbortController();
+      const cat1 = 'https://www.test-provider.com/cat1';
+      const cat2 = 'https://www.test-provider.com/cat2';
+      provider.setTestCategoryUrls([cat1, cat2]);
+
+      const responsesByUrl: Record<string, string> = { [cat1]: 'empty', [cat2]: 'links' };
+      mockFetch.mockImplementation((url: string) =>
+        Promise.resolve({ ok: true, text: () => Promise.resolve(responsesByUrl[url]) })
+      );
+      (provider as any).extractRecipeLinksFromHtml = (html: string) =>
+        html === 'links' ? [{ url: 'https://www.test-provider.com/recipeX' }] : [];
+
+      jest.spyOn(provider as any, 'delay').mockImplementation(async () => {
+        controller.abort();
+      });
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls({ signal: controller.signal })) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress?.phase).toBe('complete');
+    });
+
+    it('stops mid-batch inside a retry attempt when the abort signal fires between retried pages', async () => {
+      jest.useRealTimers();
+
+      const controller = new AbortController();
+      const cat1 = 'https://www.test-provider.com/cat1';
+      const cat2 = 'https://www.test-provider.com/cat2';
+      const cat3 = 'https://www.test-provider.com/cat3';
+      provider.setTestCategoryUrls([cat1, cat2, cat3]);
+
+      const responsesByUrl: Record<string, string> = {
+        [cat1]: 'empty',
+        [cat2]: 'empty',
+        [cat3]: 'links',
+      };
+      mockFetch.mockImplementation((url: string) =>
+        Promise.resolve({ ok: true, text: () => Promise.resolve(responsesByUrl[url]) })
+      );
+      (provider as any).extractRecipeLinksFromHtml = (html: string) =>
+        html === 'links' ? [{ url: 'https://www.test-provider.com/recipeX' }] : [];
+
+      let delayCalls = 0;
+      jest.spyOn(provider as any, 'delay').mockImplementation(async () => {
+        delayCalls++;
+        if (delayCalls === 2) {
+          controller.abort();
+        }
+      });
+
+      let lastProgress;
+      for await (const progress of provider.discoverRecipeUrls({ signal: controller.signal })) {
+        lastProgress = progress;
+      }
+
+      expect(lastProgress?.phase).toBe('complete');
+      expect(lastProgress?.recipesFound).toBe(1);
+    });
+  });
+
+  describe('delay', () => {
+    it('resolves to undefined after the given time', async () => {
+      jest.useRealTimers();
+
+      await expect((provider as any).delay(5)).resolves.toBeUndefined();
+    });
+  });
+
   describe('fetchHtml', () => {
     it('returns HTML content on success', async () => {
       const testHtml = '<html><body>Test</body></html>';

--- a/tests/unit/screens/recipe/RecipeAddManual.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddManual.test.tsx
@@ -16,6 +16,7 @@ import {
   checkTags,
   checkTime,
   checkTitle,
+  mockNavigation,
   renderRoute,
   setupDb,
   teardownDb,
@@ -197,6 +198,65 @@ describe('RecipeAddManual', () => {
       checkPersons(mockRouteAddManually, getByTestId, queryByTestId, newPersons);
       checkTime(mockRouteAddManually, getByTestId, queryByTestId, newTime);
       checkPreparation(mockRouteAddManually, getByTestId, queryByTestId);
+    });
+  });
+
+  describe('navigation callbacks', () => {
+    test('pressing the back button navigates back', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddManually);
+
+      fireEvent.press(getByTestId('Recipe::AppBar::BackButton'));
+
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+    });
+
+    test('a successful save confirms addAnyway then navigates back', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddManually);
+
+      fireEvent.press(
+        getByTestId('RecipeTitle::SetTextToEdit'),
+        'Wholly Unique Manual Save Flow Recipe'
+      );
+      fireEvent.press(getByTestId('RecipePersons::SetTextToEdit'), '4');
+      fireEvent.press(getByTestId('RecipeTime::SetTextToEdit'), '30');
+
+      fireEvent.press(getByTestId('RecipeImage::OpenModal'));
+      await waitFor(() => expect(getByTestId('ModalImageSelect')).toBeTruthy());
+      fireEvent.press(getByTestId('ModalImageSelect::Select'));
+      await waitFor(() => {
+        expect(getByTestId('RecipeImage::ImgUri').props.children).toBe('/path/to/cropped/img');
+      });
+
+      fireEvent.press(getByTestId('RecipeIngredients::AddButton::RoundButton::OnPressFunction'));
+      await waitFor(() => expect(getByTestId('RecipeIngredients::0::Row')).toBeTruthy());
+      fireEvent.press(getByTestId('RecipeIngredients::0::OnIngredientChange'), '100@@g--Spaghetti');
+      await waitFor(() => {
+        expect(getByTestId('RecipeIngredients::0::NameInput::Value').props.children).toBe(
+          'Spaghetti'
+        );
+      });
+
+      fireEvent.press(getByTestId('RecipePreparation::AddButton::RoundButton::OnPressFunction'));
+      await waitFor(() =>
+        expect(getByTestId('RecipePreparation::EditableStep::0::Step')).toBeTruthy()
+      );
+      fireEvent.changeText(
+        getByTestId('RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput'),
+        'Cook pasta until al dente'
+      );
+
+      fireEvent.press(getByTestId('Recipe::BottomActionButton'));
+
+      await waitFor(() => {
+        expect(getByTestId('Recipe::Alert::IsVisible').props.children).toBe(true);
+      });
+      expect(getByTestId('Recipe::Alert::Title').props.children).toBe('addAnyway');
+
+      fireEvent.press(getByTestId('Recipe::Alert::OnConfirm'));
+
+      await waitFor(() => {
+        expect(mockNavigation.goBack).toHaveBeenCalled();
+      });
     });
   });
 

--- a/tests/unit/screens/recipe/RecipeAddOcr.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddOcr.test.tsx
@@ -15,6 +15,7 @@ import {
   checkTime,
   checkTitle,
   defaultUri,
+  mockNavigation,
   renderRoute,
   setupDb,
   teardownDb,
@@ -203,6 +204,72 @@ describe('RecipeAddOcr', () => {
       fireEvent.press(getByTestId('Recipe::OcrSnackbar::Dismiss'));
 
       await waitFor(() => expect(queryByTestId('Recipe::OcrSnackbar')).toBeNull());
+    });
+  });
+
+  test('non-empty route imgUri seeds the shared image gallery', async () => {
+    const routeWithGalleryImage: AddFromPicProp = {
+      mode: 'addFromPic',
+      imgUri: '/pre-existing/gallery.jpg',
+    };
+    const { getByTestId } = await renderRoute(routeWithGalleryImage);
+
+    fireEvent.press(getByTestId('RecipeImage::OpenModal'));
+
+    await waitFor(() => {
+      expect(getByTestId('ModalImageSelect::Images').props.children).toBe(
+        JSON.stringify(['/pre-existing/gallery.jpg'])
+      );
+    });
+  });
+
+  describe('navigation callbacks', () => {
+    test('pressing the back button navigates back', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddOCR);
+
+      fireEvent.press(getByTestId('Recipe::AppBar::BackButton'));
+
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+    });
+
+    test('selecting an image for a non-image target runs OCR extraction and, on success, confirms addAnyway then navigates back', async () => {
+      const OCR = require('@utils/OCR');
+      (OCR.extractFieldFromImage as jest.Mock).mockResolvedValueOnce({
+        recipeImage: '/path/to/cropped/img',
+        recipeTitle: 'Wholly Unique OCR Save Flow Recipe',
+        recipePersons: 4,
+        recipeTime: 30,
+        recipePreparation: [{ title: 'Step 1', description: 'Cook pasta until al dente' }],
+        recipeIngredients: [{ name: 'Spaghetti', quantity: '100', unit: 'g' }],
+      });
+
+      const { getByTestId } = await renderRoute(mockRouteAddOCR);
+
+      fireEvent.press(getByTestId('RecipeTitle::OpenModal'));
+      await waitFor(() => expect(getByTestId('ModalImageSelect')).toBeTruthy());
+      fireEvent.press(getByTestId('ModalImageSelect::Select'));
+
+      await waitFor(() => {
+        expect(OCR.extractFieldFromImage).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(getByTestId('RecipeTitle::TextEditable').props.children).toBe(
+          'Wholly Unique OCR Save Flow Recipe'
+        );
+      });
+
+      fireEvent.press(getByTestId('Recipe::BottomActionButton'));
+
+      await waitFor(() => {
+        expect(getByTestId('Recipe::Alert::IsVisible').props.children).toBe(true);
+      });
+      expect(getByTestId('Recipe::Alert::Title').props.children).toBe('addAnyway');
+
+      fireEvent.press(getByTestId('Recipe::Alert::OnConfirm'));
+
+      await waitFor(() => {
+        expect(mockNavigation.goBack).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/tests/unit/screens/recipe/RecipeAddScrape.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddScrape.test.tsx
@@ -6,7 +6,7 @@ import { AddFromScrapeProp } from '@customTypes/RecipeNavigationTypes';
 import * as FileGestion from '@utils/FileGestion';
 import { RecipeFormScreen } from '@screens/recipe/RecipeFormScreen';
 
-import { renderRoute, setupDb, teardownDb } from './recipeTestHelpers';
+import { mockNavigation, renderRoute, setupDb, teardownDb } from './recipeTestHelpers';
 
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
@@ -107,6 +107,38 @@ describe('RecipeAddScrape', () => {
       );
 
       addRecipeSpy.mockRestore();
+    });
+
+    test('a successful add flow confirms addAnyway then navigates back', async () => {
+      const scrapedRoute: AddFromScrapeProp = {
+        mode: 'addFromScrape',
+        sourceUrl: 'https://example.com/navigate-back',
+        scrapedData: {
+          image_Source: 'navigate-back-test.jpg',
+          title: 'Wholly Unique Scrape Save Flow Recipe',
+          description: 'A test recipe',
+          persons: 4,
+          time: 30,
+          ingredients: [{ ...testIngredients[0], quantity: '100' }],
+          preparation: [{ title: 'Step 1', description: 'Test step' }],
+          tags: [],
+        },
+      };
+
+      const { getByTestId } = await renderRoute(scrapedRoute);
+
+      fireEvent.press(getByTestId('Recipe::BottomActionButton'));
+
+      await waitFor(() => {
+        expect(getByTestId('Recipe::Alert::IsVisible').props.children).toBe(true);
+      });
+      expect(getByTestId('Recipe::Alert::Title').props.children).toBe('addAnyway');
+
+      fireEvent.press(getByTestId('Recipe::Alert::OnConfirm'));
+
+      await waitFor(() => {
+        expect(mockNavigation.goBack).toHaveBeenCalled();
+      });
     });
 
     test('forwards the entered serving count as scaledFromServings to onSaveSuccess', async () => {
@@ -222,6 +254,31 @@ describe('RecipeAddScrape', () => {
       expect(getByTestId('Recipe::Alert::Content').props.children).toContain('add write failed');
 
       addRecipeSpy.mockRestore();
+    });
+  });
+
+  describe('navigation callbacks', () => {
+    test('pressing the back button navigates back', async () => {
+      const scrapedRoute: AddFromScrapeProp = {
+        mode: 'addFromScrape',
+        sourceUrl: 'https://example.com/back-button',
+        scrapedData: {
+          image_Source: 'back-button-test.jpg',
+          title: 'Unique Back Button Scrape Recipe',
+          description: 'A test recipe',
+          persons: 4,
+          time: 30,
+          ingredients: [{ ...testIngredients[0], quantity: '100' }],
+          preparation: [{ title: 'Step 1', description: 'Test step' }],
+          tags: [],
+        },
+      };
+
+      const { getByTestId } = await renderRoute(scrapedRoute);
+
+      fireEvent.press(getByTestId('Recipe::AppBar::BackButton'));
+
+      expect(mockNavigation.goBack).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/screens/recipe/defaults/buildDefaultsFromRecipe.test.ts
+++ b/tests/unit/screens/recipe/defaults/buildDefaultsFromRecipe.test.ts
@@ -1,0 +1,77 @@
+import { buildDefaultsFromRecipe } from '@screens/recipe/defaults/buildDefaultsFromRecipe';
+import {
+  ingredientType,
+  nutritionTableElement,
+  recipeTableElement,
+} from '@customTypes/DatabaseElementTypes';
+
+const nutrition: nutritionTableElement = {
+  energyKcal: 200,
+  energyKj: 837,
+  fat: 10,
+  saturatedFat: 3,
+  carbohydrates: 20,
+  sugars: 5,
+  fiber: 2,
+  protein: 8,
+  salt: 1,
+  portionWeight: 100,
+};
+
+const recipe: recipeTableElement = {
+  id: 7,
+  image_Source: 'file://tartiflette.jpg',
+  title: 'Tartiflette',
+  description: 'A cheesy dish',
+  tags: [{ id: 1, name: 'comfort' }],
+  persons: 6,
+  ingredients: [
+    {
+      id: 2,
+      name: 'Potato',
+      unit: 'g',
+      quantity: '800',
+      type: ingredientType.vegetable,
+      season: [],
+    },
+  ],
+  season: ['winter'],
+  preparation: [{ title: 'Step 1', description: 'Peel the potatoes' }],
+  time: 45,
+  nutrition,
+};
+
+describe('buildDefaultsFromRecipe', () => {
+  test('maps every recipe column onto its form field', () => {
+    expect(buildDefaultsFromRecipe(recipe)).toEqual({
+      recipeImage: 'file://tartiflette.jpg',
+      recipeTitle: 'Tartiflette',
+      recipeDescription: 'A cheesy dish',
+      recipeTags: recipe.tags,
+      recipePersons: 6,
+      recipeIngredients: recipe.ingredients,
+      recipePreparation: recipe.preparation,
+      recipeTime: 45,
+      recipeNutrition: nutrition,
+    });
+  });
+
+  test('passes tags, ingredients and preparation through by reference', () => {
+    const result = buildDefaultsFromRecipe(recipe);
+    expect(result.recipeTags).toBe(recipe.tags);
+    expect(result.recipeIngredients).toBe(recipe.ingredients);
+    expect(result.recipePreparation).toBe(recipe.preparation);
+  });
+
+  test('keeps nutrition undefined when the recipe has none', () => {
+    const withoutNutrition: recipeTableElement = { ...recipe, nutrition: undefined };
+    expect(buildDefaultsFromRecipe(withoutNutrition).recipeNutrition).toBeUndefined();
+  });
+
+  test('does not carry id, season or source columns into the form input', () => {
+    const result = buildDefaultsFromRecipe(recipe);
+    expect(result).not.toHaveProperty('id');
+    expect(result).not.toHaveProperty('season');
+    expect(result).not.toHaveProperty('sourceUrl');
+  });
+});

--- a/tests/unit/screens/recipe/fields/IngredientsField.test.tsx
+++ b/tests/unit/screens/recipe/fields/IngredientsField.test.tsx
@@ -458,4 +458,216 @@ describe('RecipeIngredientsField', () => {
       'alerts.inlineErrors.titleIngredients'
     );
   });
+
+  describe('read-only mode', () => {
+    test('renders ingredients via the read-only organism without edit affordances', () => {
+      const ingredients = [
+        {
+          id: 1,
+          name: 'flour',
+          quantity: '200',
+          unit: 'g',
+          type: ingredientType.cereal,
+          season: [],
+        },
+      ];
+      const { getByTestId, queryByTestId } = renderWithForm(
+        RecipeIngredientsField,
+        form => ({
+          form,
+          stackMode: recipeStateType.readOnly,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: ingredients }
+      );
+      expect(JSON.parse(getByTestId('RecipeIngredients::Ingredients').props.children)).toEqual(
+        ingredients
+      );
+      expect(
+        queryByTestId('RecipeIngredients::AddButton::RoundButton::OnPressFunction')
+      ).toBeNull();
+    });
+
+    test('falls back to an empty list when the form value is undefined', () => {
+      const { getByTestId } = renderWithForm(
+        RecipeIngredientsField,
+        form => ({
+          form,
+          stackMode: recipeStateType.readOnly,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: undefined }
+      );
+      expect(JSON.parse(getByTestId('RecipeIngredients::Ingredients').props.children)).toEqual([]);
+    });
+  });
+
+  describe('addOCR mode', () => {
+    test('empty array renders the empty-state block and opens the names OCR modal', () => {
+      const openModalForField = jest.fn();
+      const { getByTestId } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.addOCR,
+          openModalForField,
+          t,
+        }),
+        { recipeIngredients: [] }
+      );
+      expect(getByTestId('RecipeIngredients::PrefixText').props.children).toBe('ingredients: ');
+      fireEvent.press(
+        getByTestId('RecipeIngredients::OpenModalNames::RoundButton::OnPressFunction')
+      );
+      expect(openModalForField).toHaveBeenCalledWith('ingredientNames');
+    });
+
+    test('empty array manual-add button appends a row through the field array', () => {
+      const { getByTestId, form } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.addOCR,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: [] }
+      );
+      fireEvent.press(getByTestId('RecipeIngredients::AddButton::RoundButton::OnPressFunction'));
+      expect(form.getValues('recipeIngredients')).toHaveLength(1);
+    });
+
+    test('non-empty array hides the empty-state block and renders the add-tail OCR block', () => {
+      const openModalForField = jest.fn();
+      const ingredients = [
+        {
+          id: 1,
+          name: 'flour',
+          quantity: '200',
+          unit: 'g',
+          type: ingredientType.cereal,
+          season: [],
+        },
+      ];
+      const { getByTestId, queryByTestId, form } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.addOCR,
+          openModalForField,
+          t,
+        }),
+        { recipeIngredients: ingredients }
+      );
+      expect(
+        queryByTestId('RecipeIngredients::OpenModalNames::RoundButton::OnPressFunction')
+      ).toBeNull();
+      fireEvent.press(
+        getByTestId('RecipeIngredients::OpenModalQuantities::RoundButton::OnPressFunction')
+      );
+      expect(openModalForField).toHaveBeenCalledWith('ingredientQuantities');
+      fireEvent.press(getByTestId('RecipeIngredients::AddButton::RoundButton::OnPressFunction'));
+      expect(form.getValues('recipeIngredients')).toHaveLength(2);
+    });
+  });
+
+  describe('ingredient note dialog', () => {
+    const flourRow = {
+      id: 1,
+      name: 'flour',
+      quantity: '200',
+      unit: 'g',
+      type: ingredientType.cereal,
+      season: [],
+    };
+
+    test('opens for the pressed row prefilled with its name, and cancel closes without saving', async () => {
+      const { getByTestId, queryByTestId, form } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.edit,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: [flourRow] }
+      );
+      fireEvent.press(getByTestId('RecipeIngredients::0::NoteButton'));
+      expect(getByTestId('RecipeIngredients::NoteDialog::IngredientName').props.children).toBe(
+        'flour'
+      );
+      await act(async () => {
+        fireEvent.press(getByTestId('RecipeIngredients::NoteDialog::CancelButton'));
+      });
+      expect(queryByTestId('RecipeIngredients::NoteDialog::Title')).toBeNull();
+      expect(form.getValues('recipeIngredients.0.note')).toBeUndefined();
+    });
+
+    test('saving writes the trimmed note back onto the focused row and closes the dialog', async () => {
+      const { getByTestId, queryByTestId, form } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.edit,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: [flourRow] }
+      );
+      fireEvent.press(getByTestId('RecipeIngredients::0::NoteButton'));
+      fireEvent.changeText(
+        getByTestId('RecipeIngredients::NoteDialog::Input::CustomTextInput'),
+        '  for the sauce  '
+      );
+      await act(async () => {
+        fireEvent.press(getByTestId('RecipeIngredients::NoteDialog::SaveButton'));
+      });
+      expect(form.getValues('recipeIngredients.0.note')).toBe('for the sauce');
+      expect(form.getValues('recipeIngredients.0.quantity')).toBe('200');
+      expect(form.getValues('recipeIngredients.0.name')).toBe('flour');
+      expect(queryByTestId('RecipeIngredients::NoteDialog::Title')).toBeNull();
+    });
+
+    test('saving an unnamed row with no unit falls back to blank unit, name and note', async () => {
+      const { getByTestId, queryByTestId, form } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.edit,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: [{ quantity: '50' }] }
+      );
+      fireEvent.press(getByTestId('RecipeIngredients::0::NoteButton'));
+      await act(async () => {
+        fireEvent.press(getByTestId('RecipeIngredients::NoteDialog::SaveButton'));
+      });
+      expect(queryByTestId('RecipeIngredients::NoteDialog::Title')).toBeNull();
+      expect(form.getValues('recipeIngredients.0.quantity')).toBe('50');
+    });
+
+    test('saving is a no-op once the focused row has been removed before the dialog closes', async () => {
+      const { getByTestId, form } = renderWithForm(
+        RecipeIngredientsField,
+        f => ({
+          form: f,
+          stackMode: recipeStateType.edit,
+          openModalForField: jest.fn(),
+          t,
+        }),
+        { recipeIngredients: [flourRow] }
+      );
+      fireEvent.press(getByTestId('RecipeIngredients::0::NoteButton'));
+      await act(async () => {
+        fireEvent.press(getByTestId('RecipeIngredients::0::OnRemoveIngredient'));
+      });
+      await act(async () => {
+        fireEvent.press(getByTestId('RecipeIngredients::NoteDialog::SaveButton'));
+      });
+      expect(form.getValues('recipeIngredients')).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/screens/recipe/fields/PreparationStep.test.tsx
+++ b/tests/unit/screens/recipe/fields/PreparationStep.test.tsx
@@ -1,0 +1,105 @@
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+
+import { PreparationStepField } from '@screens/recipe/fields/PreparationStep';
+
+import { renderWithForm, t } from './fieldsTestHarness';
+
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+jest.mock('@components/organisms/RecipePreparation', () => {
+  const mocks = require('@mocks/components/organisms/RecipePreparation-mock');
+  return { EditableStep: mocks.editableStepMock };
+});
+
+const titleInputId = 'RecipePreparation::EditableStep::0::TextInputTitle::CustomTextInput';
+const descInputId = 'RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput';
+const descErrorId = 'RecipePreparation::EditableStep::0::DescriptionError';
+
+function renderStep(preparation: { title: string; description: string }[]) {
+  return renderWithForm(PreparationStepField, form => ({ form, index: 0, t }), {
+    recipePreparation: preparation,
+  });
+}
+
+describe('PreparationStepField', () => {
+  test('renders the title and description from the bound form value', () => {
+    const { getByTestId } = renderStep([{ title: 'Boil water', description: 'Until steaming' }]);
+    expect(getByTestId(titleInputId).props.value).toBe('Boil water');
+    expect(getByTestId(descInputId).props.value).toBe('Until steaming');
+  });
+
+  test('falls back to empty strings when the bound step has no title or description', () => {
+    const { getByTestId } = renderStep([{} as { title: string; description: string }]);
+    expect(getByTestId(titleInputId).props.value).toBe('');
+    expect(getByTestId(descInputId).props.value).toBe('');
+  });
+
+  test('typing a title commits live to the form value', () => {
+    const { getByTestId, form } = renderStep([{ title: 'Old', description: 'desc' }]);
+
+    act(() => {
+      fireEvent.changeText(getByTestId(titleInputId), 'New title');
+    });
+
+    expect(form.getValues('recipePreparation')![0]).toEqual({
+      title: 'New title',
+      description: 'desc',
+    });
+  });
+
+  test('typing a description commits live to the form value', () => {
+    const { getByTestId, form } = renderStep([{ title: 'Step', description: 'Old' }]);
+
+    act(() => {
+      fireEvent.changeText(getByTestId(descInputId), 'New description');
+    });
+
+    expect(form.getValues('recipePreparation')![0]!.description).toBe('New description');
+  });
+
+  test('committing the title via blur writes the value to the form', () => {
+    const { getByTestId, form } = renderStep([{ title: 'Step', description: 'desc' }]);
+
+    act(() => {
+      fireEvent(getByTestId(titleInputId), 'endEditing', {
+        nativeEvent: { text: 'Committed title' },
+      });
+    });
+
+    expect(form.getValues('recipePreparation')![0]!.title).toBe('Committed title');
+  });
+
+  test('no inline description error surfaces before the step is touched', () => {
+    const { queryByTestId } = renderStep([{ title: 'Step', description: '' }]);
+    expect(queryByTestId(descErrorId)).toBeNull();
+  });
+
+  test('committing an empty description via blur surfaces the inline error', async () => {
+    const { getByTestId } = renderStep([{ title: 'Step', description: 'Filled' }]);
+
+    await act(async () => {
+      fireEvent(getByTestId(descInputId), 'endEditing', { nativeEvent: { text: '' } });
+    });
+
+    await waitFor(() => {
+      expect(getByTestId(descErrorId).props.children).toBeTruthy();
+    });
+  });
+
+  test('typing a non-empty description after an error clears it', async () => {
+    const { getByTestId, queryByTestId } = renderStep([{ title: 'Step', description: 'Filled' }]);
+
+    await act(async () => {
+      fireEvent(getByTestId(descInputId), 'endEditing', { nativeEvent: { text: '' } });
+    });
+    await waitFor(() => {
+      expect(getByTestId(descErrorId).props.children).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId(descInputId), 'endEditing', { nativeEvent: { text: 'Now filled' } });
+    });
+    await waitFor(() => {
+      expect(queryByTestId(descErrorId)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/screens/recipe/fields/useStepArray.test.tsx
+++ b/tests/unit/screens/recipe/fields/useStepArray.test.tsx
@@ -1,0 +1,87 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useForm, UseFormReturn } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { recipeFormSchema, RecipeFormInput } from '@schemas/recipeFormSchema';
+import { defaultValueNumber } from '@utils/Constants';
+import { useStepArray } from '@screens/recipe/fields/useStepArray';
+
+function buildDefaults(preparation: RecipeFormInput['recipePreparation']): RecipeFormInput {
+  return {
+    recipeImage: '',
+    recipeTitle: 'Test',
+    recipeDescription: '',
+    recipeTags: [],
+    recipePersons: defaultValueNumber,
+    recipeIngredients: [],
+    recipePreparation: preparation,
+    recipeTime: defaultValueNumber,
+    recipeNutrition: undefined,
+  };
+}
+
+function renderUseStepArray(preparation: RecipeFormInput['recipePreparation'] = []) {
+  const formRef: { current: UseFormReturn<RecipeFormInput> | null } = { current: null };
+  const { result } = renderHook(() => {
+    const form = useForm<RecipeFormInput>({
+      resolver: zodResolver(recipeFormSchema),
+      mode: 'onTouched',
+      defaultValues: buildDefaults(preparation),
+    });
+    formRef.current = form;
+    return useStepArray(form);
+  });
+  return { result, formRef };
+}
+
+describe('useStepArray', () => {
+  test('length reflects the initial preparation array', () => {
+    const { result } = renderUseStepArray([
+      { title: 'A', description: 'first' },
+      { title: 'B', description: 'second' },
+    ]);
+    expect(result.current.length).toBe(2);
+    expect(result.current.fields).toHaveLength(2);
+  });
+
+  test('length is zero when there are no initial steps', () => {
+    const { result } = renderUseStepArray([]);
+    expect(result.current.length).toBe(0);
+    expect(result.current.fields).toHaveLength(0);
+  });
+
+  test('addStep appends a blank step to the form value', () => {
+    const { result, formRef } = renderUseStepArray([]);
+
+    act(() => {
+      result.current.addStep();
+    });
+
+    expect(formRef.current!.getValues('recipePreparation')).toEqual([
+      { title: '', description: '' },
+    ]);
+  });
+
+  test('addStep increments length and grows the fields list', () => {
+    const { result } = renderUseStepArray([{ title: 'A', description: 'first' }]);
+
+    act(() => {
+      result.current.addStep();
+    });
+
+    expect(result.current.length).toBe(2);
+    expect(result.current.fields).toHaveLength(2);
+  });
+
+  test('each appended step keeps existing rows untouched', () => {
+    const { result, formRef } = renderUseStepArray([{ title: 'Keep', description: 'me' }]);
+
+    act(() => {
+      result.current.addStep();
+    });
+
+    const prep = formRef.current!.getValues('recipePreparation')!;
+    expect(prep[0]).toEqual({ title: 'Keep', description: 'me' });
+    expect(prep[1]).toEqual({ title: '', description: '' });
+  });
+});

--- a/tests/unit/utils/OCR.test.tsx
+++ b/tests/unit/utils/OCR.test.tsx
@@ -12,6 +12,7 @@ import TextRecognition, {
   TextLine,
   TextRecognitionResult,
 } from '@react-native-ml-kit/text-recognition';
+import i18n from '@utils/i18n';
 
 jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
 
@@ -696,6 +697,31 @@ describe('OCR Utility Functions', () => {
 
         expect(result).toEqual({ recipePreparation: expectedPreparationHelloFresh });
       });
+
+      test('warns and returns nothing when no preparation steps are found', async () => {
+        mockRecognize.mockResolvedValue({
+          text: 'some random continuation text.',
+          blocks: [
+            {
+              recognizedLanguages: [],
+              text: 'some random continuation text.',
+              lines: [],
+            },
+          ],
+        });
+
+        const result = await extractFieldFromImage(
+          uriForOCR,
+          recipeColumnsNames.preparation,
+          baseState,
+          mockWarn
+        );
+
+        expect(result).toEqual({});
+        expect(mockWarn).toHaveBeenCalledWith(
+          expect.stringContaining('Expected non empty array of preparation steps')
+        );
+      });
     });
   });
 
@@ -1055,6 +1081,548 @@ describe('OCR Utility Functions', () => {
     });
   });
 
+  describe('on image field', () => {
+    test('on recognizeText logs and returns empty string', async () => {
+      mockRecognize.mockResolvedValue({ text: '', blocks: [] });
+
+      expect(await recognizeText(uriForOCR, recipeColumnsNames.image)).toEqual('');
+    });
+
+    test('on extractFieldFromImage returns recipeImage without calling OCR', async () => {
+      const result = await extractFieldFromImage(
+        uriForOCR,
+        recipeColumnsNames.image,
+        baseState,
+        mockWarn
+      );
+
+      expect(result).toEqual({ recipeImage: uriForOCR });
+      expect(mockRecognize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recognizeText error handling', () => {
+    test('returns empty string when TextRecognition.recognize rejects', async () => {
+      mockRecognize.mockRejectedValue(new Error('camera failure'));
+
+      expect(await recognizeText(uriForOCR, recipeColumnsNames.title)).toEqual('');
+    });
+  });
+
+  describe('tranformOCRInOneNumber edge cases', () => {
+    test('returns the persons array when persons and time counts do not match', async () => {
+      mockRecognize.mockResolvedValue({
+        text: '2 pers.\n3 pers.\n25 min',
+        blocks: [createBlock('2 pers.'), createBlock('3 pers.'), createBlock('25 min')],
+      });
+
+      expect(await recognizeText(uriForOCR, recipeColumnsNames.persons)).toEqual([2, 3]);
+    });
+
+    test('logs and returns the default value when neither persons nor time are found', async () => {
+      mockRecognize.mockResolvedValue({
+        text: 'abc\nxyz',
+        blocks: [createBlock('abc'), createBlock('xyz')],
+      });
+
+      expect(await recognizeText(uriForOCR, recipeColumnsNames.time)).toEqual(-1);
+    });
+  });
+
+  describe('tranformOCRInPreparation edge cases', () => {
+    const createPreparationBlock = (text: string): TextBlock => ({
+      recognizedLanguages: [],
+      text,
+      lines: [],
+    });
+
+    test('skips blocks with empty text', async () => {
+      mockRecognize.mockResolvedValue({
+        text: '\n1. Real step',
+        blocks: [createPreparationBlock(''), createPreparationBlock('1. Real step')],
+      });
+
+      const result = await recognizeText(uriForOCR, recipeColumnsNames.preparation);
+
+      expect(result).toEqual([{ title: 'Real step', description: '' }]);
+    });
+
+    test('uses whole text as title when a numbered block has no title-dot separator', async () => {
+      mockRecognize.mockResolvedValue({
+        text: '5\nJust a title',
+        blocks: [createPreparationBlock('5\nJust a title')],
+      });
+
+      const result = await recognizeText(uriForOCR, recipeColumnsNames.preparation);
+
+      expect(result).toEqual([{ title: 'Just a title', description: '' }]);
+    });
+  });
+
+  describe('on ingredients field', () => {
+    describe('on recognizeText', () => {
+      test('parses an Android-style header table with box header, split person suffix and ingredient note', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('Dans votre box'),
+            createBlock('Farine (g)'),
+            createBlock('Sucre (cups) (bio)'),
+            createBlock('Sel'),
+            createBlock('2'),
+            createBlock('pers.'),
+            createBlock('200'),
+            createBlock('100'),
+            createBlock('5'),
+            createBlock('3'),
+            createBlock('pers.'),
+            createBlock('300'),
+            createBlock('150'),
+            createBlock('7'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          {
+            name: 'Farine',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '200' },
+              { persons: 3, quantity: '300' },
+            ],
+          },
+          {
+            name: 'Sucre',
+            unit: 'cups',
+            quantityPerPersons: [
+              { persons: 2, quantity: '100' },
+              { persons: 3, quantity: '150' },
+            ],
+            note: 'bio',
+          },
+          {
+            name: 'Sel',
+            unit: '',
+            quantityPerPersons: [
+              { persons: 2, quantity: '5' },
+              { persons: 3, quantity: '7' },
+            ],
+          },
+        ]);
+      });
+
+      test('merges an ingredient split across two lines and drops the leftover suspicious group', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('Poivre'),
+            createBlock('noir (g)'),
+            createBlock('2p'),
+            createBlock('15'),
+            createBlock('100'),
+            createBlock('3p'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          {
+            name: 'Poivre noir',
+            unit: 'g',
+            quantityPerPersons: [{ persons: 2, quantity: '15' }],
+          },
+        ]);
+      });
+
+      test('gives up merging and keeps raw ingredients when two consecutive suspicious values cannot be merged safely', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('X'),
+            createBlock('Y'),
+            createBlock('Z (g)'),
+            createBlock('2p'),
+            createBlock('15'),
+            createBlock('20'),
+            createBlock('100'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'X', unit: '', quantityPerPersons: [{ persons: 2, quantity: '15' }] },
+          { name: 'Y', unit: '', quantityPerPersons: [{ persons: 2, quantity: '20' }] },
+          { name: 'Z', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '100' }] },
+        ]);
+      });
+
+      test('(iOS) detects reversed block order when markers and quantities appear before ingredient names', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('2p'),
+            createBlock('200'),
+            createBlock('100'),
+            createBlock('3p'),
+            createBlock('300'),
+            createBlock('150'),
+            createBlock('Farine (g)'),
+            createBlock('Sucre (cups)'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          {
+            name: 'Farine',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '200' },
+              { persons: 3, quantity: '300' },
+            ],
+          },
+          {
+            name: 'Sucre',
+            unit: 'cups',
+            quantityPerPersons: [
+              { persons: 2, quantity: '100' },
+              { persons: 3, quantity: '150' },
+            ],
+          },
+        ]);
+      });
+
+      test('(iOS) redistributes quantities when person markers are out of order', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('Farine (g)'),
+            createBlock('Sucre (cups)'),
+            createBlock('5p'),
+            createBlock('2005'),
+            createBlock('1005'),
+            createBlock('3p'),
+            createBlock('2003'),
+            createBlock('1003'),
+            createBlock('2p'),
+            createBlock('2002'),
+            createBlock('1002'),
+            createBlock('4p'),
+            createBlock('2004'),
+            createBlock('1004'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          {
+            name: 'Farine',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '2002' },
+              { persons: 3, quantity: '2003' },
+              { persons: 4, quantity: '2004' },
+              { persons: 5, quantity: '2005' },
+            ],
+          },
+          {
+            name: 'Sucre',
+            unit: 'cups',
+            quantityPerPersons: [
+              { persons: 2, quantity: '1002' },
+              { persons: 3, quantity: '1003' },
+              { persons: 4, quantity: '1004' },
+              { persons: 5, quantity: '1005' },
+            ],
+          },
+        ]);
+      });
+
+      test('falls back to parseIngredientsNoHeader when no person marker is present', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('Flour'),
+            createBlock('Sugar'),
+            createBlock('200 g'),
+            createBlock('100 g'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'Flour', unit: 'g', quantityPerPersons: [{ persons: -1, quantity: '200' }] },
+          { name: 'Sugar', unit: 'g', quantityPerPersons: [{ persons: -1, quantity: '100' }] },
+        ]);
+      });
+
+      test('logs and returns an empty array when i18n throws while reading ingredient OCR terms', async () => {
+        jest.spyOn(i18n, 'getResource').mockImplementationOnce(() => {
+          throw new Error('i18n boom');
+        });
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [createBlock('Farine (g)'), createBlock('2p'), createBlock('200')],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'Farine', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '200' }] },
+        ]);
+      });
+
+      test('falls back to no box headers or person suffixes when i18n has no ingredient OCR terms', async () => {
+        jest.spyOn(i18n, 'getResource').mockReturnValueOnce(undefined);
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [createBlock('Farine (g)'), createBlock('2p'), createBlock('200')],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'Farine', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '200' }] },
+        ]);
+      });
+
+      test('splits a single OCR token containing space-separated quantities', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('A (g)'),
+            createBlock('B (g)'),
+            createBlock('2p'),
+            createBlock('200 100'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'A', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '200' }] },
+          { name: 'B', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '100' }] },
+        ]);
+      });
+
+      test('pads a group with empty quantities when fewer values than ingredients precede the next marker', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('A (g)'),
+            createBlock('B (g)'),
+            createBlock('2p'),
+            createBlock('200'),
+            createBlock('3p'),
+            createBlock('300'),
+            createBlock('400'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          {
+            name: 'A',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '200' },
+              { persons: 3, quantity: '300' },
+            ],
+          },
+          {
+            name: 'B',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '' },
+              { persons: 3, quantity: '400' },
+            ],
+          },
+        ]);
+      });
+
+      test('(iOS) pads redistributed quantities when the out-of-order slice runs short', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('A (g)'),
+            createBlock('B (g)'),
+            createBlock('3p'),
+            createBlock('100'),
+            createBlock('200'),
+            createBlock('2p'),
+            createBlock('300'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          {
+            name: 'A',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '300' },
+              { persons: 3, quantity: '100' },
+            ],
+          },
+          {
+            name: 'B',
+            unit: 'g',
+            quantityPerPersons: [
+              { persons: 2, quantity: '' },
+              { persons: 3, quantity: '200' },
+            ],
+          },
+        ]);
+      });
+
+      test('cannot merge when the suspicious index points past the collected quantities', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('A'),
+            createBlock('B (g)'),
+            createBlock('C (g)'),
+            createBlock('2p'),
+            createBlock('5'),
+            createBlock('100'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'A', unit: '', quantityPerPersons: [{ persons: 2, quantity: '5' }] },
+          { name: 'B', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '100' }] },
+          { name: 'C', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '' }] },
+        ]);
+      });
+
+      test('cannot merge when the suspicious ingredient is the last one with no neighbor to merge into', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('A (g)'),
+            createBlock('B'),
+            createBlock('2p'),
+            createBlock('100'),
+            createBlock('50'),
+          ],
+        });
+
+        const result = await recognizeText(uriForOCR, recipeColumnsNames.ingredients);
+
+        expect(result).toEqual([
+          { name: 'A', unit: 'g', quantityPerPersons: [{ persons: 2, quantity: '100' }] },
+          { name: 'B', unit: '', quantityPerPersons: [{ persons: 2, quantity: '50' }] },
+        ]);
+      });
+    });
+
+    describe('on extractFieldFromImage', () => {
+      const mockResultIngredients: TextRecognitionResult = {
+        text: '',
+        blocks: [
+          createBlock('Farine (g)'),
+          createBlock('Sucre (cups) (bio)'),
+          createBlock('Sel'),
+          createBlock('2p'),
+          createBlock('200'),
+          createBlock('100'),
+          createBlock('5'),
+          createBlock('3p'),
+          createBlock('300'),
+          createBlock('150'),
+          createBlock('7'),
+        ],
+      };
+
+      test('scales to the exact matching persons count without warning', async () => {
+        mockRecognize.mockResolvedValue(mockResultIngredients);
+
+        const result = await extractFieldFromImage(
+          uriForOCR,
+          recipeColumnsNames.ingredients,
+          { ...baseState, recipePersons: 3 },
+          mockWarn
+        );
+
+        expect(result).toEqual({
+          recipeIngredients: [
+            { name: 'Farine', unit: 'g', quantity: '300' },
+            { name: 'Sucre', unit: 'cups', quantity: '150', note: 'bio' },
+            { name: 'Sel', unit: '', quantity: '7' },
+          ],
+        });
+        expect(mockWarn).not.toHaveBeenCalled();
+      });
+
+      test('falls back to the first available persons count and scales when no exact match exists', async () => {
+        mockRecognize.mockResolvedValue(mockResultIngredients);
+
+        const result = await extractFieldFromImage(
+          uriForOCR,
+          recipeColumnsNames.ingredients,
+          { ...baseState, recipePersons: 10 },
+          mockWarn
+        );
+
+        expect(result).toEqual({
+          recipeIngredients: [
+            { name: 'Farine', unit: 'g', quantity: '1000' },
+            { name: 'Sucre', unit: 'cups', quantity: '500', note: 'bio' },
+            { name: 'Sel', unit: '', quantity: '25' },
+          ],
+        });
+        expect(mockWarn).toHaveBeenCalledWith(
+          expect.stringContaining("Couldn't find exact match for persons (10)")
+        );
+      });
+
+      test('uses the first available persons count without scaling when recipePersons is not positive', async () => {
+        mockRecognize.mockResolvedValue(mockResultIngredients);
+
+        const result = await extractFieldFromImage(
+          uriForOCR,
+          recipeColumnsNames.ingredients,
+          { ...baseState, recipePersons: 0 },
+          mockWarn
+        );
+
+        expect(result).toEqual({
+          recipeIngredients: [
+            { name: 'Farine', unit: 'g', quantity: '200' },
+            { name: 'Sucre', unit: 'cups', quantity: '100', note: 'bio' },
+            { name: 'Sel', unit: '', quantity: '5' },
+          ],
+        });
+        expect(mockWarn).toHaveBeenCalledWith(
+          expect.stringContaining("Couldn't find exact match for persons in ingredient")
+        );
+      });
+
+      test('warns and returns nothing when no ingredients are found, using the default warning handler', async () => {
+        mockRecognize.mockResolvedValue({ text: '', blocks: [] });
+
+        const result = await extractFieldFromImage(
+          uriForOCR,
+          recipeColumnsNames.ingredients,
+          baseState
+        );
+
+        expect(result).toEqual({});
+      });
+    });
+  });
+
   test('extractFieldFromImage should handle unrecognized field gracefully', async () => {
     const result = await extractFieldFromImage(
       uriForOCR,
@@ -1088,6 +1656,14 @@ describe('OCR Utility Functions', () => {
 
       expect(result.ingredientNames).toEqual([]);
     });
+
+    test('logs and returns an empty array when TextRecognition.recognize rejects', async () => {
+      mockRecognize.mockRejectedValue(new Error('camera failure'));
+
+      const result = await extractFieldFromImage(uriForOCR, 'ingredientNames', baseState, mockWarn);
+
+      expect(result.ingredientNames).toEqual([]);
+    });
   });
 
   describe('on ingredientQuantities field', () => {
@@ -1109,6 +1685,19 @@ describe('OCR Utility Functions', () => {
 
     test('returns empty ingredientQuantities when OCR finds nothing', async () => {
       mockRecognize.mockResolvedValue({ text: '', blocks: [] });
+
+      const result = await extractFieldFromImage(
+        uriForOCR,
+        'ingredientQuantities',
+        baseState,
+        mockWarn
+      );
+
+      expect(result.ingredientQuantities).toEqual([]);
+    });
+
+    test('logs and returns an empty array when TextRecognition.recognize rejects', async () => {
+      mockRecognize.mockRejectedValue(new Error('camera failure'));
 
       const result = await extractFieldFromImage(
         uriForOCR,
@@ -1165,6 +1754,25 @@ describe('OCR Utility Functions', () => {
         expect(result).toEqual({
           recipeTags: new Array<TagDraft>(tagAlreadyPresent, ...expectedTags),
         });
+      });
+
+      test('warns and returns nothing when OCR finds no tag words', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '   ',
+          blocks: [createBlock('   ')],
+        });
+
+        const result = await extractFieldFromImage(
+          uriForOCR,
+          recipeColumnsNames.tags,
+          baseState,
+          mockWarn
+        );
+
+        expect(result).toEqual({});
+        expect(mockWarn).toHaveBeenCalledWith(
+          expect.stringContaining('Expected non empty array of strings for tags')
+        );
       });
     });
   });
@@ -1687,6 +2295,141 @@ describe('OCR Utility Functions', () => {
 
         mockRecognize.mockResolvedValue(mockResultNoMarker);
         expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({});
+      });
+
+      test('logs and returns empty object when i18n throws while reading nutrition OCR terms', async () => {
+        jest.spyOn(i18n, 'getResource').mockImplementationOnce(() => {
+          throw new Error('i18n boom');
+        });
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [createBlock('sel'), createBlock('pour 100g'), createBlock('5g')],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({});
+      });
+
+      test('returns empty object when fewer values than labels are found', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('sel'),
+            createBlock('fibres'),
+            createBlock('pour 100g'),
+            createBlock('5g'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({});
+      });
+
+      test('stops collecting values at the per portion column indicator', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('sel'),
+            createBlock('pour 100g'),
+            createBlock('5g'),
+            createBlock('Par portion'),
+            createBlock('999g'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({ salt: 5 });
+      });
+
+      test('omits a field whose value is a single character with no unit', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('sel'),
+            createBlock('matières grasses'),
+            createBlock('pour 100g'),
+            createBlock('5g'),
+            createBlock('5'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({ salt: 5 });
+      });
+
+      test('omits a field whose value keeps a stray non-digit character after cleanup', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('sel'),
+            createBlock('glucides'),
+            createBlock('pour 100g'),
+            createBlock('5g'),
+            createBlock('1,2,3g'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({ salt: 5 });
+      });
+
+      test('omits a field whose value is above the maximum nutrition value', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('sel'),
+            createBlock('fibres'),
+            createBlock('pour 100g'),
+            createBlock('5g'),
+            createBlock('99999g'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({ salt: 5 });
+      });
+
+      test('omits a field whose value starts with a letter', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('sel'),
+            createBlock('protéines'),
+            createBlock('pour 100g'),
+            createBlock('5g'),
+            createBlock('xyz'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({ salt: 5 });
+      });
+
+      test('assigns the new value to energyKj without swapping when it is not smaller than the existing kcal value', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('Energie'),
+            createBlock('pour 100g'),
+            createBlock('200kcal'),
+            createBlock('500kcal'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({
+          energyKcal: 200,
+          energyKj: 500,
+        });
+      });
+
+      test('swaps kj into kcal when a larger duplicate energy value follows an existing kj value', async () => {
+        mockRecognize.mockResolvedValue({
+          text: '',
+          blocks: [
+            createBlock('Energie'),
+            createBlock('pour 100g'),
+            createBlock('1500kcal'),
+            createBlock('2500kcal'),
+          ],
+        });
+
+        expect(await recognizeText(uriForOCR, recipeColumnsNames.nutrition)).toEqual({
+          energyKcal: 1500,
+          energyKj: 2500,
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes #362. Adds unit tests for every file flagged zero-coverage in the issue, then extends the audit to close the next tier of coverage gaps.

**Overall project coverage: 91.3% → 95.7% statements, 86.1% → 91.3% branches** (+90 tests, 4093 passing).

### #362 zero-coverage files (commit 1) — all 100%
- `useShopping`, `useMenu`, `useRecipes` (hooks)
- `useStepArray`, `PreparationStep` (recipe form fields)
- `buildDefaultsFromRecipe` (edit-mode form seeding)

`RecipeImportOrchestrator` was already covered since the issue was filed, so it dropped from scope.

### Broader coverage wave (commit 2)
| File | Before → After (stmt) |
|---|---|
| IngredientsField.tsx | 70 → 100 |
| VerticalBottomButtons.tsx | 69 → 100 |
| FiltersSelection.tsx | 71 → 100 |
| TagButton.tsx (new suite) | 75 → 100 |
| OCR.tsx | 63 → 97 |
| BaseRecipeProvider.ts | 63 → 99 |
| RecipeAddManual/Ocr/Scrape.tsx | 50/69/72 → 83/92/91 (branch 100) |

### Notes
- **Tests only** — zero source changes.
- Residual gaps are defensive/dead branches (e.g. add-mode `onCancel` wiring only rendered when editing) — unreachable without mocking internals.
- The four `customTypes/*Types` files still report 0% because they are pure type declarations with no runtime statements; the correct fix is a `collectCoverageFrom` exclude in `jest.config.js` (not in this PR — flag for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)