### PR TITLE
fix(deps): support 16 KB memory page sizes (ML Kit 2.0.0)

### DIFF
--- a/.github/actions/check-16kb-alignment/action.yml
+++ b/.github/actions/check-16kb-alignment/action.yml
@@ -1,0 +1,66 @@
+name: 'Check 16 KB page-size alignment'
+description: >-
+  Warns (non-blocking) when any 64-bit native library is not 16 KB ELF-aligned,
+  using Google's official AOSP check_elf_alignment.sh. Mirrors the check Google
+  Play runs at publication, giving early PR feedback before an upload is rejected.
+
+inputs:
+  artifact-path:
+    description: 'Path or glob to the built .apk or .aab to verify'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify 16 KB native library alignment
+      shell: bash
+      run: |
+        # No `set -e`: this check is advisory (warning-only), so any
+        # infrastructure failure (fetch, unzip, tooling) must degrade to a
+        # skip-with-warning rather than fail the build.
+        set -uo pipefail
+
+        artifact=$(ls ${{ inputs.artifact-path }} 2>/dev/null | head -1 || true)
+        if [ -z "$artifact" ]; then
+          echo "::warning::16 KB check skipped — no artifact matched '${{ inputs.artifact-path }}'"
+          exit 0
+        fi
+        echo "Verifying 16 KB alignment for: $artifact"
+
+        # Google's official AOSP tool. It does not recurse into archives and
+        # always exits 0, so we extract first and gate on its printed output.
+        script=$(mktemp)
+        if ! curl -fsSL "https://android.googlesource.com/platform/system/extras/+/refs/heads/master/tools/check_elf_alignment.sh?format=TEXT" | base64 -d > "$script"; then
+          echo "::warning::16 KB check skipped — could not fetch check_elf_alignment.sh"
+          exit 0
+        fi
+
+        workdir=$(mktemp -d)
+        if ! unzip -qo "$artifact" -d "$workdir"; then
+          echo "::warning::16 KB check skipped — could not unzip $artifact"
+          exit 0
+        fi
+
+        out=$(mktemp)
+        # Play only gates 64-bit ABIs; 32-bit libs are exempt. APKs use
+        # lib/<abi>, AABs use base/lib/<abi>.
+        found=0
+        for abi in arm64-v8a x86_64; do
+          for base in "$workdir/lib/$abi" "$workdir/base/lib/$abi"; do
+            if [ -d "$base" ]; then
+              found=1
+              bash "$script" "$base" | tee -a "$out" || true
+            fi
+          done
+        done
+
+        if [ "$found" -eq 0 ]; then
+          echo "::warning::16 KB check skipped — no arm64-v8a/x86_64 native libraries found in $artifact"
+          exit 0
+        fi
+
+        if grep -q "UNALIGNED" "$out"; then
+          echo "::warning::Native libraries are not 16 KB aligned — Google Play may reject this build and it can crash on 16 KB-page devices. See the UNALIGNED entries above."
+          exit 0
+        fi
+        echo "✅ All 64-bit native libraries are 16 KB aligned."

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -298,6 +298,12 @@ jobs:
             exit 1
           fi
 
+      - name: Verify 16 KB native library alignment
+        if: inputs.platform == 'android'
+        uses: ./.github/actions/check-16kb-alignment
+        with:
+          artifact-path: ${{ inputs.app-filename }}
+
       - name: Upload app
         uses: actions/upload-artifact@v7
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hookform/resolvers": "5.4.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/slider": "5.2.0",
-        "@react-native-ml-kit/text-recognition": "~1.5.2",
+        "@react-native-ml-kit/text-recognition": "~2.0.0",
         "@react-navigation/bottom-tabs": "~6.5.8",
         "@react-navigation/native": "~6.1.7",
         "@react-navigation/native-stack": "~6.9.13",
@@ -7807,9 +7807,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native-ml-kit/text-recognition": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@react-native-ml-kit/text-recognition/-/text-recognition-1.5.2.tgz",
-      "integrity": "sha512-zPnJrD19u4FhT0ntvtnZVEhvPym9KyZ0R+UXBYJbCT0ePL9DpMnSewBFnHy44YnXKGgbokRQXUQMMM+GOsQs7w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-ml-kit/text-recognition/-/text-recognition-2.0.0.tgz",
+      "integrity": "sha512-RHefLYKndSyoDtgqHQptYQe+mftFk6/H30IQDenKX7PgMlJqoDejX+HdZ8gnP1kVNAt3iH+wyl/P6vCOkLMW9Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@hookform/resolvers": "5.4.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/slider": "5.2.0",
-    "@react-native-ml-kit/text-recognition": "~1.5.2",
+    "@react-native-ml-kit/text-recognition": "~2.0.0",
     "@react-navigation/bottom-tabs": "~6.5.8",
     "@react-navigation/native": "~6.1.7",
     "@react-navigation/native-stack": "~6.9.13",

--- a/patches/@react-native-ml-kit+text-recognition+2.0.0.patch
+++ b/patches/@react-native-ml-kit+text-recognition+2.0.0.patch
@@ -1,49 +1,49 @@
 diff --git a/node_modules/@react-native-ml-kit/text-recognition/RNMLKitTextRecognition.podspec b/node_modules/@react-native-ml-kit/text-recognition/RNMLKitTextRecognition.podspec
-index ec38d23..3185d26 100644
+index 421bcfc..74a715f 100644
 --- a/node_modules/@react-native-ml-kit/text-recognition/RNMLKitTextRecognition.podspec
 +++ b/node_modules/@react-native-ml-kit/text-recognition/RNMLKitTextRecognition.podspec
 @@ -23,13 +23,15 @@ Pod::Spec.new do |s|
    s.dependency "React"
    # To recognize Latin script
-   s.dependency 'GoogleMLKit/TextRecognition', '6.0.0'
+   s.dependency 'GoogleMLKit/TextRecognition', '8.0.0'
 +  # Recipedia is Latin-only (en/fr). The non-Latin script models add tens of MB to
 +  # the iOS bundle and are never used, so they are stripped via patch-package.
    # To recognize Chinese script
--  s.dependency 'GoogleMLKit/TextRecognitionChinese', '6.0.0'
-+  # s.dependency 'GoogleMLKit/TextRecognitionChinese', '6.0.0'
+-  s.dependency 'GoogleMLKit/TextRecognitionChinese', '8.0.0'
++  # s.dependency 'GoogleMLKit/TextRecognitionChinese', '8.0.0'
    # To recognize Devanagari script
--  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '6.0.0'
-+  # s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '6.0.0'
+-  s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '8.0.0'
++  # s.dependency 'GoogleMLKit/TextRecognitionDevanagari', '8.0.0'
    # To recognize Japanese script
--  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '6.0.0'
-+  # s.dependency 'GoogleMLKit/TextRecognitionJapanese', '6.0.0'
+-  s.dependency 'GoogleMLKit/TextRecognitionJapanese', '8.0.0'
++  # s.dependency 'GoogleMLKit/TextRecognitionJapanese', '8.0.0'
    # To recognize Korean script
--  s.dependency 'GoogleMLKit/TextRecognitionKorean', '6.0.0'
-+  # s.dependency 'GoogleMLKit/TextRecognitionKorean', '6.0.0'
+-  s.dependency 'GoogleMLKit/TextRecognitionKorean', '8.0.0'
++  # s.dependency 'GoogleMLKit/TextRecognitionKorean', '8.0.0'
  end
  
 diff --git a/node_modules/@react-native-ml-kit/text-recognition/android/build.gradle b/node_modules/@react-native-ml-kit/text-recognition/android/build.gradle
-index b5a9949..5dc0554 100644
+index 6a2e36f..b03f5d5 100644
 --- a/node_modules/@react-native-ml-kit/text-recognition/android/build.gradle
 +++ b/node_modules/@react-native-ml-kit/text-recognition/android/build.gradle
 @@ -63,12 +63,14 @@ dependencies {
      implementation 'com.facebook.react:react-native:+'  // From node_modules
      // To recognize Latin script
-     implementation 'com.google.mlkit:text-recognition:16.0.0'
+     implementation 'com.google.mlkit:text-recognition:16.0.1'
 +    // Recipedia is Latin-only (en/fr). The non-Latin script models add several MB
 +    // of bundled OCR models and are never used, so they are stripped via patch-package.
      // To recognize Chinese script
--    implementation 'com.google.mlkit:text-recognition-chinese:16.0.0'
-+    // implementation 'com.google.mlkit:text-recognition-chinese:16.0.0'
+-    implementation 'com.google.mlkit:text-recognition-chinese:16.0.1'
++    // implementation 'com.google.mlkit:text-recognition-chinese:16.0.1'
      // To recognize Devanagari script
--    implementation 'com.google.mlkit:text-recognition-devanagari:16.0.0'
-+    // implementation 'com.google.mlkit:text-recognition-devanagari:16.0.0'
+-    implementation 'com.google.mlkit:text-recognition-devanagari:16.0.1'
++    // implementation 'com.google.mlkit:text-recognition-devanagari:16.0.1'
      // To recognize Japanese script
--    implementation 'com.google.mlkit:text-recognition-japanese:16.0.0'
-+    // implementation 'com.google.mlkit:text-recognition-japanese:16.0.0'
+-    implementation 'com.google.mlkit:text-recognition-japanese:16.0.1'
++    // implementation 'com.google.mlkit:text-recognition-japanese:16.0.1'
      // To recognize Korean script
--    implementation 'com.google.mlkit:text-recognition-korean:16.0.0'
-+    // implementation 'com.google.mlkit:text-recognition-korean:16.0.0'
+-    implementation 'com.google.mlkit:text-recognition-korean:16.0.1'
++    // implementation 'com.google.mlkit:text-recognition-korean:16.0.1'
  }
 diff --git a/node_modules/@react-native-ml-kit/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java b/node_modules/@react-native-ml-kit/text-recognition/android/src/main/java/com/rnmlkit/textrecognition/TextRecognitionModule.java
 index 004bfb3..0059c43 100644


### PR DESCRIPTION
## Why

Google Play Console rejected the app: **"does not support 16 KB memory page sizes"** ([ref](https://developer.android.com/guide/practices/page-sizes)). Apps targeting SDK 35+ must ship native libraries whose ELF LOAD segments are 16 KB-aligned; we target SDK 36.

## Root cause (verified against the actual binaries)

Play scans every `.so` in the APK/AAB `lib/` directory. Exactly one was misaligned:

- `libmlkit_google_ocr_pipeline.so` — LOAD segments `2**12` (4 KB).
- Pulled transitively by `@react-native-ml-kit/text-recognition@1.5.2` → `com.google.mlkit:text-recognition:16.0.0` → `text-recognition-bundled-common:16.0.0`.
- A Google-shipped **prebuilt** binary → the NDK/EAS build cannot realign it.

Every other native lib builds from source (NDK-aligned) or is already 16 KB (Chaquopy 17). No other offender.

## Fix

Bump `@react-native-ml-kit/text-recognition` `1.5.2 → 2.0.0`, which pins `text-recognition:16.0.1` → `bundled-common:17.0.0`, whose same `.so` is `2**14` (16 KB).

Low-risk (byte-diff of both npm tarballs): JS/native API and result shape identical; only breaking change is iOS min target `9.0 → 15.5`, already satisfied (app targets iOS 18.0). No New Arch / RN requirement change.

The Latin-only `patch-package` patch was regenerated against 2.0.0 (its context referenced `16.0.0`, so it no longer applied); the `+1.5.2` patch is removed.

## Verification

- `objdump` of the Maven `17.0.0` binary: `2**14`.
- `patch-package … @2.0.0 ✔` on real install.
- Local release APK build green.
- **Production AAB: all 66 `lib/` `.so` are 16 KB aligned, 0 unaligned.**

## CI guardrail (second commit)

Adds a composite action running Google's official AOSP `check_elf_alignment.sh` over the built Android artifact's 64-bit libs, **warning-only** (annotates, never blocks; degrades to skip-with-warning on infra failure). Piggybacks the existing Android build — no extra job. Catches this whole class before Play does.

## Out of scope

lxml's `libxml2/libxslt/libexslt.so` (Chaquopy wheel) are 4 KB but live in `assets/*.imy` (extracted at runtime), not `lib/` — Play does not gate them. Latent runtime risk on 16 KB-page devices only; iOS uses Pyodide WASM and is unaffected. To be tracked separately.

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)