### PR TITLE
feat(navigation): adopt react-navigation v7 behavior APIs (#499)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,7 +173,7 @@ React 19 `useDeferredValue`.
 
 ## 5. Navigation structure
 
-Navigation uses React Navigation v6. Types for screens and params are defined in `src/customTypes/ScreenTypes.tsx`.
+Navigation uses React Navigation v7 (native-stack). Types for screens and params are defined in `src/customTypes/ScreenTypes.tsx`.
 
 ```
 NavigationContainer (App.tsx)
@@ -200,6 +200,13 @@ NavigationContainer (App.tsx)
 ```
 
 All screens are header-less (`headerShown: false`). Navigation animations can be disabled globally via `EXPO_PUBLIC_DISABLE_ANIMATIONS=true` (used by E2E tests).
+
+Screen-level behaviour set on the navigators:
+
+- **Screen freezing** — `enableFreeze()` is called once in `App.tsx`, and both navigators set `freezeOnBlur`, so a blurred screen's React subtree is suspended and stops re-rendering on context updates. `BottomTabs` gates `freezeOnBlur` on the same condition as `detachInactiveScreens`: during the copilot tutorial every tab stays live, because freezing a tab that an overlay step points at would stall the walkthrough.
+- **Error boundaries** — screens that can crash on untrusted input (`RecipeAddOcr`, `RecipeAddScrape`, `BulkImportDiscovery`) declare `layout={errorBoundaryLayout}` on their `Stack.Screen`. This replaced the former `withErrorBoundary` HOC; the boundary is now part of the route declaration rather than the component export.
+- **Predictive back (Android)** — enabled through `android.predictiveBackGestureEnabled` in `app.config.ts`, which makes Expo emit `android:enableOnBackInvokedCallback="true"` into the manifest.
+- **Preloading** — `Home` preloads the `Search` tab, whose first render derives its filter lists from every recipe. Deliberately limited to that one screen: React Navigation exempts a preloaded route from `freezeOnBlur` (`shouldFreeze: … && !isPreloaded`) and only clears a preloaded tab key on `JUMP_TO`, so each preload trades freezing away until the route is first opened. Recipe cards intentionally do **not** preload `RecipeView` — `onPressIn` fires on every touch-down including scroll starts, so it dispatched a navigator state update and remounted the screen far more often than a recipe was actually opened.
 
 Each recipe route is a thin wrapper that forwards its own narrow params (see `src/customTypes/RecipeNavigationTypes.tsx`) to the shared `RecipeFormScreen`, which derives the form `mode`:
 
@@ -238,6 +245,12 @@ The recipe form is built on `react-hook-form` (RHF) with a Zod resolver. Read-on
 - `buildEmptyDefaults` — blank form (`addManually`); seeds `recipePersons` from `getDefaultPersonsSync()`
 - `buildDefaultsFromRecipe` — existing recipe (`edit`, `readOnly`)
 - `buildDefaultsFromScrape` — scraped payload (`addFromScrape`)
+
+### Unsaved-changes guard
+
+`useUnsavedChangesGuard` (`src/hooks/useUnsavedChangesGuard.tsx`) wraps React Navigation's `usePreventRemove` and is mounted by `RecipeFormScreen` with `form.formState.isDirty`. While the form is dirty, every removal of the route — hardware/predictive back, the swipe gesture, the AppBar back arrow and Cancel — is intercepted and a discard confirmation is shown instead of dropping the edits. Confirming replays the exact intercepted action, so the original destination is preserved.
+
+The save paths call `allowRemoval()` before `onSaveSuccess`: the form is still dirty at that moment, so without it the guard would block the navigation that a successful save performs.
 
 ### Per-column field controllers
 

--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import {RecipeDatabase} from '@utils/RecipeDatabase';
 import {init as initFileSystem} from '@utils/FileGestion';
 import {cleanupOrphanedImages} from '@utils/FileGestion';
 import {unregisterLegacyBackgroundTasks} from '@utils/legacyTaskCleanup';
+import {enableFreeze} from 'react-native-screens';
 
 // TODO manage horizontal mode
 
@@ -29,6 +30,11 @@ import {unregisterLegacyBackgroundTasks} from '@utils/legacyTaskCleanup';
 // TODO use eslint-config-expo ?
 
 // TODO add special gastronomy (gluten free, lactose, etc)
+
+// react-freeze suspends the React subtree of every blurred screen, so screens
+// left behind on the stack stop re-rendering on context updates until focused
+// again. Off by default in react-native-screens.
+enableFreeze();
 
 SplashScreen.preventAutoHideAsync();
 

--- a/App.tsx
+++ b/App.tsx
@@ -27,7 +27,6 @@ import {unregisterLegacyBackgroundTasks} from '@utils/legacyTaskCleanup';
 // TODO useMemo for time consuming function
 
 // TODO use eslint-config-expo ?
-// TODO replace react-navigation by expo-router
 
 // TODO add special gastronomy (gluten free, lactose, etc)
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -97,6 +97,7 @@ export default ({config}: ConfigContext): ExpoConfig => {
             },
             package: appId,
             permissions: ['android.permission.CAMERA'],
+            predictiveBackGestureEnabled: true,
         },
         plugins: [
             [

--- a/src/components/molecules/MenuRecipeCard.tsx
+++ b/src/components/molecules/MenuRecipeCard.tsx
@@ -32,12 +32,7 @@ export function MenuRecipeCard({
   const { colors } = useTheme();
   const { recipes } = useRecipes();
 
-  const handlePress = () => {
-    const recipe = recipes.find(r => r.id === menuItem.recipeId);
-    if (recipe) {
-      navigate('RecipeView', { recipe });
-    }
-  };
+  const recipe = recipes.find(r => r.id === menuItem.recipeId);
 
   return (
     <Card
@@ -50,7 +45,9 @@ export function MenuRecipeCard({
           backgroundColor: menuItem.isCooked ? colors.surfaceVariant : colors.surface,
         },
       ]}
-      onPress={handlePress}
+      onPress={() => {
+        if (recipe) navigate('RecipeView', { recipe });
+      }}
     >
       <View style={styles.content}>
         <Checkbox

--- a/src/components/organisms/ErrorBoundary.tsx
+++ b/src/components/organisms/ErrorBoundary.tsx
@@ -20,7 +20,7 @@
  * ```
  */
 
-import React, { Component, ComponentType, ErrorInfo, ReactNode } from 'react';
+import React, { Component, ErrorInfo, ReactNode } from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 import { ErrorFallback } from '@components/molecules/ErrorFallback';
 import { appLogger } from '@utils/logger';
@@ -91,22 +91,23 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 }
 
 /**
- * Wraps a component in an {@link ErrorBoundary} so a render crash inside it is
- * contained instead of taking down the whole navigation tree.
+ * Screen `layout` that contains a render error inside the screen that threw
+ * instead of tearing down the whole navigator.
  *
- * @param WrappedComponent - the component to protect
- * @param testID - optional testID forwarded to the boundary's fallback
- * @returns a component rendering `WrappedComponent` inside an error boundary
+ * Passed to a `Stack.Screen`'s `layout` or a `Stack.Group`'s `screenLayout` in
+ * React Navigation v7. This replaced the former `withErrorBoundary` HOC: the
+ * wrapping is declared on the route rather than baked into the screen's export.
+ *
+ * @param props - Screen layout args; only `children` (the rendered screen) is used
+ * @returns The screen wrapped in an {@link ErrorBoundary}
+ *
+ * @example
+ * ```tsx
+ * <Stack.Group screenLayout={errorBoundaryLayout}>
+ *   <Stack.Screen name='RecipeAddOcr' component={RecipeAddOcr} />
+ * </Stack.Group>
+ * ```
  */
-export function withErrorBoundary<P extends object>(
-  WrappedComponent: ComponentType<P>,
-  testID?: string
-): ComponentType<P> {
-  const Guarded = (props: P) => (
-    <ErrorBoundary testID={testID}>
-      <WrappedComponent {...props} />
-    </ErrorBoundary>
-  );
-  Guarded.displayName = `withErrorBoundary(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
-  return Guarded;
+export function errorBoundaryLayout({ children }: { children: ReactNode }) {
+  return <ErrorBoundary>{children}</ErrorBoundary>;
 }

--- a/src/hooks/useUnsavedChangesGuard.tsx
+++ b/src/hooks/useUnsavedChangesGuard.tsx
@@ -1,0 +1,115 @@
+/**
+ * useUnsavedChangesGuard - Discard-confirmation guard for dirty forms
+ *
+ * Wraps React Navigation v7's `usePreventRemove` so a screen holding unsaved
+ * edits intercepts every removal of itself — hardware/predictive back, the
+ * swipe-back gesture, the header back arrow and any explicit `goBack()` /
+ * `reset()` — and surfaces a confirmation dialog instead of silently dropping
+ * the edits.
+ *
+ * The intercepted action is replayed verbatim once the user confirms, so the
+ * original destination is preserved rather than being approximated with a
+ * `goBack()`. React Navigation tags an action with the routes that already
+ * emitted `beforeRemove` for it, so replaying it does not re-trigger this
+ * guard.
+ *
+ * Saves must call `allowRemoval()` before navigating away: the form is still
+ * dirty at that point, and the guard would otherwise block the very navigation
+ * that a successful save performs.
+ */
+
+import { useRef, useState } from 'react';
+import { useNavigation, usePreventRemove } from '@react-navigation/native';
+import type { NavigationAction } from '@react-navigation/native';
+
+/**
+ * Dialog state and handlers returned by {@link useUnsavedChangesGuard}.
+ */
+export interface UnsavedChangesGuard {
+  /** Whether the discard-confirmation dialog should be rendered. */
+  isDiscardDialogVisible: boolean;
+  /** Dismisses the dialog and replays the navigation action that was blocked. */
+  confirmDiscard: () => void;
+  /** Drops the blocked action and keeps the user on the screen. */
+  cancelDiscard: () => void;
+  /** Hides the dialog without deciding — safe to run before `confirmDiscard`. */
+  dismissDialog: () => void;
+  /** Disarms the guard permanently so a completed save can navigate away. */
+  allowRemoval: () => void;
+}
+
+/**
+ * Blocks removal of the current screen while it holds unsaved changes.
+ *
+ * @param hasUnsavedChanges - Whether the screen currently holds edits that
+ *   would be lost by navigating away. Typically React Hook Form's
+ *   `formState.isDirty`.
+ * @returns Dialog visibility plus the confirm/cancel/disarm handlers.
+ *
+ * @example
+ * ```typescript
+ * const guard = useUnsavedChangesGuard(form.formState.isDirty);
+ *
+ * async function save() {
+ *   await persist();
+ *   guard.allowRemoval();
+ *   navigation.goBack();
+ * }
+ *
+ * return (
+ *   <Alert
+ *     testId='RecipeDiscard'
+ *     isVisible={guard.isDiscardDialogVisible}
+ *     title={t('unsavedChanges.title')}
+ *     content={t('unsavedChanges.content')}
+ *     confirmText={t('unsavedChanges.discard')}
+ *     cancelText={t('unsavedChanges.keepEditing')}
+ *     onClose={guard.dismissDialog}
+ *     onConfirm={guard.confirmDiscard}
+ *     onCancel={guard.cancelDiscard}
+ *   />
+ * );
+ * ```
+ */
+export function useUnsavedChangesGuard(hasUnsavedChanges: boolean): UnsavedChangesGuard {
+  const navigation = useNavigation();
+  const [isDiscardDialogVisible, setIsDiscardDialogVisible] = useState(false);
+  const pendingActionRef = useRef<NavigationAction | null>(null);
+  const isRemovalAllowedRef = useRef(false);
+
+  usePreventRemove(hasUnsavedChanges, ({ data }) => {
+    if (isRemovalAllowedRef.current) {
+      navigation.dispatch(data.action);
+      return;
+    }
+    pendingActionRef.current = data.action;
+    setIsDiscardDialogVisible(true);
+  });
+
+  const confirmDiscard = () => {
+    setIsDiscardDialogVisible(false);
+    const action = pendingActionRef.current;
+    pendingActionRef.current = null;
+    if (action) {
+      navigation.dispatch(action);
+    }
+  };
+
+  // Dialogs report dismissal separately from an explicit cancel, and may report
+  // both for one tap. Hiding must therefore stay free of side effects so it can
+  // precede `confirmDiscard` without disarming it.
+  const dismissDialog = () => {
+    setIsDiscardDialogVisible(false);
+  };
+
+  const cancelDiscard = () => {
+    pendingActionRef.current = null;
+    dismissDialog();
+  };
+
+  const allowRemoval = () => {
+    isRemovalAllowedRef.current = true;
+  };
+
+  return { isDiscardDialogVisible, confirmDiscard, cancelDiscard, dismissDialog, allowRemoval };
+}

--- a/src/navigation/BottomTabs.tsx
+++ b/src/navigation/BottomTabs.tsx
@@ -172,11 +172,13 @@ export function BottomTabBar({ navigation, state, descriptors, insets }: BottomT
 export function BottomTabs() {
   const { t } = useI18n();
 
-  // Only disable lazy loading during tutorial mode (when copilot is active)
-  // to ensure all tutorial steps are registered before copilot starts.
-  // In normal operation, enable lazy loading for better performance.
-  const copilotData = useSafeCopilot();
-  const shouldRenderLazy = !copilotData;
+  // During the tutorial every tab must stay mounted, attached and unfrozen:
+  // steps have to be registered before copilot starts, detaching an inactive
+  // screen mid-overlay reparents its native view and crashes Fabric's Yoga
+  // layout, and freezing one stalls the step anchored to it. Outside the
+  // tutorial all three revert to their cheaper defaults.
+  const isTutorialActive = useSafeCopilot() != null;
+  const shouldRenderLazy = !isTutorialActive;
 
   const labels = {
     home: t('home'),
@@ -189,11 +191,8 @@ export function BottomTabs() {
   return (
     <Tab.Navigator
       initialRouteName='Home'
-      // During the tutorial (copilot active) keep every tab screen attached:
-      // detaching an inactive screen mid-overlay reparents its native view and
-      // crashes Fabric's Yoga layout. Outside the tutorial, detach normally.
-      detachInactiveScreens={!copilotData}
-      screenOptions={{ headerShown: false }}
+      detachInactiveScreens={!isTutorialActive}
+      screenOptions={{ headerShown: false, freezeOnBlur: !isTutorialActive }}
       tabBar={props => <BottomTabBar {...props} />}
     >
       <Tab.Screen

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -90,6 +90,7 @@ export function RootNavigator() {
   const screenOptions = {
     headerShown: false,
     animation: animationsDisabled ? ('none' as const) : ('default' as const),
+    freezeOnBlur: true,
     listeners: {
       focus: (e: { target?: string }) => {
         navigationLogger.debug('Screen focused', { screenName: e.target?.split('-')[0] });

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -73,11 +73,7 @@ import { BugReport } from '@screens/BugReport';
 import { Stack } from '@customTypes/ScreenTypes';
 import { BottomTabs } from '@navigation/BottomTabs';
 import { navigationLogger } from '@utils/logger';
-import { withErrorBoundary } from '@components/organisms/ErrorBoundary';
-
-const GuardedBulkImportDiscovery = withErrorBoundary(BulkImportDiscovery);
-const GuardedRecipeAddOcr = withErrorBoundary(RecipeAddOcr);
-const GuardedRecipeAddScrape = withErrorBoundary(RecipeAddScrape);
+import { errorBoundaryLayout } from '@components/organisms/ErrorBoundary';
 
 /**
  * RootNavigator component - Main app navigation container
@@ -107,15 +103,17 @@ export function RootNavigator() {
       <Stack.Screen name='RecipeView' component={RecipeView} />
       <Stack.Screen name='RecipeEdit' component={RecipeEdit} />
       <Stack.Screen name='RecipeAddManual' component={RecipeAddManual} />
-      <Stack.Screen name='RecipeAddOcr' component={GuardedRecipeAddOcr} />
-      <Stack.Screen name='RecipeAddScrape' component={GuardedRecipeAddScrape} />
+      <Stack.Group screenLayout={errorBoundaryLayout}>
+        <Stack.Screen name='RecipeAddOcr' component={RecipeAddOcr} />
+        <Stack.Screen name='RecipeAddScrape' component={RecipeAddScrape} />
+        <Stack.Screen name='BulkImportDiscovery' component={BulkImportDiscovery} />
+      </Stack.Group>
       <Stack.Screen name='LanguageSettings' component={LanguageSettings} />
       <Stack.Screen name='DefaultPersonsSettings' component={DefaultPersonsSettings} />
       <Stack.Screen name='IngredientsSettings' component={IngredientsSettings} />
       <Stack.Screen name='TagsSettings' component={TagsSettings} />
       <Stack.Screen name='BulkImportSettings' component={BulkImportSettings} />
       <Stack.Screen name='DismissedRecipesSettings' component={DismissedRecipesSettings} />
-      <Stack.Screen name='BulkImportDiscovery' component={GuardedBulkImportDiscovery} />
       <Stack.Screen name='BulkImportValidation' component={BulkImportValidation} />
       <Stack.Screen name='BugReport' component={BugReport} />
     </Stack.Navigator>

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -48,6 +48,8 @@ import { RecipeRecommendation } from '@components/organisms/RecipeRecommendation
 import { RecommendationSkeletonRow } from '@components/molecules/RecommendationSkeletonRow';
 
 import React, { useEffect, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { TabScreenNavigation } from '@customTypes/ScreenTypes';
 import { useResetOnChange } from '@hooks/useResetOnChange';
 import { FlatList, RefreshControl, View } from 'react-native';
 import { Text, useTheme } from 'react-native-paper';
@@ -103,6 +105,15 @@ export function Home() {
   useResetOnChange([recipes, ingredients, tags, seasonFilter], () =>
     setIsLoadingRecommendations(true)
   );
+
+  // Search derives its filter lists from every recipe on first render, so warm
+  // it from the landing tab instead of paying for it on the first tap.
+  // Trade-off: a preloaded tab is exempt from `freezeOnBlur` until the user
+  // actually visits it (JUMP_TO clears the preload key).
+  const { preload } = useNavigation<TabScreenNavigation>();
+  useEffect(() => {
+    preload('Search');
+  }, [preload]);
 
   useEffect(() => {
     homeLogger.debug('Loading smart recipe recommendations', {

--- a/src/screens/recipe/RecipeFormScreen.tsx
+++ b/src/screens/recipe/RecipeFormScreen.tsx
@@ -31,7 +31,7 @@ import React, { ReactNode, useRef, useState } from 'react';
 import { Keyboard, KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Snackbar, useTheme } from 'react-native-paper';
-import { FieldErrors, FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { FieldErrors, FormProvider, useForm, useFormContext, useFormState } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import {
@@ -43,6 +43,7 @@ import { RecipePropType } from '@customTypes/RecipeNavigationTypes';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
 import { clearCache } from '@utils/FileGestion';
 import { useRecipes } from '@hooks/useRecipes';
+import { useUnsavedChangesGuard } from '@hooks/useUnsavedChangesGuard';
 import { AppBar } from '@components/organisms/AppBar';
 import { useI18n } from '@utils/i18n';
 import { Alert } from '@components/dialogs/Alert';
@@ -248,6 +249,15 @@ function RecipeFormBody({
   const tags = useRecipeTags();
   const editingIngredientCountRef = useIngredientFocusRef();
   useScalingOnPersonsChange(form, form.getValues('recipePersons'), editingIngredientCountRef);
+  const { isDirty } = useFormState({ control: form.control });
+  const holdsImportedContent = mode === 'addFromScrape';
+  const unsavedChangesGuard = useUnsavedChangesGuard(isDirty || holdsImportedContent);
+
+  /** Disarms the discard guard, then hands off to the caller's save handler. */
+  const completeSave = (savedRecipe: recipeTableElement, scaledFromServings?: number) => {
+    unsavedChangesGuard.allowRemoval();
+    onSaveSuccess(savedRecipe, scaledFromServings);
+  };
 
   /** Opens the shared image-select modal targeting the given OCR field. */
   const openModalForField = (field: OcrModalTarget) => {
@@ -349,7 +359,7 @@ function RecipeFormBody({
       }
 
       clearCache();
-      onSaveSuccess(savedRecipe, scaledFromServings);
+      completeSave(savedRecipe, scaledFromServings);
     } catch (error) {
       recipeLogger.error('editValidation failed with unexpected error', { error });
       showSaveErrorDialog('failedToEditRecipe', form.getValues('recipeTitle'), error);
@@ -387,7 +397,7 @@ function RecipeFormBody({
           content: t('addedToDatabase', { recipeName: recipeToAdd.title }),
           confirmText: t('understood'),
           onConfirm: () =>
-            onSaveSuccess(savedRecipe, getServingsScaledFrom(recipeToAdd.persons, defaultPersons)),
+            completeSave(savedRecipe, getServingsScaledFrom(recipeToAdd.persons, defaultPersons)),
         });
       } catch (error) {
         validationLogger.error('Failed to validate and add recipe to database', {
@@ -590,6 +600,18 @@ function RecipeFormBody({
         isVisible={dialogs.isValidationDialogOpen}
         testId={RECIPE_TEST_ID}
         onClose={dialogs.hideValidationDialog}
+      />
+
+      <Alert
+        testId={`${RECIPE_TEST_ID}UnsavedChanges`}
+        isVisible={unsavedChangesGuard.isDiscardDialogVisible}
+        title={t('alerts.unsavedChanges.title')}
+        content={t('alerts.unsavedChanges.content')}
+        confirmText={t('alerts.unsavedChanges.discard')}
+        cancelText={t('alerts.unsavedChanges.keepEditing')}
+        onClose={unsavedChangesGuard.dismissDialog}
+        onConfirm={unsavedChangesGuard.confirmDiscard}
+        onCancel={unsavedChangesGuard.cancelDiscard}
       />
 
       {dialogs.similarityDialog.item && (

--- a/src/translations/en/alerts.ts
+++ b/src/translations/en/alerts.ts
@@ -34,6 +34,12 @@ export default {
     titleTime: 'Enter a preparation time',
     nutrition: 'Fill in all nutrition values',
   },
+  unsavedChanges: {
+    title: 'Discard changes?',
+    content: 'This recipe has unsaved changes. If you leave now, they will be lost.',
+    discard: 'Discard',
+    keepEditing: 'Keep editing',
+  },
   ocrRecipe: {
     explanationText: 'Choose a picture:',
     photo: 'Take a new photo',

--- a/src/translations/en/index.ts
+++ b/src/translations/en/index.ts
@@ -42,6 +42,7 @@ export default {
   alerts: {
     missingElements: alerts.missingElements,
     inlineErrors: alerts.inlineErrors,
+    unsavedChanges: alerts.unsavedChanges,
     ocrRecipe: alerts.ocrRecipe,
     tagSimilarity: alerts.tagSimilarity,
     ingredientSimilarity: alerts.ingredientSimilarity,

--- a/src/translations/fr/alerts.ts
+++ b/src/translations/fr/alerts.ts
@@ -32,6 +32,13 @@ export default {
     titleTime: 'Indiquez un temps de préparation',
     nutrition: 'Renseignez toutes les valeurs nutritionnelles',
   },
+  unsavedChanges: {
+    title: 'Abandonner les modifications ?',
+    content:
+      'Cette recette contient des modifications non enregistrées. Si vous quittez maintenant, elles seront perdues.',
+    discard: 'Abandonner',
+    keepEditing: 'Continuer la modification',
+  },
   ocrRecipe: {
     explanationText: 'Choisissez une image:',
     photo: 'Prendre une nouvelle photo',

--- a/src/translations/fr/index.ts
+++ b/src/translations/fr/index.ts
@@ -44,6 +44,7 @@ export default {
   alerts: {
     missingElements: alerts.missingElements,
     inlineErrors: alerts.inlineErrors,
+    unsavedChanges: alerts.unsavedChanges,
     ocrRecipe: alerts.ocrRecipe,
     tagSimilarity: alerts.tagSimilarity,
     ingredientSimilarity: alerts.ingredientSimilarity,

--- a/tests/e2e/asserts/alerts/en/unsavedChangesDialog.yaml
+++ b/tests/e2e/asserts/alerts/en/unsavedChangesDialog.yaml
@@ -1,0 +1,21 @@
+appId: "com.recipedia"
+---
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Title"
+    text: "Discard changes?"
+    label: "Discard dialog title is rendered"
+
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Content"
+    text: "This recipe has unsaved changes. If you leave now, they will be lost."
+    label: "Discard dialog message is rendered"
+
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Cancel-text"
+    text: "Keep editing"
+    label: "Keep editing button is rendered"
+
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Confirm-text"
+    text: "Discard"
+    label: "Discard button is rendered"

--- a/tests/e2e/asserts/alerts/fr/unsavedChangesDialog.yaml
+++ b/tests/e2e/asserts/alerts/fr/unsavedChangesDialog.yaml
@@ -1,0 +1,21 @@
+appId: "com.recipedia"
+---
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Title"
+    text: "Abandonner les modifications ?"
+    label: "Discard dialog title is rendered"
+
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Content"
+    text: "Cette recette contient des modifications non enregistrées. Si vous quittez maintenant, elles seront perdues."
+    label: "Discard dialog message is rendered"
+
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Cancel-text"
+    text: "Continuer la modification"
+    label: "Keep editing button is rendered"
+
+- assertVisible:
+    id: "RecipeUnsavedChanges::Dialog::Confirm-text"
+    text: "Abandonner"
+    label: "Discard button is rendered"

--- a/tests/e2e/cases/duplicates-ingredient/1_ingredient_unique.yaml
+++ b/tests/e2e/cases/duplicates-ingredient/1_ingredient_unique.yaml
@@ -233,6 +233,10 @@ tags:
     label: "Cleanup - Exit recipe creation without saving"
 
 - runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
+- runFlow:
     file: "../../flows/parameters/ingredients/navigateToIngredientsSettings.yaml"
     label: "Cleanup - Navigate to Ingredients Settings"
 

--- a/tests/e2e/cases/duplicates-recipe/4_recipe_ingredients.yaml
+++ b/tests/e2e/cases/duplicates-recipe/4_recipe_ingredients.yaml
@@ -74,6 +74,10 @@ tags:
     label: "Action - Go back to home"
 
 - runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
+- runFlow:
     file: "../../flows/recipe/adding/createRecipeWithDifferentIngredients.yaml"
     label: "Action - Create recipe with different ingredients"
 

--- a/tests/e2e/cases/recipe-create/2_manual_cancel.yaml
+++ b/tests/e2e/cases/recipe-create/2_manual_cancel.yaml
@@ -42,6 +42,10 @@ tags:
 - tapOn:
     id: "Recipe::AppBar::BackButton"
     label: "Action - Cancel recipe adding"
+
+- runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
 - tapOn:
     id: "BottomTabs::Search"
     label: "Verification - Navigate to Search screen"

--- a/tests/e2e/cases/recipe-edit/10_discard_unsaved_changes.yaml
+++ b/tests/e2e/cases/recipe-edit/10_discard_unsaved_changes.yaml
@@ -1,0 +1,112 @@
+name: "10 - Recipe Edit Discard Unsaved Changes Flow"
+appId: "com.recipedia"
+tags:
+  - recipe-edit
+---
+- tapOn:
+    id: "BottomTabs::Search"
+    label: "Action - Navigate to Search screen"
+
+- waitForAnimationToEnd
+
+- scrollUntilVisible:
+    element:
+      text: "Pesto Pasta"
+    direction: DOWN
+    speed: 40
+    timeout: 120000
+    centerElement: true
+    label: "Action - Scroll to find Pesto Pasta"
+
+- waitForAnimationToEnd
+
+- tapOn:
+    text: "Pesto Pasta"
+    label: "Action - Open Pesto Pasta recipe"
+
+- runFlow:
+    file: "../../asserts/recipe/common/buttonsReadOnly.yaml"
+    label: "Assert - Verify read-only mode buttons"
+
+- runFlow:
+    file: "../../flows/recipe/tapRecipeEdit.yaml"
+    label: "Action - Enter edit mode"
+
+- runFlow:
+    file: "../../asserts/recipe/common/buttonsEdit.yaml"
+    label: "Assert - Verify edit mode buttons"
+
+# A pristine form must not be guarded: leaving immediately has nothing to lose.
+- tapOn:
+    id: "Recipe::AppBar::Cancel"
+    label: "Action - Cancel without touching any field"
+
+- assertNotVisible:
+    id: "RecipeUnsavedChanges::Dialog::Title"
+    text: "Discard changes?"
+    label: "Assert - No discard prompt for a form that was never edited"
+
+- runFlow:
+    file: "../../asserts/recipe/common/buttonsReadOnly.yaml"
+    label: "Assert - Back in read-only mode"
+
+- runFlow:
+    file: "../../flows/recipe/tapRecipeEdit.yaml"
+    label: "Action - Re-enter edit mode"
+
+- runFlow:
+    file: "../../flows/recipe/adding/setRecipeTitle.yaml"
+    env:
+      TITLE: "Discarded Pesto Title"
+    label: "Action - Edit the title so the form becomes dirty"
+
+# Editing the title scrolls it into the centre of the form, which leaves the
+# image button above the viewport once the guard restores the same scroll offset.
+- scrollUntilVisible:
+    element:
+      id: "RecipeImage::RoundButton"
+    direction: UP
+    speed: 20
+    label: "Action - Scroll back to the top of the form"
+
+# Keep editing: the guard must cancel the navigation and preserve the edit.
+- tapOn:
+    id: "Recipe::AppBar::Cancel"
+    label: "Action - Attempt to leave the dirty form"
+
+- runFlow:
+    file: "../../asserts/alerts/en/unsavedChangesDialog.yaml"
+    label: "Assert - Discard confirmation is raised"
+
+- tapOn:
+    id: "RecipeUnsavedChanges::Dialog::Cancel"
+    label: "Action - Choose to keep editing"
+
+- waitForAnimationToEnd
+
+- runFlow:
+    file: "../../asserts/recipe/common/buttonsEdit.yaml"
+    label: "Assert - Still in edit mode after keeping the edits"
+
+- assertVisible:
+    id: "RecipeTitle::CustomTextInput"
+    text: "Discarded Pesto Title"
+    label: "Assert - The pending edit survived the cancelled navigation"
+
+# Discard: the guard must replay the navigation and drop the edit.
+- tapOn:
+    id: "Recipe::AppBar::Cancel"
+    label: "Action - Attempt to leave the dirty form again"
+
+- runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
+- runFlow:
+    file: "../../asserts/recipe/common/buttonsReadOnly.yaml"
+    label: "Assert - Returned to read-only mode"
+
+- assertVisible:
+    id: "RecipeTitle::Text"
+    text: "PESTO PASTA"
+    label: "Assert - The original title is intact, the edit was dropped"

--- a/tests/e2e/cases/recipe-edit/4_edit_cancel.yaml
+++ b/tests/e2e/cases/recipe-edit/4_edit_cancel.yaml
@@ -75,6 +75,10 @@ tags:
     label: "Action - Cancel changes and return to read-only mode"
 
 - runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
+- runFlow:
     file: "../../asserts/recipe/common/buttonsReadOnly.yaml"
     label: "Assert - Verify returned to read-only mode"
 

--- a/tests/e2e/cases/recipe-edit/8_edit_save_edit_cancel_restores_saved.yaml
+++ b/tests/e2e/cases/recipe-edit/8_edit_save_edit_cancel_restores_saved.yaml
@@ -76,6 +76,10 @@ tags:
     id: "Recipe::AppBar::Cancel"
     label: "Action - Cancel the draft edit"
 
+- runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
 - extendedWaitUntil:
     visible:
       id: "Recipe::AppBar::Edit"

--- a/tests/e2e/cases/recipe-edit/9_cancel_re_enter_no_inline_errors.yaml
+++ b/tests/e2e/cases/recipe-edit/9_cancel_re_enter_no_inline_errors.yaml
@@ -98,6 +98,10 @@ tags:
     id: "Recipe::AppBar::Cancel"
     label: "Action - Cancel the draft edit (clears touched fields via form.reset)"
 
+- runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
 - extendedWaitUntil:
     visible:
       id: "Recipe::AppBar::Edit"

--- a/tests/e2e/cases/recipe-edit/ci/10_discard_unsaved_changes.yaml
+++ b/tests/e2e/cases/recipe-edit/ci/10_discard_unsaved_changes.yaml
@@ -1,0 +1,14 @@
+name: "10 - Recipe Edit Discard Unsaved Changes Flow"
+appId: "com.recipedia"
+tags:
+  - recipe-edit
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: "../../../flows/setupTest.yaml"
+          label: "Setup - Launch app and wait for ready"
+      - runFlow:
+          file: "../10_discard_unsaved_changes.yaml"
+          label: "Run 10 - Recipe Edit Discard Unsaved Changes Flow"

--- a/tests/e2e/cases/web-edge-cases/3_web_cancel_after_validation.yaml
+++ b/tests/e2e/cases/web-edge-cases/3_web_cancel_after_validation.yaml
@@ -42,6 +42,10 @@ tags:
     id: "Recipe::AppBar::BackButton"
     label: "Action - Cancel recipe creation by pressing back"
 
+- runFlow:
+    file: "../../flows/recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"
+
 - assertNotVisible:
     id: "RecipeTitle::CustomTextInput"
     label: "Assert - Recipe screen is closed"

--- a/tests/e2e/flows/performance/ocrFlow.yaml
+++ b/tests/e2e/flows/performance/ocrFlow.yaml
@@ -69,3 +69,7 @@ appId: "com.recipedia"
 - tapOn:
     id: "Recipe::AppBar::BackButton"
     label: "Cancel OCR without saving"
+
+- runFlow:
+    file: "../recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"

--- a/tests/e2e/flows/performance/webScraping.yaml
+++ b/tests/e2e/flows/performance/webScraping.yaml
@@ -38,3 +38,7 @@ appId: "com.recipedia"
 - tapOn:
     id: "Recipe::AppBar::BackButton"
     label: "Cancel without saving"
+
+- runFlow:
+    file: "../recipe/discardRecipeChanges.yaml"
+    label: "Action - Confirm discarding the unsaved changes"

--- a/tests/e2e/flows/recipe/discardRecipeChanges.yaml
+++ b/tests/e2e/flows/recipe/discardRecipeChanges.yaml
@@ -1,0 +1,19 @@
+appId: "com.recipedia"
+---
+# Confirm the discard dialog raised when leaving a recipe form with unsaved edits.
+#
+# Call this right after tapping Cancel or the AppBar back arrow on a form that
+# has been modified. The dialog is asserted rather than probed conditionally:
+# a flow that reaches here is expected to have a dirty form, so a missing dialog
+# is a regression in the guard, not a state to tolerate.
+
+- runFlow:
+    file: "../../asserts/alerts/en/unsavedChangesDialog.yaml"
+    label: "Assert - Discard confirmation is raised for the unsaved edits"
+
+- tapOn:
+    id: "RecipeUnsavedChanges::Dialog::Confirm"
+    label: "Action - Discard the unsaved changes and leave"
+
+- waitForAnimationToEnd:
+    label: "Wait for the dialog dismissal and the pending navigation"

--- a/tests/e2e/recipe-edit.yaml
+++ b/tests/e2e/recipe-edit.yaml
@@ -18,3 +18,4 @@ executionOrder:
     - "7 - Recipe Edit Inline Field Errors Flow"
     - "8 - Recipe Edit Save Then Cancel Restores Saved Flow"
     - "9 - Recipe Edit Cancel Then Re-Enter No Inline Errors Flow"
+    - "10 - Recipe Edit Discard Unsaved Changes Flow"

--- a/tests/mocks/components/dialogs/Alert-mock.tsx
+++ b/tests/mocks/components/dialogs/Alert-mock.tsx
@@ -30,13 +30,25 @@ export function alertMock({
       </TouchableOpacity>
 
       {onConfirm && (
-        <TouchableOpacity testID={dialogTestId + '::OnConfirm'} onPress={onConfirm}>
+        <TouchableOpacity
+          testID={dialogTestId + '::OnConfirm'}
+          onPress={() => {
+            onClose();
+            void onConfirm();
+          }}
+        >
           <Text>OnConfirm</Text>
         </TouchableOpacity>
       )}
 
       {onCancel && (
-        <TouchableOpacity testID={dialogTestId + '::OnCancel'} onPress={onCancel}>
+        <TouchableOpacity
+          testID={dialogTestId + '::OnCancel'}
+          onPress={() => {
+            onClose();
+            onCancel();
+          }}
+        >
           <Text>OnCancel</Text>
         </TouchableOpacity>
       )}

--- a/tests/mocks/deps/react-hook-form-mock.tsx
+++ b/tests/mocks/deps/react-hook-form-mock.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode, useState } from 'react';
+
+/**
+ * Freezes the form context value, reproducing what React Compiler does to
+ * `<FormProvider {...form}>` in a build: `useForm` returns a stable object it
+ * mutates each render, so the compiler caches the spread and consumers stop
+ * re-rendering on `formState` transitions. Jest runs without the compiler, so
+ * a `form.formState.x` read looks correct there while being stale on a device.
+ * Consumers subscribing through `control` are unaffected.
+ */
+export function reactHookFormFrozenProviderMock() {
+  const actual = jest.requireActual('react-hook-form');
+
+  function FrozenFormProvider({ children, ...form }: { children: ReactNode }) {
+    const [frozenForm] = useState(form);
+    return <actual.FormProvider {...frozenForm}>{children}</actual.FormProvider>;
+  }
+
+  return { ...actual, FormProvider: FrozenFormProvider };
+}

--- a/tests/mocks/deps/react-navigation-mock.tsx
+++ b/tests/mocks/deps/react-navigation-mock.tsx
@@ -20,8 +20,9 @@ export function resetMockRouteParams() {
 }
 
 export function reactNavigationMock() {
+  const actual = jest.requireActual('@react-navigation/native');
   return {
-    ...jest.requireActual('@react-navigation/native'),
+    ...actual,
     useNavigation: () => ({
       navigate: mockNavigate,
       addListener: mockAddListener,
@@ -34,7 +35,8 @@ export function reactNavigationMock() {
     useFocusEffect: jest.fn(() => {}),
     useIsFocused: () => true,
     CommonActions: {
-      reset: jest.fn(config => ({ type: 'reset', ...config })),
+      ...actual.CommonActions,
+      reset: jest.fn(config => actual.CommonActions.reset(config)),
     },
   };
 }

--- a/tests/mocks/deps/react-navigation-mock.tsx
+++ b/tests/mocks/deps/react-navigation-mock.tsx
@@ -8,6 +8,7 @@ export const mockAddListener = jest.fn((event, handler) => {
 
 export const mockGoBack = jest.fn();
 export const mockDispatch = jest.fn();
+export const mockPreload = jest.fn();
 
 let mockRouteParams: Record<string, unknown> = {};
 
@@ -51,6 +52,7 @@ export function reactNavigationMock() {
       addListener: mockAddListener,
       goBack: mockGoBack,
       dispatch: mockDispatch,
+      preload: mockPreload,
     }),
     useRoute: () => ({
       params: mockRouteParams,

--- a/tests/mocks/deps/react-navigation-mock.tsx
+++ b/tests/mocks/deps/react-navigation-mock.tsx
@@ -19,6 +19,29 @@ export function resetMockRouteParams() {
   mockRouteParams = {};
 }
 
+type PreventRemoveCallback = (options: { data: { action: unknown } }) => void;
+
+let preventRemoveRegistration: {
+  preventRemove: boolean;
+  callback: PreventRemoveCallback;
+} | null = null;
+
+export function triggerPreventRemove(action: unknown = { type: 'GO_BACK' }) {
+  if (!preventRemoveRegistration?.preventRemove) {
+    return false;
+  }
+  preventRemoveRegistration.callback({ data: { action } });
+  return true;
+}
+
+export function isPreventRemoveArmed() {
+  return preventRemoveRegistration?.preventRemove ?? false;
+}
+
+export function resetPreventRemove() {
+  preventRemoveRegistration = null;
+}
+
 export function reactNavigationMock() {
   const actual = jest.requireActual('@react-navigation/native');
   return {
@@ -34,6 +57,9 @@ export function reactNavigationMock() {
     }),
     useFocusEffect: jest.fn(() => {}),
     useIsFocused: () => true,
+    usePreventRemove: (preventRemove: boolean, callback: PreventRemoveCallback) => {
+      preventRemoveRegistration = { preventRemove, callback };
+    },
     CommonActions: {
       ...actual.CommonActions,
       reset: jest.fn(config => actual.CommonActions.reset(config)),

--- a/tests/unit/components/organisms/ErrorBoundary.test.tsx
+++ b/tests/unit/components/organisms/ErrorBoundary.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text } from 'react-native';
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { ErrorBoundary, withErrorBoundary } from '@components/organisms/ErrorBoundary';
+import { ErrorBoundary, errorBoundaryLayout } from '@components/organisms/ErrorBoundary';
 import { mockHideAsync } from '@mocks/deps/expo-splash-screen-mock';
 import { mockReportCrash } from '@mocks/utils/bug-report-mock';
 
@@ -200,43 +200,32 @@ describe('ErrorBoundary', () => {
     expect(mockReportCrash.mock.calls[0][0].message).toBe('Unknown render error');
   });
 
-  describe('withErrorBoundary', () => {
-    test('renders wrapped component output when it does not throw', () => {
-      const Guarded = withErrorBoundary(Boom);
-      const { getByTestId } = render(<Guarded crash={false} />);
+  describe('errorBoundaryLayout', () => {
+    test('renders the screen untouched when it does not throw', () => {
+      const { getByTestId } = render(errorBoundaryLayout({ children: <Boom crash={false} /> }));
 
       expect(getByTestId('SafeChild')).toBeTruthy();
     });
 
-    test('renders fallback when wrapped component throws', () => {
-      const Guarded = withErrorBoundary(Boom, 'GuardedBoom');
-      const { getByTestId } = render(<Guarded crash={true} />);
+    test('contains a screen render error in the fallback', () => {
+      const { getByTestId, queryByTestId } = render(
+        errorBoundaryLayout({ children: <Boom crash={true} /> })
+      );
 
-      expect(getByTestId('GuardedBoom')).toBeTruthy();
+      expect(queryByTestId('SafeChild')).toBeNull();
+      expect(getByTestId('ErrorFallback::Title')).toBeTruthy();
     });
 
-    test('sets a descriptive displayName from the component name', () => {
-      const Guarded = withErrorBoundary(Boom);
+    test('reports the screen error when the report action is pressed', async () => {
+      const { getByTestId } = render(errorBoundaryLayout({ children: <Boom crash={true} /> }));
 
-      expect(Guarded.displayName).toBe('withErrorBoundary(Boom)');
-    });
+      await act(async () => {
+        fireEvent.press(getByTestId('ErrorFallback::Report'));
+      });
 
-    test('prefers an explicit displayName over the function name', () => {
-      const Named = ({ crash }: { crash: boolean }) => <Boom crash={crash} />;
-      Named.displayName = 'ExplicitName';
-
-      const Guarded = withErrorBoundary(Named);
-
-      expect(Guarded.displayName).toBe('withErrorBoundary(ExplicitName)');
-    });
-
-    test('falls back to "Component" for an anonymous component', () => {
-      const nameless = jest.fn(() => null);
-      Object.defineProperty(nameless, 'name', { value: '' });
-
-      const Guarded = withErrorBoundary(nameless as unknown as React.ComponentType);
-
-      expect(Guarded.displayName).toBe('withErrorBoundary(Component)');
+      const [reportedError] = mockReportCrash.mock.calls[0];
+      expect(reportedError).toBeInstanceOf(Error);
+      expect(reportedError.message).toBe('render exploded');
     });
   });
 });

--- a/tests/unit/hooks/useUnsavedChangesGuard.test.tsx
+++ b/tests/unit/hooks/useUnsavedChangesGuard.test.tsx
@@ -1,0 +1,174 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useUnsavedChangesGuard } from '@hooks/useUnsavedChangesGuard';
+import {
+  isPreventRemoveArmed,
+  mockDispatch,
+  resetPreventRemove,
+  triggerPreventRemove,
+} from '@mocks/deps/react-navigation-mock';
+
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
+
+const firstAction = { type: 'GO_BACK' };
+const secondAction = { type: 'NAVIGATE', payload: { name: 'Recipes' } };
+
+beforeEach(() => {
+  resetPreventRemove();
+  jest.clearAllMocks();
+});
+
+describe('useUnsavedChangesGuard', () => {
+  test('does not arm the guard when there are no unsaved changes', () => {
+    renderHook(() => useUnsavedChangesGuard(false));
+
+    expect(isPreventRemoveArmed()).toBe(false);
+  });
+
+  test('triggering removal without unsaved changes returns false and skips the dialog', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(false));
+
+    let dispatched: boolean = false;
+    act(() => {
+      dispatched = triggerPreventRemove(firstAction);
+    });
+
+    expect(dispatched).toBe(false);
+    expect(result.current.isDiscardDialogVisible).toBe(false);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('triggering removal with unsaved changes shows the dialog without dispatching', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(true);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('confirmDiscard hides the dialog and dispatches the intercepted action', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+    act(() => {
+      result.current.confirmDiscard();
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(false);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(firstAction);
+  });
+
+  test('cancelDiscard hides the dialog and dispatches nothing', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+    act(() => {
+      result.current.cancelDiscard();
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(false);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('confirmDiscard dispatches when the dialog dismiss handler runs before it', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+    act(() => {
+      result.current.dismissDialog();
+      result.current.confirmDiscard();
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(false);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(firstAction);
+  });
+
+  test('cancelDiscard drops the pending action so a later confirm is inert', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+    act(() => {
+      result.current.cancelDiscard();
+      result.current.confirmDiscard();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('confirmDiscard with no pending action dispatches nothing', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      result.current.confirmDiscard();
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(false);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('allowRemoval makes subsequent triggers dispatch immediately without showing the dialog', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      result.current.allowRemoval();
+    });
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(false);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(firstAction);
+  });
+
+  test('cancelling then triggering again re-arms the dialog with the new action', () => {
+    const { result } = renderHook(() => useUnsavedChangesGuard(true));
+
+    act(() => {
+      triggerPreventRemove(firstAction);
+    });
+    act(() => {
+      result.current.cancelDiscard();
+    });
+    act(() => {
+      triggerPreventRemove(secondAction);
+    });
+
+    expect(result.current.isDiscardDialogVisible).toBe(true);
+
+    act(() => {
+      result.current.confirmDiscard();
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(secondAction);
+  });
+
+  test('flipping hasUnsavedChanges to false disarms the guard', () => {
+    const { rerender } = renderHook(
+      ({ hasUnsavedChanges }: { hasUnsavedChanges: boolean }) =>
+        useUnsavedChangesGuard(hasUnsavedChanges),
+      { initialProps: { hasUnsavedChanges: true } }
+    );
+
+    expect(isPreventRemoveArmed()).toBe(true);
+
+    rerender({ hasUnsavedChanges: false });
+
+    expect(isPreventRemoveArmed()).toBe(false);
+  });
+});

--- a/tests/unit/screens/BulkImportValidation.test.tsx
+++ b/tests/unit/screens/BulkImportValidation.test.tsx
@@ -259,9 +259,8 @@ describe('BulkImportValidation', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'reset',
-        index: 0,
-        routes: [{ name: 'Tabs' }],
+        type: 'RESET',
+        payload: { index: 0, routes: [{ name: 'Tabs' }] },
       })
     );
   });

--- a/tests/unit/screens/Home.test.tsx
+++ b/tests/unit/screens/Home.test.tsx
@@ -9,6 +9,11 @@ import RecipeDatabase from '@utils/RecipeDatabase';
 import { testIngredients } from '@test-data/ingredientsDataset';
 import { testTags } from '@test-data/tagsDataset';
 import { SeasonFilterProvider } from '@context/SeasonFilterContext';
+import { mockPreload } from '@mocks/deps/react-navigation-mock';
+
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
 
 jest.mock(
   '@components/organisms/VerticalBottomButtons',
@@ -72,6 +77,12 @@ describe('Home Screen', () => {
     await database.addMultipleRecipes(testRecipes);
   });
   afterEach(async () => await database.closeAndReset());
+
+  test('preloads the Search tab on mount', async () => {
+    await renderHomeAndWaitForRecommendations();
+
+    expect(mockPreload).toHaveBeenCalledWith('Search');
+  });
 
   // -------- INITIAL RENDERING TESTS --------
   test('renders all navigation buttons correctly', async () => {

--- a/tests/unit/screens/recipe/RecipeAddManual.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddManual.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+import {
+  isPreventRemoveArmed,
+  mockDispatch,
+  resetPreventRemove,
+  triggerPreventRemove,
+} from '@mocks/deps/react-navigation-mock';
 import { testRecipes } from '@test-data/recipesDataset';
 import RecipeDatabase from '@utils/RecipeDatabase';
 import { AddManuallyProp } from '@customTypes/RecipeNavigationTypes';
@@ -17,10 +23,15 @@ import {
   checkTime,
   checkTitle,
   mockNavigation,
+  fillMinimalRecipe,
   renderRoute,
   setupDb,
   teardownDb,
 } from './recipeTestHelpers';
+
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
 
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
@@ -81,6 +92,7 @@ describe('RecipeAddManual', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    resetPreventRemove();
     dbInstance = await setupDb();
   });
 
@@ -257,6 +269,52 @@ describe('RecipeAddManual', () => {
       await waitFor(() => {
         expect(mockNavigation.goBack).toHaveBeenCalled();
       });
+    });
+
+    test('a dirty add form asks to confirm before discarding', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddManually);
+
+      fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), 'Half Typed Recipe');
+
+      await waitFor(() => {
+        expect(isPreventRemoveArmed()).toBe(true);
+      });
+
+      act(() => {
+        triggerPreventRemove({ type: 'GO_BACK' });
+      });
+
+      expect(getByTestId('RecipeUnsavedChanges::Alert::IsVisible').props.children).toBe(true);
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      fireEvent.press(getByTestId('RecipeUnsavedChanges::Alert::OnConfirm'));
+
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
+    });
+
+    test('a saved add form leaves without asking even though it stays dirty', async () => {
+      const { getByTestId } = await renderRoute(mockRouteAddManually);
+
+      await fillMinimalRecipe(getByTestId, 'Wholly Unique Guarded Save Recipe');
+
+      fireEvent.press(getByTestId('Recipe::BottomActionButton'));
+      await waitFor(() => {
+        expect(getByTestId('Recipe::Alert::IsVisible').props.children).toBe(true);
+      });
+      fireEvent.press(getByTestId('Recipe::Alert::OnConfirm'));
+
+      await waitFor(() => {
+        expect(mockNavigation.goBack).toHaveBeenCalled();
+      });
+
+      expect(isPreventRemoveArmed()).toBe(true);
+
+      act(() => {
+        triggerPreventRemove({ type: 'GO_BACK' });
+      });
+
+      expect(getByTestId('RecipeUnsavedChanges::Alert::IsVisible').props.children).toBe(false);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
     });
   });
 

--- a/tests/unit/screens/recipe/RecipeAddOcr.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddOcr.test.tsx
@@ -21,6 +21,10 @@ import {
   teardownDb,
 } from './recipeTestHelpers';
 
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
+
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
 

--- a/tests/unit/screens/recipe/RecipeAddScrape.test.tsx
+++ b/tests/unit/screens/recipe/RecipeAddScrape.test.tsx
@@ -8,6 +8,10 @@ import { RecipeFormScreen } from '@screens/recipe/RecipeFormScreen';
 
 import { mockNavigation, renderRoute, setupDb, teardownDb } from './recipeTestHelpers';
 
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
+
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
 

--- a/tests/unit/screens/recipe/RecipeEdit.test.tsx
+++ b/tests/unit/screens/recipe/RecipeEdit.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+import {
+  isPreventRemoveArmed,
+  mockDispatch,
+  resetPreventRemove,
+  triggerPreventRemove,
+} from '@mocks/deps/react-navigation-mock';
 import { testRecipes } from '@test-data/recipesDataset';
 import RecipeDatabase from '@utils/RecipeDatabase';
 import { EditRecipeProp, RecipePropType } from '@customTypes/RecipeNavigationTypes';
@@ -24,6 +30,10 @@ import {
   setupDb,
   teardownDb,
 } from './recipeTestHelpers';
+
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
 
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
@@ -84,12 +94,99 @@ describe('RecipeEdit', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    resetPreventRemove();
     dbInstance = await setupDb();
     mockRouteEdit = { mode: 'edit', recipe: { ...testRecipes[6]! } } as EditRecipeProp;
   });
 
   afterEach(async () => {
     await teardownDb();
+  });
+
+  describe('unsaved changes guard', () => {
+    const discardAlertId = 'RecipeUnsavedChanges::Alert';
+    const backAction = { type: 'GO_BACK' };
+
+    test('leaves an untouched form free to navigate away', async () => {
+      const { getByTestId } = await renderRoute(mockRouteEdit);
+
+      expect(isPreventRemoveArmed()).toBe(false);
+      expect(triggerPreventRemove(backAction)).toBe(false);
+      expect(getByTestId(`${discardAlertId}::IsVisible`).props.children).toBe(false);
+    });
+
+    test('shows the discard dialog when leaving a dirty form', async () => {
+      const { getByTestId } = await renderRoute(mockRouteEdit);
+
+      fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), 'Dirty Title');
+
+      await waitFor(() => {
+        expect(isPreventRemoveArmed()).toBe(true);
+      });
+
+      act(() => {
+        triggerPreventRemove(backAction);
+      });
+
+      expect(getByTestId(`${discardAlertId}::IsVisible`).props.children).toBe(true);
+      expect(getByTestId(`${discardAlertId}::Title`).props.children).toBe(
+        'alerts.unsavedChanges.title'
+      );
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    test('keeps the user on the form when the discard is cancelled', async () => {
+      const { getByTestId } = await renderRoute(mockRouteEdit);
+
+      fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), 'Dirty Title');
+      await waitFor(() => {
+        expect(isPreventRemoveArmed()).toBe(true);
+      });
+      act(() => {
+        triggerPreventRemove(backAction);
+      });
+
+      fireEvent.press(getByTestId(`${discardAlertId}::OnCancel`));
+
+      expect(getByTestId(`${discardAlertId}::IsVisible`).props.children).toBe(false);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    test('replays the intercepted action when the discard is confirmed', async () => {
+      const { getByTestId } = await renderRoute(mockRouteEdit);
+
+      fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), 'Dirty Title');
+      await waitFor(() => {
+        expect(isPreventRemoveArmed()).toBe(true);
+      });
+      act(() => {
+        triggerPreventRemove(backAction);
+      });
+
+      fireEvent.press(getByTestId(`${discardAlertId}::OnConfirm`));
+
+      expect(getByTestId(`${discardAlertId}::IsVisible`).props.children).toBe(false);
+      expect(mockDispatch).toHaveBeenCalledWith(backAction);
+    });
+
+    test('does not block the navigation performed by a successful save', async () => {
+      const { getByTestId } = await renderRoute(mockRouteEdit);
+
+      fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), 'Saved Title');
+      fireEvent.press(getByTestId('Recipe::AppBar::Validate'));
+
+      await waitFor(() => {
+        expect(mockNavigation.dispatch).toHaveBeenCalled();
+      });
+
+      expect(isPreventRemoveArmed()).toBe(false);
+
+      act(() => {
+        triggerPreventRemove(backAction);
+      });
+
+      expect(getByTestId(`${discardAlertId}::IsVisible`).props.children).toBe(false);
+    });
   });
 
   test('renders initial state in edit mode', async () => {

--- a/tests/unit/screens/recipe/RecipeFormScreen.test.tsx
+++ b/tests/unit/screens/recipe/RecipeFormScreen.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { isPreventRemoveArmed, resetPreventRemove } from '@mocks/deps/react-navigation-mock';
+import { AddFromScrapeProp, AddManuallyProp } from '@customTypes/RecipeNavigationTypes';
+import { testIngredients } from '@test-data/ingredientsDataset';
+
+import { renderRoute, setupDb, teardownDb } from './recipeTestHelpers';
+
+jest.mock('react-hook-form', () =>
+  require('@mocks/deps/react-hook-form-mock').reactHookFormFrozenProviderMock()
+);
+
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
+
+jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
+jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
+
+jest.mock('@components/organisms/RecipeTags', () => ({
+  RecipeTags: require('@mocks/components/organisms/RecipeTags-mock').recipeTagsMock,
+}));
+jest.mock('@components/organisms/RecipeImage', () => ({
+  RecipeImage: require('@mocks/components/organisms/RecipeImage-mock').recipeImageMock,
+}));
+jest.mock('@components/organisms/RecipeText', () => ({
+  RecipeText: require('@mocks/components/organisms/RecipeText-mock').recipeTextMock,
+}));
+jest.mock('@components/organisms/RecipeNumber', () => ({
+  RecipeNumber: require('@mocks/components/organisms/RecipeNumber-mock').recipeNumberMock,
+}));
+jest.mock('@components/organisms/RecipeIngredients', () => {
+  const mocks = require('@mocks/components/organisms/RecipeIngredients-mock');
+  return {
+    RecipeIngredients: mocks.recipeIngredientsMock,
+    IngredientsTable: mocks.ingredientsTableMock,
+    IngredientRow: mocks.ingredientRowMock,
+    IngredientsAddEmpty: mocks.ingredientsAddEmptyMock,
+    IngredientsAddTail: mocks.ingredientsAddTailMock,
+  };
+});
+jest.mock('@components/organisms/RecipePreparation', () => {
+  const mocks = require('@mocks/components/organisms/RecipePreparation-mock');
+  return {
+    RecipePreparation: mocks.recipePreparationMock,
+    PreparationSection: mocks.preparationSectionMock,
+    PreparationEmptyAdd: mocks.preparationEmptyAddMock,
+    EditableStep: mocks.editableStepMock,
+  };
+});
+jest.mock('@components/molecules/NutritionTable', () =>
+  require('@mocks/components/molecules/NutritionTable-mock')
+);
+jest.mock('@components/molecules/NutritionEmptyState', () =>
+  require('@mocks/components/molecules/NutritionEmptyState-mock')
+);
+jest.mock('@components/dialogs/Alert', () => ({
+  Alert: require('@mocks/components/dialogs/Alert-mock').alertMock,
+}));
+jest.mock('@components/dialogs/ValidationQueue', () =>
+  require('@mocks/components/dialogs/ValidationQueue-mock')
+);
+jest.mock('@components/organisms/AppBar', () => ({
+  AppBar: require('@mocks/components/organisms/AppBar-mock').appBarMock,
+}));
+jest.mock('@screens/ModalImageSelect', () => ({
+  ModalImageSelect: require('@mocks/screens/ModalImageSelect-mock').modalImageSelectMock,
+}));
+
+describe('RecipeFormScreen discard guard with a frozen form provider', () => {
+  const mockRouteAddManually: AddManuallyProp = { mode: 'addManually' };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    resetPreventRemove();
+    await setupDb();
+  });
+
+  afterEach(async () => {
+    await teardownDb();
+  });
+
+  test('leaves the guard disarmed while the form is pristine', async () => {
+    await renderRoute(mockRouteAddManually);
+
+    expect(isPreventRemoveArmed()).toBe(false);
+  });
+
+  test('arms the guard when a field is edited', async () => {
+    const { getByTestId } = await renderRoute(mockRouteAddManually);
+
+    fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), 'Half Typed Recipe');
+
+    await waitFor(() => {
+      expect(isPreventRemoveArmed()).toBe(true);
+    });
+  });
+});
+
+describe('RecipeFormScreen discard guard on an imported form', () => {
+  const mockRouteAddFromScrape: AddFromScrapeProp = {
+    mode: 'addFromScrape',
+    sourceUrl: 'https://example.com/guarded-scrape',
+    scrapedData: {
+      image_Source: 'guarded-scrape.jpg',
+      title: 'Wholly Unique Guarded Scrape Recipe',
+      description: 'A scraped recipe',
+      persons: 4,
+      time: 30,
+      ingredients: [{ ...testIngredients[0], quantity: '100' }],
+      preparation: [{ title: 'Step 1', description: 'Scraped step' }],
+      tags: [],
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    resetPreventRemove();
+    await setupDb();
+  });
+
+  afterEach(async () => {
+    await teardownDb();
+  });
+
+  test('arms the guard as soon as the scraped recipe is mounted', async () => {
+    await renderRoute(mockRouteAddFromScrape);
+
+    await waitFor(() => {
+      expect(isPreventRemoveArmed()).toBe(true);
+    });
+  });
+});

--- a/tests/unit/screens/recipe/RecipeView.test.tsx
+++ b/tests/unit/screens/recipe/RecipeView.test.tsx
@@ -25,6 +25,10 @@ import {
   teardownDb,
 } from './recipeTestHelpers';
 
+jest.mock('@react-navigation/native', () =>
+  require('@mocks/deps/react-navigation-mock').reactNavigationMock()
+);
+
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 jest.mock('@utils/OCR', () => require('@mocks/utils/OCR-mock').ocrMock());
 

--- a/tests/unit/screens/recipe/recipeTestHelpers.tsx
+++ b/tests/unit/screens/recipe/recipeTestHelpers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import RecipeDatabase from '@utils/RecipeDatabase';
 import { testRecipes } from '@test-data/recipesDataset';
 import { testTags } from '@test-data/tagsDataset';
@@ -661,4 +661,31 @@ export async function setupDb() {
 export async function teardownDb() {
   const dbInstance = RecipeDatabase.getInstance();
   await dbInstance.closeAndReset();
+}
+
+export async function fillMinimalRecipe(getByTestId: GetByIdType, title: string) {
+  fireEvent.press(getByTestId('RecipeTitle::SetTextToEdit'), title);
+  fireEvent.press(getByTestId('RecipePersons::SetTextToEdit'), '4');
+  fireEvent.press(getByTestId('RecipeTime::SetTextToEdit'), '30');
+
+  fireEvent.press(getByTestId('RecipeImage::OpenModal'));
+  await waitFor(() => expect(getByTestId('ModalImageSelect')).toBeTruthy());
+  fireEvent.press(getByTestId('ModalImageSelect::Select'));
+  await waitFor(() => {
+    expect(getByTestId('RecipeImage::ImgUri').props.children).toBe('/path/to/cropped/img');
+  });
+
+  fireEvent.press(getByTestId('RecipeIngredients::AddButton::RoundButton::OnPressFunction'));
+  await waitFor(() => expect(getByTestId('RecipeIngredients::0::Row')).toBeTruthy());
+  fireEvent.press(getByTestId('RecipeIngredients::0::OnIngredientChange'), '100@@g--Spaghetti');
+  await waitFor(() => {
+    expect(getByTestId('RecipeIngredients::0::NameInput::Value').props.children).toBe('Spaghetti');
+  });
+
+  fireEvent.press(getByTestId('RecipePreparation::AddButton::RoundButton::OnPressFunction'));
+  await waitFor(() => expect(getByTestId('RecipePreparation::EditableStep::0::Step')).toBeTruthy());
+  fireEvent.changeText(
+    getByTestId('RecipePreparation::EditableStep::0::TextInputContent::CustomTextInput'),
+    'Cook pasta until al dente'
+  );
 }


### PR DESCRIPTION
Closes #499 (partially — see *Not adopted* below).

Adopts the non-visual React Navigation v7 / native-stack capabilities from #499. Visual native-feel swaps stay in #500.

## What landed

| # | Item | Commit |
|---|---|---|
| 1 | Predictive back gesture (Android) | `f467b32a` |
| 2 | `usePreventRemove` unsaved-changes guard | `1f7ac7eb` |
| 3 | Screen preloading | `147f3463` |
| 4 | Screen freezing | `00ae0a3b` |
| 6 | `layout` / `screenLayout` | `801de66b` |
| — | Housekeeping (stale TODO, nav mocks) | `7526d5d9`, `6de96a83` |

### Unsaved-changes guard
Recipe forms dropped edits silently — back, swipe, the AppBar back arrow and Cancel all popped the screen with no prompt. `useUnsavedChangesGuard` wraps `usePreventRemove` and mounts in the shared `RecipeFormScreen`, so all four editable routes are covered at once. The intercepted action is **replayed verbatim** on confirm, preserving the original destination rather than approximating it with `goBack()`.

Hiding is split from cancelling because `Alert` fires `onClose` before `onConfirm`; collapsing the two disarmed the pending action before it could be replayed. Saves route through `completeSave`, which disarms the guard — the form is still dirty when a successful save navigates.

### Preloading — deliberately narrow
Only `Home → Search`. React Navigation exempts a preloaded route from `freezeOnBlur` (`shouldFreeze: … && !isPreloaded`) and only clears a preloaded tab key on `JUMP_TO`, so **every preload trades freezing away** until the route is first opened. Recipe cards are *not* preloaded: `onPressIn` fires on every touch-down including scroll starts, dispatching navigator updates and remounting `RecipeView` far more often than a recipe was actually opened.

### Predictive back
Enabled via `android.predictiveBackGestureEnabled`, which is a first-class Expo config field — the issue's suggested `expo-build-properties` route has no such option. Audited the imperative handling: one `BackHandler` (Search keyboard dismiss), none in the copilot tutorial. RN 0.85 keeps it working via an always-enabled `OnBackPressedCallback`.

## Not adopted

**Static API / `Stack.Protected`.** `Protected` does not exist in `@react-navigation/core@7.21.5` (latest stable) — only in the `8.0.0-alpha` line. `createStaticNavigation` itself works, but migrating means rewriting `RootNavigator`, `BottomTabs` and `ScreenTypes`, replacing `NavigationContainer` in `App.tsx` (which collides with the first-launch `WelcomeScreen` gate), and repairing ~26 test suites — for no user-facing change. Recommend revisiting only if a v8 upgrade lands.

## Behaviour changes to be aware of

1. **Cancel and the AppBar back arrow now prompt**, not just hardware back and swipe. Nine existing E2E flows leave a dirty form and gained an explicit discard step.
2. **A preloaded Search tab stays unfrozen** until first opened. Documented in `ARCHITECTURE.md` rather than left implicit.

## Testing

- 4070 unit tests pass; new suites for the guard hook and `errorBoundaryLayout`
- New E2E case `10_discard_unsaved_changes` covers the full contract: a pristine form is **not** guarded, "Keep editing" cancels the navigation *and preserves the pending edit*, "Discard" leaves with the original title intact
- Dialog text asserted per locale (en/fr), button labels matched on the `-text` child Paper renders
- `typecheck` / `lint` / `prettier` / `knip` / `docs:build` clean; `expo:doctor` 21/21

⚠️ **E2E has not been executed.** The nine explicit discard steps and the new case are unverified against a device. Two of the nine (`webScraping`, `web-edge-cases/3`) are inferred dirty from `validateAllDialogs` writing into the form rather than a literal field tap — if either is actually pristine, its `assertVisible` will fail loudly, which is the intended trade-off over a silent conditional.

## Follow-ups

- Reassure/Flashlight numbers for preload and freezing (the issue asked to measure; Reassure can't observe native freezing, so Flashlight is the right instrument)
- Extend the guard to `BugReport`, which is a full RHF form whose back still discards silently
- `@react-navigation/stack` is no longer imported anywhere in `src/` — test-only legacy, candidate for removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)