### PR TITLE
test(e2e): close E2E coverage gaps — smoke, seasonality, Menu

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -247,6 +247,37 @@ jobs:
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
+  # Release build seeded with the *production* dataset (`production-maestro`
+  # profile). Runs only the smoke suite so each build's core flows are validated
+  # against production data + release optimizations — the one gap the test-dataset
+  # suites can't cover. Needs the prod dataset, so no fork fallback; skipped for
+  # dependabot.
+  build-android-production-maestro:
+    name: Build Android APK (Production Smoke)
+    if: needs.install-and-doctor.outputs.is_internal == 'true' && github.actor != 'dependabot[bot]'
+    needs: install-and-doctor
+    uses: ./.github/workflows/build-app.yml
+    with:
+      platform: android
+      build-profile: production-maestro
+      artifact-name: build-apk-production-maestro
+      app-filename: recipedia-production-maestro.apk
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+  build-ios-production-maestro:
+    name: Build iOS App (Production Smoke)
+    if: needs.install-and-doctor.outputs.is_internal == 'true' && github.actor != 'dependabot[bot]'
+    needs: install-and-doctor
+    uses: ./.github/workflows/build-app.yml
+    with:
+      platform: ios
+      build-profile: production-maestro
+      artifact-name: build-ios-app-production-maestro
+      app-filename: Recipedia.app
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
   e2e-tests-android:
     name: E2E Tests (Android)
     needs: [ build-android, install-and-doctor ]
@@ -287,11 +318,35 @@ jobs:
       QUITOQUE_USERNAME: ${{ secrets.QUITOQUE_USERNAME }}
       QUITOQUE_PASSWORD: ${{ secrets.QUITOQUE_PASSWORD }}
 
+  # Smoke suite against the production-dataset release builds (both platforms).
+  # Runs as soon as its build is ready — in parallel with the main E2E matrix —
+  # so a broken build fails fast. (Unlike the performance job, which is delayed to
+  # yield runners; smoke's whole value is early feedback.)
+  e2e-tests-android-production-maestro:
+    name: E2E Smoke Android (Production)
+    if: needs.install-and-doctor.outputs.is_internal == 'true' && github.actor != 'dependabot[bot]'
+    needs: [ build-android-production-maestro, install-and-doctor ]
+    uses: ./.github/workflows/e2e-maestro.yml
+    with:
+      platform: android
+      app-artifact: build-apk-production-maestro
+      suites: '["smoke"]'
+
+  e2e-tests-ios-production-maestro:
+    name: E2E Smoke iOS (Production)
+    if: needs.install-and-doctor.outputs.is_internal == 'true' && github.actor != 'dependabot[bot]'
+    needs: [ build-ios-production-maestro, install-and-doctor ]
+    uses: ./.github/workflows/e2e-maestro.yml
+    with:
+      platform: ios
+      app-artifact: build-ios-app-production-maestro
+      suites: '["smoke"]'
+
   merge-test-artifacts:
     name: Merge E2E Test Artifacts
     if: always()
     runs-on: ubuntu-latest
-    needs: [ e2e-tests-android, e2e-tests-android-performance, e2e-tests-ios ]
+    needs: [ e2e-tests-android, e2e-tests-android-performance, e2e-tests-ios, e2e-tests-android-production-maestro, e2e-tests-ios-production-maestro ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/app.config.ts
+++ b/app.config.ts
@@ -28,25 +28,32 @@ function versionToCode(version: string): number {
  * simulator) keeps the plain `baseAppId`, identical to Android, so the E2E flows
  * can launch a single shared bundle id.
  *
- * The store build is detected via `EXPO_PUBLIC_DATASET_TYPE === 'production'`,
- * which only the `production` EAS profile sets in its `env` block. This is used
- * instead of `EAS_BUILD_PROFILE` because EAS only injects `EAS_BUILD_PROFILE`
- * into the build job, whereas the bundle id is resolved earlier, when `eas build`
- * evaluates this config to set up credentials — before the job env exists. A
- * build-profile `env` var is applied at config-evaluation time, so it resolves
- * the same bundle id for both local (`eas build --local`) and cloud builds.
+ * The store build is the one that ships the production dataset
+ * (`EXPO_PUBLIC_DATASET_TYPE === 'production'`) and is not an automation build.
+ * Every Maestro/E2E profile sets `EXPO_PUBLIC_DISABLE_ANIMATIONS === 'true'` and
+ * the store `production` profile does not, so that flag discriminates the store
+ * build from the `production-maestro` E2E build (which seeds production data yet
+ * must keep the shared `com.recipedia` id so Maestro can launch it on iOS). This
+ * reuses two existing profile `env` vars instead of adding a dedicated store flag;
+ * the trade-off is that it relies on the invariant that store builds keep
+ * animations on and automation builds turn them off. `EAS_BUILD_PROFILE` can't be
+ * used because EAS only injects it into the build job, after the bundle id is
+ * resolved for credentials. See `tests/e2e/E2E_TESTING.md` → "Production Smoke
+ * Build" for the full rationale.
  *
  * @param baseAppId - The platform-agnostic application id (e.g. `com.recipedia`).
- * @param env - Environment variables to read the dataset type from. Defaults to
- *   `process.env`.
- * @returns The store bundle id (`<baseAppId>.ios`) for production builds,
- *   otherwise `baseAppId`.
+ * @param env - Environment variables to read the dataset type and animation flag
+ *   from. Defaults to `process.env`.
+ * @returns The store bundle id (`<baseAppId>.ios`) for the store build, otherwise
+ *   `baseAppId`.
  */
 export function resolveIosBundleId(
     baseAppId: string,
     env: Record<string, string | undefined> = process.env,
 ): string {
-    const isStoreBuild = env.EXPO_PUBLIC_DATASET_TYPE === 'production';
+    const usesProductionDataset = env.EXPO_PUBLIC_DATASET_TYPE === 'production';
+    const isAutomationBuild = env.EXPO_PUBLIC_DISABLE_ANIMATIONS === 'true';
+    const isStoreBuild = usesProductionDataset && !isAutomationBuild;
     return isStoreBuild ? `${baseAppId}.ios` : baseAppId;
 }
 
@@ -54,7 +61,8 @@ const configuredName = toSlug(pkg.name);
 const appId = `com.${toIdentifierSegment(pkg.name)}`;
 
 // Maestro E2E flows hardcode a single `com.recipedia` shared across platforms,
-// so only the store build carries the `.ios` suffix. See `resolveIosBundleId`.
+// so only the store build (production dataset, animations enabled) carries the
+// `.ios` suffix. See `resolveIosBundleId`.
 const iosAppId = resolveIosBundleId(appId);
 
 const primaryColorLight = '#006D38';

--- a/eas.json
+++ b/eas.json
@@ -46,6 +46,13 @@
         "EXPO_PUBLIC_DATASET_TYPE": "performance"
       }
     },
+    "production-maestro": {
+      "extends": "maestro",
+      "env": {
+        "NODE_OPTIONS": "--max-old-space-size=4096",
+        "EXPO_PUBLIC_DATASET_TYPE": "production"
+      }
+    },
     "production": {
       "autoIncrement": true,
       "distribution": "store",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build:prod:ios": "eas build --local --profile production --platform ios --non-interactive",
     "build:perf:android": "eas build --local --profile performance --platform android --non-interactive",
     "build:perf:ios": "eas build --local --profile performance --platform ios --non-interactive",
+    "build:production-maestro:android": "eas build --local --profile production-maestro --platform android --non-interactive",
+    "build:production-maestro:ios": "eas build --local --profile production-maestro --platform ios --non-interactive",
     "build:clean": "rm -rf android/app/build ios/build .expo",
     "install:android": "adb install *.apk && rm -f *.apk",
     "install:ios": "xcrun simctl install booted *.app",

--- a/tests/e2e/E2E_TESTING.md
+++ b/tests/e2e/E2E_TESTING.md
@@ -50,6 +50,13 @@ maestro test cases/search/
 Tests are organized into **test suites**, each with its own configuration file
 at the root of `tests/e2e/`:
 
+- **smoke.yaml** - Minimal core-flow sanity: launch, navigate all bottom tabs
+  (incl. Menu), open a recipe, search. Fast guard that each build doesn't crash
+  on the primary journeys; assertions are shallow, locale-agnostic and
+  dataset-agnostic (id-only, no assumptions about seeded recipe names). Runs on
+  the **production-dataset** release build (`production-maestro` EAS profile) so
+  it validates the production seed data + release optimizations — see
+  [Production smoke build](#production-smoke-build)
 - **app-init.yaml** - App launch, onboarding, FAB menu
 - **search.yaml** - Search bar behaviour (open/close, scroll, results, typing)
 - **search-filters.yaml** - Filter page and filter chip behaviour
@@ -160,6 +167,8 @@ flow files in the parent directory are used for local runs.
 
 **Available Suite Configurations**:
 
+- `smoke.yaml` - Minimal core-flow smoke tests (launch, tab nav, view recipe,
+  search)
 - `app-init.yaml` - Application initialization tests
 - `search.yaml` - Search bar tests
 - `search-filters.yaml` - Filter page and filter chip tests
@@ -1561,6 +1570,52 @@ breaking the run and losing state.
 - The committed test YAML MAY keep `launchApp` for CI — the release **test
   build** handles it correctly (unlike the local dev build). Keep it in the
   file; only the local reload is handed to the user.
+
+## Production Smoke Build
+
+Most suites run on the **test-dataset** release build (`maestro` EAS profile).
+The `smoke` suite instead runs on a **production-dataset** release build so each
+CI run also validates that the app boots and its core flows work against the
+real production seed data under release optimizations — the one thing the
+test-dataset suites can't catch.
+
+- **Profile**: `production-maestro` (in `eas.json`) extends `maestro`
+  (installable APK / iOS simulator, `assembleRelease` / Release config — same
+  R8/proguard/ Hermes/shrink as the store build) and overrides
+  `EXPO_PUBLIC_DATASET_TYPE=production`. It inherits
+  `EXPO_PUBLIC_DISABLE_ANIMATIONS=true` from `maestro` via `extends` (no need to
+  re-declare — same as `performance`; this profile is unsigned, so its bundle id
+  resolves at prebuild time with the merged env). `resolveIosBundleId` treats a
+  production-dataset build with animations disabled as **not** a store build, so
+  it keeps the shared `com.recipedia` id (the real store `production` profile
+  ships the production dataset with animations enabled and resolves to
+  `com.recipedia.ios`). No dedicated flag is introduced — the gate reuses two
+  existing profile `env` vars, relying on the invariant that store builds keep
+  animations on and automation builds turn them off. Because
+  `production-maestro` only overrides the dataset (identical release
+  optimizations, same production seed data), the smoke build exercises the same
+  app code as the store build.
+- **Why not the literal store build**: the store artifacts are an Android AAB
+  (not emulator-installable) and an iOS **device** IPA — neither is
+  Maestro-runnable on a CI runner. `production-maestro` reproduces every
+  release-only and prod-dataset crash surface; only AAB packaging + store
+  signing differ, and those are covered by the publish step.
+- **CI jobs** (`build-test.yml`): `build-android-production-maestro` /
+  `build-ios-production-maestro` build the profile, then
+  `e2e-tests-android-production-maestro` / `e2e-tests-ios-production-maestro`
+  run `suites: '["smoke"]'`. Internal-only (needs the prod dataset, so no fork
+  fallback) and skipped for dependabot.
+- **Keep smoke dataset-agnostic**: because the production seed data differs from
+  the test dataset, smoke flows must not assume specific recipe names — target
+  ids/indices (`RecipeCards::1::Cover`) and the suggestion dropdown, never a
+  typed recipe title. This is why smoke has its own cases rather than reusing
+  the test-dataset suites: `recipe-readonly` opens "Chicken Tacos" (absent from
+  the production data) and `app-init`'s `assertHomeScreen` requires the
+  season/grain/ tag recommendation carousels, which depend on the current month
+  and the dataset's variety. Smoke still **reuses** the shared, dataset-agnostic
+  asserts where it can — `1_core_navigation` composes `assertSearchScreenUI`,
+  `assertMenuEmpty`, `assertShoppingEmpty` and `assertAppearanceSection` rather
+  than re-inlining them.
 
 ## CI Retry Mechanism
 

--- a/tests/e2e/VISUAL_TESTING_EVALUATION.md
+++ b/tests/e2e/VISUAL_TESTING_EVALUATION.md
@@ -1,0 +1,75 @@
+# Maestro Visual Testing — Evaluation
+
+Evaluation of Maestro's visual/screenshot regression testing for Recipedia,
+answering issue #323 item 3. **Decision: defer.**
+
+## Environment
+
+- **Maestro:** `2.6.0` (pinned in `.github/workflows/e2e-maestro.yml`).
+- **CI model:** E2E runs on **local emulators/simulators inside GitHub Actions**
+  — Android on `ubuntu-latest`, iOS on `macos-15`. Not Maestro Cloud.
+- **Current screenshot usage:** none (`takeScreenshot` / `assertScreenshot` /
+  `assertWithAI` absent from `tests/e2e/`).
+
+## What Maestro 2.6.0 offers
+
+### 1. `assertScreenshot` — pixel-diff (local, free)
+
+- `assertScreenshot: file.png`, or object form with `path`, `cropOn: { id }`,
+  `thresholdPercentage` (default 95.0), `label`.
+- Compares against a reference PNG **committed alongside the flow**. Fails if
+  similarity < threshold or the reference is missing.
+- Baseline is created manually (`takeScreenshot`, commit the PNG); updating a
+  baseline = re-capture and re-commit. **No managed baseline store — the repo is
+  the store.**
+- Runs fully locally; fits the existing pipeline mechanically.
+
+### 2. `assertWithAI` / `assertNoDefectsWithAI` — LLM visual checks (Cloud-gated)
+
+- Natural-language assertion / automatic defect scan (cut-off, overlapping,
+  mis-centered UI).
+- **Requires Maestro Cloud auth** — screenshots are uploaded to Maestro-managed
+  LLM providers. Bring-your-own-key vars are deprecated.
+- Explicitly experimental; `optional` defaults to `true`, so results are
+  non-deterministic by design and weak as a hard gate.
+
+## Repo-specific risks
+
+Recipedia is a near-worst-case fit for strict pixel baselines:
+
+- **Two platforms × two themes:** Android + iOS, light + dark
+  (`cases/settings/1_dark_mode.yaml`) → ≥4 baseline sets per screen. Font
+  rendering differs across OS/renderer, so one threshold rarely holds for both.
+- **i18n en/fr** (`cases/settings/6_language_switch.yaml`): every localized
+  screen needs per-locale baselines; text length shifts layout → doubles the
+  matrix again.
+- **Non-deterministic content (the real blocker):**
+  - **Season filter** (`cases/settings/2_season_filter_toggle.yaml`) is
+    date/season-dependent — the same screen renders differently by run date.
+    Seasonality reads the real system clock (`FilterFunctions.tsx`
+    `isRecipeInCurrentSeason`), so there is no test-clock override.
+  - **Menu / dynamic dates** and recipe-list ordering drift over time with no
+    code change.
+- **Baseline maintenance cost:** matrix ≈ screens × 2 platforms × 2 themes × 2
+  locales. Every intentional UI tweak forces a bulk re-capture + re-commit of
+  PNG blobs in git. High churn, high noise.
+
+## Recommendation: defer
+
+Do **not** adopt broad screenshot regression now, and do **not** adopt the AI
+commands in this pipeline.
+
+- **Reject `assertWithAI` / `assertNoDefectsWithAI`:** require Cloud coupling,
+  experimental/non-deterministic, upload screenshots to a third party, cannot
+  serve as a hard gate.
+- **Reject broad `assertScreenshot` baselining:** the platform × theme × locale
+  matrix plus season/date non-determinism makes full-screen baselines a
+  flakiness and maintenance sink.
+- **Optional narrow pilot:** `assertScreenshot` with `cropOn` on a **static,
+  deterministic, locale-invariant** region only (e.g. an icon/logo, an
+  empty-state illustration, a single control) — never a full screen containing
+  dates, season-filtered lists, or translated copy. Platform-scoped, generous
+  threshold. This is the only variant that fits the current local-emulator CI.
+
+Revisit only if a concrete stable-UI regression need arises, scoped via
+`cropOn`.

--- a/tests/e2e/asserts/bottomtabs/en/assertBottomTabs.yaml
+++ b/tests/e2e/asserts/bottomtabs/en/assertBottomTabs.yaml
@@ -9,6 +9,10 @@ appId: "com.recipedia"
     text: "Search"
     label: "Search tab is displayed"
 - assertVisible:
+    id: "BottomTabs::Menu"
+    text: "Menu"
+    label: "Menu tab is displayed"
+- assertVisible:
     id: "BottomTabs::Shopping"
     text: "Shopping"
     label: "Shopping tab is displayed"

--- a/tests/e2e/asserts/bottomtabs/fr/assertBottomTabs.yaml
+++ b/tests/e2e/asserts/bottomtabs/fr/assertBottomTabs.yaml
@@ -9,6 +9,10 @@ appId: "com.recipedia"
     text: "Recherche"
     label: "Search tab is displayed in French"
 - assertVisible:
+    id: "BottomTabs::Menu"
+    text: "Menu"
+    label: "Menu tab is displayed in French"
+- assertVisible:
     id: "BottomTabs::Shopping"
     text: "Courses"
     label: "Shopping tab is displayed in French"

--- a/tests/e2e/cases/app-init/2_bottom_tabs.yaml
+++ b/tests/e2e/cases/app-init/2_bottom_tabs.yaml
@@ -21,7 +21,18 @@ tags:
     id: "BottomTabs::Home"
     label: "Action - Navigate back to Home screen"
 
-# TODO Menu
+# Check Menu Screen
+- tapOn:
+    id: "BottomTabs::Menu"
+    label: "Action - Navigate to Menu screen"
+
+- runFlow:
+    file: "../../asserts/menu/en/assertMenuEmpty.yaml"
+    label: "Assert - Verify Menu screen is displayed correctly"
+
+- tapOn:
+    id: "BottomTabs::Home"
+    label: "Action - Navigate back to Home screen"
 
 # Check Shopping Screen
 - tapOn:

--- a/tests/e2e/cases/ingredients-db/7_seasonal_recipe_stays_visible.yaml
+++ b/tests/e2e/cases/ingredients-db/7_seasonal_recipe_stays_visible.yaml
@@ -1,0 +1,45 @@
+name: "7 - Seasonal Recipe Stays Visible Flow"
+appId: "com.recipedia"
+tags:
+  - database
+  - ingredients-db
+---
+- runFlow:
+    file: "../../flows/parameters/ingredients/navigateToIngredientsSettings.yaml"
+    label: "Action - Navigate to Ingredients Settings"
+
+- runFlow:
+    file: "../../flows/parameters/ingredients/addSeasonalIngredient.yaml"
+    label: "Action - Create ingredient RecipeIngredient in season all year"
+
+- runFlow:
+    file: "../../flows/parameters/ingredients/returnToHome.yaml"
+    label: "Action - Return to Home screen"
+
+- runFlow:
+    file: "../../flows/recipe/adding/manual/en/createRecipeWithIngredient.yaml"
+    label: "Action - Create minimal recipe with the all-year ingredient"
+
+- runFlow:
+    file: "../../flows/recipe/verifyIngredientInRecipe.yaml"
+    label: "Assert - Verify ingredient appears in recipe"
+
+- tapOn:
+    id: "SearchScreen::FiltersSelection::0::Chip"
+    label: "Action - Remove name filter"
+
+- runFlow:
+    file: "../../flows/filter/applySeasonFilter.yaml"
+    label: "Action - Apply season filter"
+
+- runFlow:
+    file: "../../flows/filter/verifyRecipeInSeasonFilteredList.yaml"
+    label: "Verification - Verify recipe still found with season filter ON"
+
+- tapOn:
+    id: "SearchScreen::FiltersSelection::1::Chip"
+    label: "Action - Remove filter on name"
+
+- tapOn:
+    id: "SearchScreen::FiltersSelection::0::Chip"
+    label: "Action - Remove on-season filter"

--- a/tests/e2e/cases/ingredients-db/ci/7_seasonal_recipe_stays_visible.yaml
+++ b/tests/e2e/cases/ingredients-db/ci/7_seasonal_recipe_stays_visible.yaml
@@ -1,0 +1,15 @@
+name: "7 - Seasonal Recipe Stays Visible Flow"
+appId: "com.recipedia"
+tags:
+  - database
+  - ingredients-db
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../7_seasonal_recipe_stays_visible.yaml"
+          label: "Run 7 - Seasonal Recipe Stays Visible Flow"

--- a/tests/e2e/cases/smoke/1_core_navigation.yaml
+++ b/tests/e2e/cases/smoke/1_core_navigation.yaml
@@ -1,0 +1,48 @@
+name: "1 - Smoke Core Navigation Flow"
+appId: "com.recipedia"
+tags:
+  - smoke
+---
+- assertVisible:
+    id: "Home::RecipeRecommendation::random::SubHeader"
+    label: "Home screen renders"
+
+- tapOn:
+    id: "BottomTabs::Search"
+    label: "Navigate to Search screen"
+
+- runFlow:
+    file: "../../asserts/search/en/assertSearchScreenUI.yaml"
+    label: "Search screen renders"
+
+- tapOn:
+    id: "BottomTabs::Menu"
+    label: "Navigate to Menu screen"
+
+- runFlow:
+    file: "../../asserts/menu/en/assertMenuEmpty.yaml"
+    label: "Menu screen renders"
+
+- tapOn:
+    id: "BottomTabs::Shopping"
+    label: "Navigate to Shopping screen"
+
+- runFlow:
+    file: "../../asserts/shopping/en/assertShoppingEmpty.yaml"
+    label: "Shopping screen renders"
+
+- tapOn:
+    id: "BottomTabs::Parameters"
+    label: "Navigate to Parameters screen"
+
+- runFlow:
+    file: "../../asserts/parameters/en/assertAppearanceSection.yaml"
+    label: "Parameters screen renders"
+
+- tapOn:
+    id: "BottomTabs::Home"
+    label: "Return to Home screen"
+
+- assertVisible:
+    id: "Home::RecipeRecommendation::random::SubHeader"
+    label: "Home screen renders again after full tab loop"

--- a/tests/e2e/cases/smoke/2_view_recipe.yaml
+++ b/tests/e2e/cases/smoke/2_view_recipe.yaml
@@ -1,0 +1,32 @@
+name: "2 - Smoke View Recipe Flow"
+appId: "com.recipedia"
+tags:
+  - smoke
+---
+- tapOn:
+    id: "BottomTabs::Search"
+    label: "Navigate to Search screen"
+
+- waitForAnimationToEnd
+
+- assertVisible:
+    id: "SearchScreen::RecipeCards::1::Cover"
+    label: "At least one recipe card renders"
+
+- tapOn:
+    id: "SearchScreen::RecipeCards::1::Cover"
+    label: "Open first recipe"
+
+- extendedWaitUntil:
+    visible:
+      id: "Recipe::AppBar"
+    timeout: 30000
+    label: "Recipe screen renders"
+
+- tapOn:
+    id: "Recipe::AppBar::BackButton"
+    label: "Return to Search screen"
+
+- assertVisible:
+    id: "SearchScreen::SearchBar"
+    label: "Back on Search screen"

--- a/tests/e2e/cases/smoke/3_search.yaml
+++ b/tests/e2e/cases/smoke/3_search.yaml
@@ -1,0 +1,31 @@
+name: "3 - Smoke Search Flow"
+appId: "com.recipedia"
+tags:
+  - smoke
+---
+- tapOn:
+    id: "BottomTabs::Search"
+    label: "Navigate to Search screen"
+
+- tapOn:
+    id: "SearchScreen::SearchBar"
+    label: "Focus search bar to open the suggestion dropdown"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard:
+          label: "Dismiss keyboard on Android (iOS shows none without typed text)"
+
+- assertVisible:
+    id: "SearchScreen::SearchBarResults::Item::0-content"
+    label: "Search suggestions render"
+
+- runFlow:
+    file: "../../flows/search/selectFirstSuggestion.yaml"
+    label: "Select top suggestion to close dropdown and reveal grid"
+
+- assertVisible:
+    id: "SearchScreen::RecipeCards::.*::Cover"
+    label: "Recipe grid renders"

--- a/tests/e2e/cases/smoke/ci/1_core_navigation.yaml
+++ b/tests/e2e/cases/smoke/ci/1_core_navigation.yaml
@@ -1,0 +1,14 @@
+name: "1 - Smoke Core Navigation Flow"
+appId: "com.recipedia"
+tags:
+  - smoke
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../1_core_navigation.yaml"
+          label: "Run Smoke Core Navigation Flow"

--- a/tests/e2e/cases/smoke/ci/2_view_recipe.yaml
+++ b/tests/e2e/cases/smoke/ci/2_view_recipe.yaml
@@ -1,0 +1,14 @@
+name: "2 - Smoke View Recipe Flow"
+appId: "com.recipedia"
+tags:
+  - smoke
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../2_view_recipe.yaml"
+          label: "Run Smoke View Recipe Flow"

--- a/tests/e2e/cases/smoke/ci/3_search.yaml
+++ b/tests/e2e/cases/smoke/ci/3_search.yaml
@@ -1,0 +1,14 @@
+name: "3 - Smoke Search Flow"
+appId: "com.recipedia"
+tags:
+  - smoke
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../3_search.yaml"
+          label: "Run Smoke Search Flow"

--- a/tests/e2e/flows/filter/verifyRecipeInSeasonFilteredList.yaml
+++ b/tests/e2e/flows/filter/verifyRecipeInSeasonFilteredList.yaml
@@ -1,0 +1,15 @@
+appId: "com.recipedia"
+---
+- runFlow:
+    file: "../recipe/openTestRecipe.yaml"
+    label: "Navigate to and search for E2E Test Recipe"
+
+- extendedWaitUntil:
+    visible:
+      text: "E2E Test Recipe"
+    timeout: 30000
+    label: "E2E Test Recipe is still visible when season filter is ON (ingredient is in season all year)"
+
+- assertNotVisible:
+    id: "SearchScreen::TextWhenEmpty"
+    label: "Empty-results text is not shown because a matching recipe remains"

--- a/tests/e2e/flows/parameters/ingredients/addSeasonalIngredient.yaml
+++ b/tests/e2e/flows/parameters/ingredients/addSeasonalIngredient.yaml
@@ -1,0 +1,77 @@
+appId: "com.recipedia"
+---
+- tapOn:
+    id: "IngredientsSettings::BottomActionButton"
+    label: "Tap Add button to create a new ingredient"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::Name::CustomTextInput"
+    label: "Focus on ingredient name input field"
+
+- inputText:
+    text: "RecipeIngredient"
+    label: "Enter new ingredient name"
+
+- waitForAnimationToEnd:
+    label: "Wait for keyboard animation"
+
+- runFlow:
+    file: "../../../flows/dismissModalKeyboard.yaml"
+    label: "Dismiss modal keyboard (platform-specific)"
+
+- runFlow:
+    file: "../../waitForKeyboardDismiss.yaml"
+    label: "Wait for keyboard to dismiss"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion"
+    label: "Expand type accordion"
+
+- extendedWaitUntil:
+    visible:
+      id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion::ingredientTypes.*"
+    timeout: 30000
+    label: "Wait for type items to appear in accordion"
+
+- scrollUntilVisible:
+    element:
+      id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion::ingredientTypes.legumes"
+    direction: DOWN
+    speed: 20
+    centerElement: true
+    label: "Action - Scroll to legumes item"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion::ingredientTypes.legumes"
+    label: "Select legumes type"
+
+- runFlow:
+    file: "../../waitForCheckSettle.yaml"
+    env:
+      CHECK_TEXT: "radio button, checked"
+    label: "Wait for item to settle after check (platform-specific)"
+
+- scrollUntilVisible:
+    element:
+      id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion"
+    direction: UP
+    speed: 20
+    centerElement: true
+    label: "Action - Scroll up to ensure type accordion is visible"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::TypeAccordion"
+    label: "Collapse type accordion"
+
+- runFlow:
+    file: "selectAllSeasons.yaml"
+    label: "Mark the ingredient in season all year"
+
+- assertVisible:
+    id: "IngredientsSettings::ItemDialog::AddModal::ConfirmButton"
+    enabled: true
+    label: "Confirm button should be enabled"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::ConfirmButton"
+    label: "Confirm adding the new all-year ingredient"

--- a/tests/e2e/flows/parameters/ingredients/selectAllSeasons.yaml
+++ b/tests/e2e/flows/parameters/ingredients/selectAllSeasons.yaml
@@ -1,0 +1,28 @@
+appId: "com.recipedia"
+---
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::SeasonalityCalendar"
+    label: "Expand seasonality accordion"
+
+- extendedWaitUntil:
+    visible:
+      id: "IngredientsSettings::ItemDialog::AddModal::SeasonalityCalendar::ToggleAllButton"
+    timeout: 5000
+    label: "Wait for seasonality accordion to expand"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::SeasonalityCalendar::ToggleAllButton"
+    label: "Select all months so the ingredient is in season all year"
+
+- waitForAnimationToEnd:
+    label: "Wait for selection animation"
+
+- tapOn:
+    id: "IngredientsSettings::ItemDialog::AddModal::SeasonalityCalendar"
+    label: "Collapse seasonality accordion"
+
+- extendedWaitUntil:
+    notVisible:
+      id: "IngredientsSettings::ItemDialog::AddModal::SeasonalityCalendar::ToggleAllButton"
+    timeout: 5000
+    label: "Wait for seasonality accordion to collapse"

--- a/tests/e2e/ingredients-db.yaml
+++ b/tests/e2e/ingredients-db.yaml
@@ -15,3 +15,4 @@ executionOrder:
     - "4 - Add Ingredient And Use In Recipe Flow"
     - "5 - Ingredient Edge Cases Flow"
     - "6 - Add Ingredient Without Unit"
+    - "7 - Seasonal Recipe Stays Visible Flow"

--- a/tests/e2e/smoke.yaml
+++ b/tests/e2e/smoke.yaml
@@ -1,0 +1,14 @@
+platform:
+  ios:
+    disableAnimations: true
+  android:
+    disableAnimations: true
+
+flows:
+  - cases/smoke/ci/*
+
+executionOrder:
+  flowsOrder:
+    - "1 - Smoke Core Navigation Flow"
+    - "2 - Smoke View Recipe Flow"
+    - "3 - Smoke Search Flow"

--- a/tests/unit/app.config.test.ts
+++ b/tests/unit/app.config.test.ts
@@ -3,10 +3,19 @@ import { resolveIosBundleId } from '@app/app.config';
 describe('resolveIosBundleId', () => {
   const baseAppId = 'com.recipedia';
 
-  it('appends the .ios suffix for production store builds', () => {
+  it('appends the .ios suffix for the store build (production dataset, animations on)', () => {
     expect(resolveIosBundleId(baseAppId, { EXPO_PUBLIC_DATASET_TYPE: 'production' })).toBe(
       'com.recipedia.ios'
     );
+  });
+
+  it('keeps the plain id for a production-dataset automation build (animations disabled)', () => {
+    expect(
+      resolveIosBundleId(baseAppId, {
+        EXPO_PUBLIC_DATASET_TYPE: 'production',
+        EXPO_PUBLIC_DISABLE_ANIMATIONS: 'true',
+      })
+    ).toBe('com.recipedia');
   });
 
   it('keeps the plain id for the test dataset', () => {
@@ -16,25 +25,33 @@ describe('resolveIosBundleId', () => {
   });
 
   it('keeps the plain id for the performance dataset', () => {
-    expect(resolveIosBundleId(baseAppId, { EXPO_PUBLIC_DATASET_TYPE: 'performance' })).toBe(
-      'com.recipedia'
-    );
+    expect(
+      resolveIosBundleId(baseAppId, {
+        EXPO_PUBLIC_DATASET_TYPE: 'performance',
+        EXPO_PUBLIC_DISABLE_ANIMATIONS: 'true',
+      })
+    ).toBe('com.recipedia');
   });
 
-  it('keeps the plain id when the dataset type is unset', () => {
+  it('keeps the plain id when the env is empty', () => {
     expect(resolveIosBundleId(baseAppId, {})).toBe('com.recipedia');
   });
 
   it('reads from process.env when no env is provided', () => {
-    const previous = process.env.EXPO_PUBLIC_DATASET_TYPE;
+    const previousDataset = process.env.EXPO_PUBLIC_DATASET_TYPE;
+    const previousAnimations = process.env.EXPO_PUBLIC_DISABLE_ANIMATIONS;
     process.env.EXPO_PUBLIC_DATASET_TYPE = 'production';
+    delete process.env.EXPO_PUBLIC_DISABLE_ANIMATIONS;
     try {
       expect(resolveIosBundleId(baseAppId)).toBe('com.recipedia.ios');
     } finally {
-      if (previous === undefined) {
+      if (previousDataset === undefined) {
         delete process.env.EXPO_PUBLIC_DATASET_TYPE;
       } else {
-        process.env.EXPO_PUBLIC_DATASET_TYPE = previous;
+        process.env.EXPO_PUBLIC_DATASET_TYPE = previousDataset;
+      }
+      if (previousAnimations !== undefined) {
+        process.env.EXPO_PUBLIC_DISABLE_ANIMATIONS = previousAnimations;
       }
     }
   });


### PR DESCRIPTION
Resolves #323 — the identified E2E coverage gaps.

## What
- **Smoke suite** (`smoke.yaml`, both platforms): launch → all 5 tabs (incl. Menu) → view a recipe → search. Shallow, id-based, dataset-agnostic. Runs on a **production-dataset** release build, in parallel with the main matrix for fast fail-fast feedback.
- **Production-maestro EAS profile**: extends `maestro` (installable APK / iOS simulator, Release opts) but seeds the production dataset — validates the real seed data under release optimizations, the one gap the test-dataset builds can't cover. `resolveIosBundleId` reuses the existing dataset + animations env vars (no new flag) to keep the shared `com.recipedia` id so Maestro can launch it on iOS.
- **Ingredient seasonality**: positive case — an all-year ingredient keeps its recipe visible under the season filter (deterministic complement to the existing negative case). Adds a reusable `selectAllSeasons` flow; leaves shared `addNewIngredient` untouched.
- **Menu tab**: fixes `# TODO Menu` — the shared bottom-tabs assert (en/fr) and app-init nav now cover all 5 tabs.
- **Visual testing**: evaluated per the issue → **defer** (see `VISUAL_TESTING_EVALUATION.md`); baseline matrix + season/date non-determinism make screenshot regression a flakiness sink.

## Commits
- `test(e2e): cover Menu tab in bottom-tabs navigation`
- `build(eas): add production-maestro profile for prod-dataset E2E`
- `test(e2e): add production smoke suite`
- `test(e2e): cover seasonal recipe stays visible under filter`
- `docs(e2e): evaluate Maestro visual testing`

## Validation
- Smoke flows ran green on Android emulator (pre-refactor); the reused/simplified pieces are CI-proven.
- `app.config` gate unit-tested (TDD, 6/6). All YAML/JSON parse clean.
- Not live-validated: production-maestro CI path (needs a prod-dataset build) and the dataset-agnostic search rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)