### PR TITLE
fix(recipe-card): contain title in border with uniform card height

### DIFF
--- a/src/components/molecules/RecipeCard.tsx
+++ b/src/components/molecules/RecipeCard.tsx
@@ -33,6 +33,7 @@
 
 import React from 'react';
 import { Card, Text, useTheme } from 'react-native-paper';
+import type { TextProps } from 'react-native-paper';
 import { padding, screenWidth } from '@styles/spacing';
 import { View } from 'react-native';
 import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
@@ -52,6 +53,8 @@ export type RecipeCardProps = {
   recipe: recipeTableElement;
 };
 
+const titleLines = 2;
+
 /**
  * RecipeCard component
  *
@@ -60,10 +63,16 @@ export type RecipeCardProps = {
  */
 export function RecipeCard({ testId, size, recipe }: RecipeCardProps) {
   const { navigate } = useNavigation<StackScreenNavigation>();
-  const { colors } = useTheme();
+  const { colors, fonts } = useTheme();
   const { t } = useI18n();
-  const cardWidth = screenWidth * (size === 'small' ? 0.35 : 0.45);
+  const isSmallCard = size === 'small';
+  const cardWidth = screenWidth * (isSmallCard ? 0.35 : 0.45);
   const radius = cardWidth / 12;
+  const titleVariant: NonNullable<TextProps<never>['variant']> = isSmallCard
+    ? 'labelLarge'
+    : 'titleMedium';
+  const titleFont = isSmallCard ? fonts.labelLarge : fonts.titleMedium;
+  const titleMinHeight = titleLines * titleFont.lineHeight + 2 * padding.medium;
 
   return (
     <Card
@@ -71,10 +80,8 @@ export function RecipeCard({ testId, size, recipe }: RecipeCardProps) {
       testID={testId + `::${recipe.title}`}
       mode={'outlined'}
       style={{
-        flex: 1,
         margin: padding.small,
         width: cardWidth,
-        justifyContent: 'flex-start',
         backgroundColor: colors.surface,
         borderRadius: radius,
       }}
@@ -95,9 +102,13 @@ export function RecipeCard({ testId, size, recipe }: RecipeCardProps) {
       <Text
         testID={testId + '::Title'}
         accessible={true}
-        variant={size === 'small' ? 'labelLarge' : 'titleMedium'}
-        numberOfLines={2}
-        style={{ padding: padding.medium }}
+        variant={titleVariant}
+        numberOfLines={titleLines}
+        style={{
+          padding: padding.medium,
+          lineHeight: titleFont.lineHeight,
+          minHeight: titleMinHeight,
+        }}
       >
         {recipe.title}
       </Text>

--- a/tests/mocks/deps/react-native-paper-mock.tsx
+++ b/tests/mocks/deps/react-native-paper-mock.tsx
@@ -355,11 +355,11 @@ export const useTheme = jest.fn(() => ({
     headlineMedium: { fontSize: 20 },
     headlineLarge: { fontSize: 24 },
     titleSmall: { fontSize: 16 },
-    titleMedium: { fontSize: 18 },
+    titleMedium: { fontSize: 16, lineHeight: 24 },
     titleLarge: { fontSize: 20 },
     labelSmall: { fontSize: 10 },
     labelMedium: { fontSize: 12 },
-    labelLarge: { fontSize: 14 },
+    labelLarge: { fontSize: 14, lineHeight: 20 },
   },
 }));
 

--- a/tests/unit/components/molecules/RecipeCard.test.tsx
+++ b/tests/unit/components/molecules/RecipeCard.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import RecipeCard, { RecipeCardProps } from '@components/molecules/RecipeCard';
+import { padding } from '@styles/spacing';
 import React from 'react';
 import { testRecipes } from '@test-data/recipesDataset';
 import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
@@ -230,6 +232,44 @@ describe('RecipeCard Component', () => {
       assertRecipeDataDisplay(getByTestId, queryByTestId, 'medium', minimalRecipe);
     }
   });
+
+  const titleLineHeightBySize = { small: 20, medium: 24 } as const;
+
+  test.each(['small', 'medium'] as const)(
+    'reserves a fixed two-line title block so %s cards keep a uniform height',
+    size => {
+      const lineHeight = titleLineHeightBySize[size];
+      const shortTitle = renderRecipeCard({ size, recipe: { ...sampleRecipe, title: 'A' } });
+      const longTitle = renderRecipeCard({
+        size,
+        recipe: {
+          ...sampleRecipe,
+          title: 'A Very Long Recipe Title That Wraps Across Exactly Two Full Lines',
+        },
+      });
+
+      const expectedMinHeight = 2 * lineHeight + 2 * padding.medium;
+
+      for (const utils of [shortTitle, longTitle]) {
+        const titleStyle = StyleSheet.flatten(
+          utils.getByTestId('test-recipe-card::Title').props.style
+        );
+        expect(titleStyle.lineHeight).toBe(lineHeight);
+        expect(titleStyle.minHeight).toBe(expectedMinHeight);
+      }
+    }
+  );
+
+  test.each(['small', 'medium'] as const)(
+    'does not stretch the %s card via flex so its border wraps the whole content',
+    size => {
+      const { getByTestId } = renderRecipeCard({ size });
+      const cardStyle = StyleSheet.flatten(
+        getByTestId(`test-recipe-card::${sampleRecipe.title}`).props.style
+      );
+      expect(cardStyle.flex).toBeUndefined();
+    }
+  );
 
   test('handles size prop changes correctly', () => {
     const { getByTestId, queryByTestId, rerender } = renderRecipeCard({


### PR DESCRIPTION
## Summary

Fixes #480 — on Home the recipe titles in the horizontal carousels rendered **below** the outlined card border, overflowing the card.

Regression from the Expo SDK 55 → 56 upgrade (RN `0.83.2` → `0.85.3`): the `flex: 1` on the fixed-width `RecipeCard` collapsed its cross-size toward the cover height under RN 0.85's Yoga change, so the outlined `<Card>` border (an absolutely-positioned `height:100%` overlay) stopped wrapping the title. `react-native-paper` was untouched and already on the latest stable `5.15.3`, so a version bump does **not** fix it.

## Changes

- **`RecipeCard.tsx`** — remove `flex: 1` (and the now-redundant `justifyContent: 'flex-start'`) so each Surface sizes to its own content and the border wraps the title again.
- Reserve a **fixed two-line title block** (`minHeight = titleLines * lineHeight + 2 * padding.medium`, `titleLines` single-sourcing the `numberOfLines` clamp) so 1- and 2-line titles occupy the same vertical space → **every carousel card has the same height**, independent of sibling stretch.
- Line-height is sourced from `useTheme().fonts` (MD3 typescale) rather than hardcoded, so it tracks the typography scale; `titleVariant` is typed from paper's own `TextProps`.

## Tests

- TDD: added `RecipeCard` cases asserting the reserved title `lineHeight`/`minHeight` (short + long title, both sizes) and that the card no longer sets `flex`.
- Enriched the react-native-paper mock's `useTheme().fonts` with the MD3 `lineHeight` values the component now reads.

## Verification

- `npm run typecheck` ✅ · lint ✅ · prettier ✅ · `npm run test:unit` — 4044 passed ✅
- Pending manual on-device check: Home carousels (1-/2-line titles inside border, equal height) on Android + iOS, and the 2-column Search grid unaffected.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)