### PR TITLE
ci(dependabot): group Expo patches, drop dead reviewers config, ignore gradle/actions majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,17 @@
 version: 2
 updates:
+  # ---------------------------------------------------------------------------
   # npm dependencies. Expo SDK pins the React Native / React / Expo / Babel /
   # Metro toolchain. Standalone JS libs and dev tooling: minor + patch only,
-  # major bumps are a deliberate human action. The Expo-SDK-managed family
-  # (expo*, react-native*, react, jest-expo, eslint-config-expo) is restricted
-  # to PATCH-only: Expo republishes these patches within an SDK on a weekly
-  # cadence, and a stale lockfile makes `expo-doctor` fail CI. Patch PRs keep
-  # the lockfile fresh; minor/major on that family = an SDK upgrade, done by
-  # hand via `expo install` — never by Dependabot.
+  # major bumps are a deliberate human action.
+  #
+  # The Expo runtime family (expo, expo-*, @expo/*) is PATCH-only and lands as a
+  # single grouped PR (`expo-sdk`). Expo republishes patches within an SDK on a
+  # rolling cadence and a stale lockfile makes `expo-doctor` fail CI; grouping
+  # keeps the family moving in lockstep instead of as isolated bumps that can
+  # land desynchronised. Minor/major on that family = an SDK upgrade, done by
+  # hand via `expo install`.
+  # ---------------------------------------------------------------------------
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -16,8 +20,6 @@ updates:
       time: "09:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 5
-    reviewers:
-      - "AntoC"
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -33,6 +35,15 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
     groups:
+      # One PR for the whole Expo runtime family so its packages never land
+      # desynchronised.
+      expo-sdk:
+        patterns:
+          - "expo"
+          - "expo-*"
+          - "@expo/*"
+        update-types:
+          - "patch"
       testing:
         patterns:
           - "*jest*"
@@ -54,22 +65,26 @@ updates:
       # Expo-SDK-managed family — allow PATCH only (keeps lockfile fresh so
       # expo-doctor stays green); block minor/major (= SDK upgrade, done via
       # `expo install` by hand).
-      - dependency-name: "expo*"
+      - dependency-name: "expo"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "@expo*"
+      - dependency-name: "expo-*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "@expo/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "react-native*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "@react-native*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "react"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "jest-expo"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "eslint-config-expo"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # react / react-dom — FULLY ignored (all update types, patch included):
+      # they must move in lockstep with the Expo-pinned React version via
+      # `expo install`, never by a lone Dependabot patch. A react-only patch
+      # (19.2.3 -> 19.2.8) left react-dom at 19.2.3 and broke the E2E suite.
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
       # Toolchain pins — fully ignored (bumped only alongside an SDK upgrade).
       - dependency-name: "react-compiler-runtime"
       - dependency-name: "babel-plugin-react-compiler"
@@ -101,8 +116,6 @@ updates:
       time: "09:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 3
-    reviewers:
-      - "AntoC"
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -112,3 +125,11 @@ updates:
       - "ci"
       - "automated"
       - "github-actions"
+    ignore:
+      # gradle/actions v6 moved "enhanced" caching into a proprietary component
+      # (free for public repos, but no longer MIT) and dropped configuration-
+      # cache support. v5 covers our Android build needs — stay on it and treat
+      # any new major as a deliberate, hand-reviewed upgrade. v5.x patch/minor
+      # bumps still flow through to keep the pin fresh.
+      - dependency-name: "gradle/actions"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Context

Follow-up to the audit of the open Dependabot PRs. **No application dependency is changed** — `dependabot.yml` only.

## Changes

### 1. Expo runtime family → a single `expo-sdk` group, patch-only

The `Expo Configuration Check` (expo-doctor) is red on `main` because some `expo*` packages lag behind the patch versions pinned by SDK 56.

`expo` / `expo-*` / `@expo/*` are now grouped into **one weekly PR** (`update-types: patch`) instead of independent bumps. One lockfile resolution, so the family **can no longer land desynchronised** — precisely the failure mode that broke the E2E suite. Minor/major stay manual (SDK upgrade via `expo install`).

### 2. `react` / `react-dom` → fully ignored

The config already blocked `react`/`react-dom` on minor/major but **let patches through**. Result: #508 bumped `react` `19.2.3 → 19.2.8` **without** co-bumping `react-dom` (left at `19.2.3`).

They are now **fully ignored** (all update types, patch included). Unlike the tilde-ranged `expo-*` packages, the SDK pins them to an **exact** version, so a lone Dependabot patch puts them ahead of the SDK version map and fails expo-doctor. They move via `expo install` only. → **supersedes #508** (to close).

### 3. `gradle/actions` → majors ignored (staying on v5)

v6 moved "enhanced" caching into a **proprietary** component (free for public repos, but no longer MIT) and dropped configuration-cache support. v5 covers the Android build. v5.x patch/minor bumps still flow through. → **supersedes #510** (to close).

### 4. `reviewers` removed — it was dead config

Two compounding bugs, both verified against the last 6 Dependabot PRs (**zero reviewers requested on every one**):

- GitHub **retired the `reviewers` option** on 2025-08-08 in favour of CODEOWNERS ([changelog](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/)).
- The configured value, `AntoC`, resolves to GitHub account `antoc` (id 4174576) — **an unrelated third party**, not the maintainer `AntoC-dev`.

### 5. Labels — fixed on the repo side, not in the YAML

The declared labels (`automated`, `ci`, `github-actions`) were **silently dropped**: Dependabot only applies labels that **already exist**. #510 landed with no labels at all, #511–514 with only `released`.

All three labels have been **created in the repository**. The config itself was correct and is unchanged.

## What was dropped

Earlier revisions of this PR added a second npm entry (a Friday Expo lane) plus an auto-merge workflow. Both are removed:

- **The second npm entry was invalid.** Dependabot requires a unique `package-ecosystem` + `directory` + `target-branch` triple; two npm entries on `/` make it **reject the whole file**, breaking *all* updates, not just the new one. The `expo-sdk` group achieves the same result inside the existing entry.
- **Auto-merge is dropped** (decision: CI gets reviewed before merging). It would have required status checks on the `main` ruleset anyway — there are none today, so `--auto` would have merged on approval **without waiting for CI**.

## Verification

- `dependabot.yml`: valid YAML, 2 entries (npm Monday / github-actions Monday).
- Labels `automated`, `ci`, `github-actions`, `dependencies`: present in the repo.
- After merge: the next Dependabot PR should carry its labels, and Expo patches should arrive as a single grouped PR.

## Open question

CODEOWNERS is the official replacement for `reviewers`, but the `main` ruleset has `require_code_owner_review: true` — currently inert with no such file. Adding one would **activate** that rule: with a single maintainer, you cannot approve your own PRs, so every PR would need an admin bypass. Not added here.

---
_Generated by [Claude Code](https://claude.ai/code/session_0131d8MCxJzMriSL9naXkyWd)_
