### PR TITLE
refactor(e2e): extract symmetric platform-specific flows (#481)

### DIFF
--- a/tests/e2e/E2E_TESTING.md
+++ b/tests/e2e/E2E_TESTING.md
@@ -1159,6 +1159,57 @@ enter key press can be flaky on CI simulators. Android continues to use
 different follow-up work (e.g. selecting an autocomplete item after the keyboard
 hides), keep those asymmetric platform blocks inline.
 
+**Sibling shared flows for symmetric platform splits**: the same
+extract-the-split-once pattern applies to other per-OS blocks that accomplish
+the same goal a different way. Wrap them via `runFlow`; do **not** re-inline the
+platform branches. Keep a block inline only when one OS does something the other
+lacks (asymmetric).
+
+- **`flows/dismissKeyboardVia.yaml`** (env `KEY`): plain keyboard dismiss where
+  iOS taps a non-`Done` return key — `hideKeyboard` on Android, tap `${KEY}` on
+  iOS. Use for `returnKeyType` variants like `Search` and `Return`
+  (`dismissModalKeyboard.yaml` remains the `Done` special case).
+
+  ```yaml
+  - runFlow:
+      file: '../../dismissKeyboardVia.yaml' # adjust relative path per caller depth
+      env:
+        KEY: 'Search'
+      label: 'Dismiss keyboard (platform-specific)'
+  ```
+
+- **`flows/confirmInputKeyboard.yaml`**: confirm/commit an input via the
+  keyboard — `pressKey: Enter` on Android, tap the `Done` return key on iOS.
+  Distinct from a plain dismiss, which does not submit on Android.
+
+  ```yaml
+  - runFlow:
+      file: '../../confirmInputKeyboard.yaml' # adjust relative path per caller depth
+      label: 'Confirm input via keyboard (platform-specific)'
+  ```
+
+- **`flows/waitForCheckSettle.yaml`** (env `CHECK_TEXT`): wait for a
+  radio/checkbox selection to settle. iOS animates the checked state in, so it
+  waits for `CHECK_TEXT` to appear (30s); Android updates instantly, so the flow
+  is a no-op there.
+
+  ```yaml
+  - runFlow:
+      file: '../../waitForCheckSettle.yaml' # adjust relative path per caller depth
+      env:
+        CHECK_TEXT: 'radio button, checked'
+      label: 'Wait for item to settle after check (platform-specific)'
+  ```
+
+- **`flows/recipe/adding/ocr/pickImageSource.yaml`**: pick the recipe-image
+  source in the open modal — tap the camera option on Android, the gallery
+  option on iOS (the simulator has no camera).
+
+- **`flows/recipe/adding/ocr/validateWithoutCropping.yaml`**: validate the
+  picked image without cropping — wraps the per-OS
+  `android/validateWithoutCropping.yaml` / `iOS/validateWithoutCropping.yaml`
+  and dispatches by platform.
+
 **Non-Modal Single-Line Inputs**: For inputs on regular screens (not in modals),
 `pressKey: enter` can still be used but may be replaced with the
 platform-specific approach if flakiness is observed.
@@ -1773,6 +1824,20 @@ automatically — see the [CI Retry Mechanism](#ci-retry-mechanism) section.
   inlined 40x across 30 case/flow files; extracted to one shared flow (mirrors
   `commitTypedSearch.yaml`). Asymmetric platform blocks that do extra per-OS
   follow-up work were left inline.
+- **Remaining symmetric platform splits wrapped** (follow-up to the above):
+  extracted the leftover per-OS blocks where both branches reach the same goal a
+  different way, replacing the inline copies with `runFlow`:
+  - `flows/dismissKeyboardVia.yaml` (env `KEY`) — `hideKeyboard` on Android /
+    tap a non-`Done` return key (`Search`, `Return`) on iOS; 5 inline blocks.
+  - `flows/confirmInputKeyboard.yaml` — `pressKey: Enter` on Android / tap
+    `Done` on iOS to commit an input; 7 inline blocks.
+  - `flows/waitForCheckSettle.yaml` (env `CHECK_TEXT`) — iOS waits for the
+    checked state to animate in, Android no-op; 13 inline blocks.
+  - `flows/recipe/adding/ocr/pickImageSource.yaml` — tap camera (Android) /
+    gallery (iOS) source in the image modal; 3 inline blocks.
+  - `flows/recipe/adding/ocr/validateWithoutCropping.yaml` — dispatches to the
+    per-OS crop-validate flows; 3 inline pairs. Asymmetric per-OS blocks (one OS
+    asserts/does something the other lacks) were left inline by design.
 - **Generic filter-accordion asserts**
   (`asserts/search/en/filters/accordions/`): the per-category/per-item assert
   files (`{cat}-all.yaml`, `{cat}-filtered.yaml`, `{cat}-hidden.yaml`, and ~120

--- a/tests/e2e/cases/duplicates-ingredient/1_ingredient_unique.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/1_ingredient_unique.yaml
@@ -64,18 +64,8 @@ tags:
     label: "Assert - Verify ingredient name appears in recipe"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: "ENTER"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Tap Done key to dismiss keyboard on iOS"
+    file: "../../flows/confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../flows/waitForKeyboardDismiss.yaml"
@@ -161,14 +151,10 @@ tags:
     label: "Action - Select Fish type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - scrollUntilVisible:
     element:
@@ -218,14 +204,10 @@ tags:
     label: "Action - Select february for seasonality"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "February"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "February"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - assertVisible:
     id: "RecipeValidation::ValidationQueue::Ingredient::ItemDialog::AddModal::ConfirmButton"

--- a/tests/e2e/cases/duplicates-ingredient/2_ingredient_fuzzy.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/2_ingredient_fuzzy.yaml
@@ -47,18 +47,8 @@ tags:
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: enter
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Tap Done key to validate the input on iOS"
+    file: "../../flows/confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../flows/waitForKeyboardDismiss.yaml"

--- a/tests/e2e/cases/duplicates-ingredient/4_ingredient_realtime_validation.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/4_ingredient_realtime_validation.yaml
@@ -113,14 +113,10 @@ tags:
     label: "Action - Select Cereal type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion"

--- a/tests/e2e/cases/duplicates-ingredient/6_ingredient_parenthetical_matching.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/6_ingredient_parenthetical_matching.yaml
@@ -26,14 +26,10 @@ tags:
     label: "Action - Select Condiment type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion"

--- a/tests/e2e/cases/duplicates-ingredient/7_ingredient_pick_from_database.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/7_ingredient_pick_from_database.yaml
@@ -46,18 +46,8 @@ tags:
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: "ENTER"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Tap Done key to validate the ingredient on iOS"
+    file: "../../flows/confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../flows/waitForKeyboardDismiss.yaml"

--- a/tests/e2e/cases/duplicates-ingredient/8_ingredient_database_picker_search.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/8_ingredient_database_picker_search.yaml
@@ -46,18 +46,8 @@ tags:
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: "ENTER"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Tap Done key to validate the ingredient on iOS"
+    file: "../../flows/confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../flows/waitForKeyboardDismiss.yaml"
@@ -87,19 +77,10 @@ tags:
     label: "Wait for list to filter after debounce"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - hideKeyboard:
-          label: "Dismiss keyboard on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Search"
-          label: "Tap Search key to dismiss keyboard on iOS"
+    file: "../../flows/dismissKeyboardVia.yaml"
+    env:
+      KEY: "Search"
+    label: "Dismiss keyboard (platform-specific)"
 
 - runFlow:
     file: "../../flows/waitForKeyboardDismiss.yaml"

--- a/tests/e2e/cases/ingredients-db/3_edit_existing.yaml
+++ b/tests/e2e/cases/ingredients-db/3_edit_existing.yaml
@@ -55,14 +55,10 @@ tags:
     label: "Action - Change type from vegetable to Bread"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "IngredientsSettings::ItemDialog::EditModal::TypeAccordion"
@@ -125,14 +121,10 @@ tags:
     label: "Action - Remove october from seasonality"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "January"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "January"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "IngredientsSettings::ItemDialog::EditModal::ConfirmButton"

--- a/tests/e2e/cases/ingredients-db/6_add_without_unit.yaml
+++ b/tests/e2e/cases/ingredients-db/6_add_without_unit.yaml
@@ -52,14 +52,10 @@ tags:
     label: "Action - Select cereal type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../flows/waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion"

--- a/tests/e2e/flows/confirmInputKeyboard.yaml
+++ b/tests/e2e/flows/confirmInputKeyboard.yaml
@@ -1,0 +1,20 @@
+appId: "com.recipedia"
+---
+# Confirm / commit the current text input via the keyboard, the platform way.
+# Android submits with the Enter key; iOS taps the "Done" return key. Both close
+# the keyboard and validate the field — distinct from a plain dismiss, which on
+# Android only calls `hideKeyboard` without submitting.
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - pressKey: Enter
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "Done"
+          label: "Tap Done key to validate the input on iOS"

--- a/tests/e2e/flows/dismissKeyboardVia.yaml
+++ b/tests/e2e/flows/dismissKeyboardVia.yaml
@@ -1,0 +1,27 @@
+appId: "com.recipedia"
+---
+# Dismiss the keyboard via a platform-specific action, parameterised by the iOS
+# return-key label. Android has a universal `hideKeyboard`; iOS has no such
+# command, so it taps the on-screen return key whose accessibility id matches
+# the input's `returnKeyType` (e.g. "Search", "Return", "Done").
+#
+# Pass the iOS key id via the env var KEY:
+#   - runFlow:
+#       file: "../../dismissKeyboardVia.yaml"
+#       env:
+#         KEY: "Search"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard:
+          label: "Dismiss keyboard on Android"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "${KEY}"
+          label: "Tap ${KEY} key to dismiss keyboard on iOS"

--- a/tests/e2e/flows/parameters/ingredients/addNewIngredient.yaml
+++ b/tests/e2e/flows/parameters/ingredients/addNewIngredient.yaml
@@ -46,14 +46,10 @@ appId: "com.recipedia"
     label: "Select legumes type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - scrollUntilVisible:
     element:

--- a/tests/e2e/flows/parameters/ingredients/createTestIngredient.yaml
+++ b/tests/e2e/flows/parameters/ingredients/createTestIngredient.yaml
@@ -47,14 +47,10 @@ appId: "com.recipedia"
     label: "Action - Select vegetable type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - scrollUntilVisible:
     element:
@@ -117,14 +113,10 @@ appId: "com.recipedia"
     label: "Action - Add december to seasonality"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "December"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "December"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "IngredientsSettings::ItemDialog::AddModal::ConfirmButton"

--- a/tests/e2e/flows/parameters/searchInSettingsList.yaml
+++ b/tests/e2e/flows/parameters/searchInSettingsList.yaml
@@ -20,19 +20,10 @@ appId: "com.recipedia"
     label: "Wait for list to filter"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - hideKeyboard:
-          label: "Dismiss keyboard on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Search"
-          label: "Tap Search key to validates the search"
+    file: "../../flows/dismissKeyboardVia.yaml"
+    env:
+      KEY: "Search"
+    label: "Dismiss keyboard (platform-specific)"
 
 - runFlow:
     file: "../../flows/waitForKeyboardDismiss.yaml"

--- a/tests/e2e/flows/recipe/adding/en/addRecipeImage.yaml
+++ b/tests/e2e/flows/recipe/adding/en/addRecipeImage.yaml
@@ -9,19 +9,8 @@ appId: "com.recipedia"
     label: "Check camera modal is displayed"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - tapOn:
-          id: "Modal::Camera::RoundButton"
-          label: "Select camera option on Android"
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Modal::Gallery::RoundButton"
-          label: "Select gallery option on iOS (simulator doesn't support camera)"
+    file: "../ocr/pickImageSource.yaml"
+    label: "Select image source (platform-specific)"
 
 - runFlow:
     file: "../ocr/android/takePhoto.yaml"
@@ -43,15 +32,8 @@ appId: "com.recipedia"
     label: "Select camera picture"
 
 - runFlow:
-    file: "../ocr/android/validateWithoutCropping.yaml"
-    when:
-      platform: Android
-    label: "Validate without cropping on Android"
-- runFlow:
-    file: "../ocr/iOS/validateWithoutCropping.yaml"
-    when:
-      platform: iOS
-    label: "Validate without cropping on iOS"
+    file: "../ocr/validateWithoutCropping.yaml"
+    label: "Validate without cropping (platform-specific)"
 
 - extendedWaitUntil:
     notVisible:

--- a/tests/e2e/flows/recipe/adding/fr/addRecipeImage.yaml
+++ b/tests/e2e/flows/recipe/adding/fr/addRecipeImage.yaml
@@ -8,19 +8,8 @@ appId: "com.recipedia"
     label: "Check camera modal is displayed in French"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - tapOn:
-          id: "Modal::Camera::RoundButton"
-          label: "Select camera option on Android"
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Modal::Gallery::RoundButton"
-          label: "Select gallery option on iOS (simulator doesn't support camera)"
+    file: ../ocr/pickImageSource.yaml
+    label: "Select image source (platform-specific)"
 
 - runFlow:
     file: ../ocr/android/takePhoto.yaml
@@ -38,15 +27,8 @@ appId: "com.recipedia"
     label: "Select camera picture"
 
 - runFlow:
-    file: ../ocr/android/validateWithoutCropping.yaml
-    when:
-      platform: Android
-    label: "Validate without cropping on Android"
-- runFlow:
-    file: ../ocr/iOS/validateWithoutCropping.yaml
-    when:
-      platform: iOS
-    label: "Validate without cropping on iOS"
+    file: ../ocr/validateWithoutCropping.yaml
+    label: "Validate without cropping (platform-specific)"
 
 - extendedWaitUntil:
     notVisible:

--- a/tests/e2e/flows/recipe/adding/manual/en/addAiguillettes.yaml
+++ b/tests/e2e/flows/recipe/adding/manual/en/addAiguillettes.yaml
@@ -93,18 +93,8 @@ appId: "com.recipedia"
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: enter
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Tap Done key to dismiss keyboard on iOS"
+    file: "../../../../confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../../../waitForKeyboardDismiss.yaml"
@@ -441,18 +431,8 @@ appId: "com.recipedia"
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: "ENTER"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Tap Done key to dismiss keyboard on iOS"
+    file: "../../../../confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../../../waitForKeyboardDismiss.yaml"

--- a/tests/e2e/flows/recipe/adding/ocr/gallery/ocrImage.yaml
+++ b/tests/e2e/flows/recipe/adding/ocr/gallery/ocrImage.yaml
@@ -40,13 +40,8 @@ appId: "com.recipedia"
     label: "Select first image from app modal"
 
 - runFlow:
-    file: ../android/validateWithoutCropping.yaml
-    when:
-      platform: Android
-- runFlow:
-    file: ../iOS/validateWithoutCropping.yaml
-    when:
-      platform: iOS
+    file: ../validateWithoutCropping.yaml
+    label: "Validate without cropping (platform-specific)"
 
 - evalScript: ${output.modalImageCounter = output.modalImageCounter + 1}
 

--- a/tests/e2e/flows/recipe/adding/ocr/pickImageSource.yaml
+++ b/tests/e2e/flows/recipe/adding/ocr/pickImageSource.yaml
@@ -1,0 +1,21 @@
+appId: "com.recipedia"
+---
+# Pick the recipe-image source in the open camera/gallery modal. Android taps the
+# camera option; iOS taps the gallery option because the simulator has no camera.
+# Both open the OS image picker that follows.
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: "Modal::Camera::RoundButton"
+          label: "Select camera option on Android"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "Modal::Gallery::RoundButton"
+          label: "Select gallery option on iOS (simulator doesn't support camera)"

--- a/tests/e2e/flows/recipe/adding/ocr/validateWithoutCropping.yaml
+++ b/tests/e2e/flows/recipe/adding/ocr/validateWithoutCropping.yaml
@@ -1,0 +1,17 @@
+appId: "com.recipedia"
+---
+# Validate the picked image without cropping, the platform way. Android confirms
+# the native crop menu; iOS taps the "Choose" button of the photo picker. Both
+# commit the image and dismiss the picker.
+
+- runFlow:
+    file: "android/validateWithoutCropping.yaml"
+    when:
+      platform: Android
+    label: "Validate without cropping on Android"
+
+- runFlow:
+    file: "iOS/validateWithoutCropping.yaml"
+    when:
+      platform: iOS
+    label: "Validate without cropping on iOS"

--- a/tests/e2e/flows/recipe/adding/web/submitUrlWithAuth.yaml
+++ b/tests/e2e/flows/recipe/adding/web/submitUrlWithAuth.yaml
@@ -51,19 +51,10 @@ appId: "com.recipedia"
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - hideKeyboard:
-          label: "Dismiss keyboard on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Return"
-          label: "Tap Return key to dismiss keyboard on iOS"
+    file: "../../../dismissKeyboardVia.yaml"
+    env:
+      KEY: "Return"
+    label: "Dismiss keyboard (platform-specific)"
 
 - runFlow:
     file: "../../../waitForKeyboardDismiss.yaml"
@@ -83,19 +74,10 @@ appId: "com.recipedia"
     label: "Wait for keyboard animation"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - hideKeyboard:
-          label: "Dismiss keyboard on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Return"
-          label: "Tap Return key to dismiss keyboard on iOS"
+    file: "../../../dismissKeyboardVia.yaml"
+    env:
+      KEY: "Return"
+    label: "Dismiss keyboard (platform-specific)"
 
 - runFlow:
     file: "../../../waitForKeyboardDismiss.yaml"

--- a/tests/e2e/flows/recipe/ingredients/confirmAddNewIngredient.yaml
+++ b/tests/e2e/flows/recipe/ingredients/confirmAddNewIngredient.yaml
@@ -39,14 +39,10 @@ appId: "com.recipedia"
     label: "Select Baking type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - scrollUntilVisible:
     element:
@@ -94,14 +90,10 @@ appId: "com.recipedia"
     label: "Select may for seasonality"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "May"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "May"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - tapOn:
     id: "RecipeValidation::ValidationQueue::Ingredient::ItemDialog::AddModal::SeasonalityCalendar"

--- a/tests/e2e/flows/recipe/ingredients/pickIngredientFromDatabase.yaml
+++ b/tests/e2e/flows/recipe/ingredients/pickIngredientFromDatabase.yaml
@@ -24,19 +24,10 @@ appId: "com.recipedia"
     label: "Wait for list to filter"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - hideKeyboard:
-          label: "Dismiss keyboard on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Search"
-          label: "Tap Search key to dismiss keyboard on iOS"
+    file: "../../dismissKeyboardVia.yaml"
+    env:
+      KEY: "Search"
+    label: "Dismiss keyboard (platform-specific)"
 
 - runFlow:
     file: "../../waitForKeyboardDismiss.yaml"

--- a/tests/e2e/flows/recipe/shared/openImageModalAndPick.yaml
+++ b/tests/e2e/flows/recipe/shared/openImageModalAndPick.yaml
@@ -9,19 +9,8 @@ appId: "com.recipedia"
     label: "Check camera modal is displayed"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - tapOn:
-          id: "Modal::Camera::RoundButton"
-          label: "Select camera option on Android"
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Modal::Gallery::RoundButton"
-          label: "Select gallery option on iOS (simulator doesn't support camera)"
+    file: "../adding/ocr/pickImageSource.yaml"
+    label: "Select image source (platform-specific)"
 
 - runFlow:
     file: "../adding/ocr/android/takePhoto.yaml"

--- a/tests/e2e/flows/recipe/tags/addTagToRecipeInput.yaml
+++ b/tests/e2e/flows/recipe/tags/addTagToRecipeInput.yaml
@@ -49,18 +49,8 @@ appId: "com.recipedia"
     label: "Verify tag is filled properly"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - pressKey: enter
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Done"
-          label: "Close keyboard on iOS"
+    file: "../../confirmInputKeyboard.yaml"
+    label: "Confirm input via keyboard (platform-specific)"
 
 - runFlow:
     file: "../../waitForKeyboardDismiss.yaml"

--- a/tests/e2e/flows/recipe/tags/pickTagFromDatabase.yaml
+++ b/tests/e2e/flows/recipe/tags/pickTagFromDatabase.yaml
@@ -20,19 +20,10 @@ appId: "com.recipedia"
     label: "Wait for list to filter"
 
 - runFlow:
-    when:
-      platform: Android
-    commands:
-      - hideKeyboard:
-          label: "Dismiss keyboard on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - tapOn:
-          id: "Search"
-          label: "Tap Done key to dismiss keyboard on iOS"
+    file: "../../dismissKeyboardVia.yaml"
+    env:
+      KEY: "Search"
+    label: "Dismiss keyboard (platform-specific)"
 
 - tapOn:
     id: "RecipeValidation::ValidationQueue::Tag::DatabasePicker::Item::0"

--- a/tests/e2e/flows/recipe/validation/validateOneIngredient.yaml
+++ b/tests/e2e/flows/recipe/validation/validateOneIngredient.yaml
@@ -43,14 +43,10 @@ appId: "com.recipedia"
     label: "Select Baking ingredient type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for item to be checked on iOS"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - scrollUntilVisible:
     element:

--- a/tests/e2e/flows/recipe/validation/validateOneIngredientReviewItem.yaml
+++ b/tests/e2e/flows/recipe/validation/validateOneIngredientReviewItem.yaml
@@ -48,14 +48,10 @@ appId: "com.recipedia"
     label: "Select Cheese type"
 
 - runFlow:
-    when:
-      platform: iOS
-    commands:
-      - extendedWaitUntil:
-          visible:
-            text: "radio button, checked"
-          timeout: 30000
-          label: "Wait for checked state (iOS)"
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
 
 - scrollUntilVisible:
     element:

--- a/tests/e2e/flows/waitForCheckSettle.yaml
+++ b/tests/e2e/flows/waitForCheckSettle.yaml
@@ -1,0 +1,21 @@
+appId: "com.recipedia"
+---
+# Wait for a selection to settle after tapping a radio/checkbox item. iOS animates
+# the checked state in, so we wait for its accessibility text to appear; Android
+# updates instantly and needs no wait, so this flow is a no-op there.
+#
+# Pass the text that marks the settled state via the env var CHECK_TEXT:
+#   - runFlow:
+#       file: "../../waitForCheckSettle.yaml"
+#       env:
+#         CHECK_TEXT: "radio button, checked"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - extendedWaitUntil:
+          visible:
+            text: "${CHECK_TEXT}"
+          timeout: 30000
+          label: "Wait for item to be checked on iOS"


### PR DESCRIPTION
## What

Dedup repeated Android/iOS platform-branch idioms scattered across ~24 Maestro flows into shared, parameterized subflows.

New shared flows (`tests/e2e/flows/`):

| Flow | Behavior |
|---|---|
| `confirmInputKeyboard.yaml` | submit + close — Android `pressKey Enter` / iOS tap `Done` |
| `dismissKeyboardVia.yaml` (env `KEY`) | plain dismiss — Android `hideKeyboard` / iOS tap return key |
| `waitForCheckSettle.yaml` (env `CHECK_TEXT`) | iOS check-settle wait / Android no-op |
| `pickImageSource.yaml` | Android camera / iOS gallery |
| `validateWithoutCropping.yaml` | dispatch to `android/`·`iOS/` crop subfiles |

## Why

- Same 4-branch platform idiom was copy-pasted ~20 places.
- The old inline block labeled "dismiss keyboard on iOS" actually **submitted** on Android (`pressKey Enter`). Split into **confirm** (submits) vs **dismiss** (no submit) to match real platform behavior and fix the mislabel.

## Notes

- **Net −150 lines**, no behavior change — pure structural dedup.
- Relative paths resolve correctly from every caller depth; `pressKey` casing is Maestro-case-insensitive (repo already mixes ENTER/enter/Enter).
- Composite branches that bundle a dismiss with follow-up asserts/taps (`addAiguillettes`, `createRecipeWithIngredient`, `createMinimalRecipeWithTag`, `setRecipePersons`) left inline intentionally — extracting would need param'd command lists, net-negative readability.
- Two clean misses folded in during review: `validateOneIngredientReviewItem.yaml` → `waitForCheckSettle`, `searchInSettingsList.yaml` → `dismissKeyboardVia KEY=Search`.
- `E2E_TESTING.md` documents the new shared flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)