### PR TITLE
refactor(types): fix failing knip dead-code gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Guidance for AI coding agents in this repo — Claude Code, Cursor, and any tool
 - `npm run lint:fix` — auto-fix lint
 - `npm run format` — Prettier
 - `npm run typecheck` — TypeScript
-- `npm run knip` — dead-code check (unused files/exports/types); CI-gated, config in `knip.json`
+- `npm run knip:check` — dead-code check (unused files/exports/types); CI-gated, config in `knip.json`
 - `npm run security:audit` — security audit
 
 ### Build

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -12,7 +12,7 @@
 
 import { useSyncExternalStore } from 'react';
 import { RecipeDatabase } from '@utils/RecipeDatabase';
-import { menuTableElement, recipeTableElement } from '@customTypes/DatabaseElementTypes';
+import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
 
 /**
  * Provides reactive menu data and all menu/purchase operations.
@@ -74,5 +74,3 @@ export function useMenu() {
     clearPurchased,
   };
 }
-
-export type { menuTableElement };

--- a/src/utils/RecipeFormHelpers.tsx
+++ b/src/utils/RecipeFormHelpers.tsx
@@ -33,16 +33,7 @@ import { RecipeNumberProps } from '@components/organisms/RecipeNumber';
 import { RecipeNutritionProps } from '@components/organisms/RecipeNutrition';
 import { RecipeSourceUrlProps } from '@components/molecules/RecipeSourceUrl';
 
-export type {
-  RecipeMode,
-  BaseRecipeProp,
-  ReadRecipeProp,
-  EditRecipeProp,
-  AddManuallyProp,
-  AddFromPicProp,
-  AddFromScrapeProp,
-  RecipePropType,
-} from '@customTypes/RecipeNavigationTypes';
+export type { RecipePropType } from '@customTypes/RecipeNavigationTypes';
 
 /**
  * Generic configuration type mapping all recipe states to a value type


### PR DESCRIPTION
## Summary

Restore green `knip:check` gate + fix a stale docs reference.

## Changes

- **`refactor(types)`** — `RecipeFormHelpers.tsx` and `useMenu.ts` re-exported navigation/db types (`RecipeMode`, `BaseRecipeProp`, `ReadRecipeProp`, `EditRecipeProp`, `AddManuallyProp`, `AddFromPicProp`, `AddFromScrapeProp`, `menuTableElement`) that are always imported directly from their source modules, never via these re-exports. `knip:check` flagged all 8 as unused exports. Removed them; kept `RecipePropType` (still consumed). Pruned the now-unused `menuTableElement` import in `useMenu.ts`.
- **`docs(agents)`** — `AGENTS.md` referenced `npm run knip`, which does not exist; corrected to `knip:check` to match `package.json`.

## Verification

- `npm run knip:check` ✅
- `npm run typecheck` ✅
- `eslint` on touched files ✅

## Note — security audit

`npm run security:audit` (moderate gate) still fails, but **out of scope here by decision**: all 61 vulns amplify from 3 leaf advisories (`brace-expansion`, `fast-uri`, `tar`), all dev/build-tooling DoS with **no patched version published upstream** — unfixable without MAJOR downgrades. CI's security job gates at `--audit-level=critical` (0 critical → already green). Revisit when upstream patches ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)