### PR TITLE
fix(android): honor edge-to-edge insets around the bottom tab bar

### DIFF
--- a/src/components/organisms/VerticalBottomButtons.tsx
+++ b/src/components/organisms/VerticalBottomButtons.tsx
@@ -29,7 +29,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useResetOnChange } from '@hooks/useResetOnChange';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
 import { View } from 'react-native';
 import { CopilotStep, walkthroughable } from 'react-native-copilot';
 import { useSafeCopilot } from '@hooks/useSafeCopilot';
@@ -43,7 +43,7 @@ import { Icons } from '@assets/Icons';
 import { StackScreenNavigation } from '@customTypes/ScreenTypes';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
 import { FAB, Portal, useTheme } from 'react-native-paper';
-import { padding, screenHeight } from '@styles/spacing';
+import { padding } from '@styles/spacing';
 import { UrlInputDialog } from '@components/dialogs/UrlInputDialog';
 import { AuthenticationDialog } from '@components/dialogs/AuthenticationDialog';
 
@@ -51,6 +51,8 @@ const MAIN_FAB_SIZE = 56;
 const ACTION_BUTTON_SIZE = 40;
 const ACTION_BUTTON_SPACING = 16;
 const ACTION_BUTTON_COUNT = 4;
+/** Gap below the main FAB. Shared so the portalled FAB and the tutorial highlight align. */
+const FAB_BOTTOM_OFFSET = padding.small;
 
 /** TestIDs for FAB elements - used for E2E testing */
 const FAB_TEST_IDS = {
@@ -78,14 +80,11 @@ function VerticalBottomButtons() {
   const { navigate } = useNavigation<StackScreenNavigation>();
   const { colors } = useTheme();
   const { t } = useI18n();
-  const insets = useSafeAreaInsets();
-
-  const tabBarHeight = screenHeight / 9 + insets.bottom;
+  const tabBarHeight = React.useContext(BottomTabBarHeightContext) ?? 0;
   const copilotHeight =
     MAIN_FAB_SIZE +
     (ACTION_BUTTON_SIZE + ACTION_BUTTON_SPACING) * ACTION_BUTTON_COUNT +
     ACTION_BUTTON_SPACING;
-  const copilotBottom = tabBarHeight - MAIN_FAB_SIZE;
 
   const copilotData = useSafeCopilot();
   const copilotEvents = copilotData?.copilotEvents;
@@ -230,7 +229,7 @@ function VerticalBottomButtons() {
               testID={'HomeTutorial'}
               style={{
                 position: 'absolute',
-                bottom: copilotBottom,
+                bottom: FAB_BOTTOM_OFFSET,
                 left: padding.small,
                 right: padding.small,
                 height: copilotHeight,
@@ -283,8 +282,10 @@ function VerticalBottomButtons() {
                 },
               ]}
               onStateChange={({ open: isOpen }) => setOpen(isOpen)}
+              // Replaces Paper's own insets.bottom padding, already inside the measured height.
+              style={{ paddingBottom: tabBarHeight }}
               fabStyle={{
-                marginBottom: tabBarHeight,
+                marginBottom: FAB_BOTTOM_OFFSET,
                 marginRight: padding.small,
                 backgroundColor: colors.primaryContainer,
                 borderRadius: 999,

--- a/src/navigation/BottomTabs.tsx
+++ b/src/navigation/BottomTabs.tsx
@@ -45,8 +45,9 @@
  */
 
 import { BottomNavigation, Icon, useTheme } from 'react-native-paper';
-import { Icons, iconsSize } from '@assets/Icons';
+import { dictionaryIcons, Icons, iconsSize } from '@assets/Icons';
 import React from 'react';
+import { View } from 'react-native';
 import { CommonActions } from '@react-navigation/native';
 import { Home } from '@screens/Home';
 import { Menu } from '@screens/Menu';
@@ -54,9 +55,10 @@ import { Shopping } from '@screens/Shopping';
 import { Parameters } from '@screens/Parameters';
 import { useI18n } from '@utils/i18n';
 import { Search } from '@screens/Search';
-import { Tab } from '@customTypes/ScreenTypes';
+import { Tab, TabScreenParamList } from '@customTypes/ScreenTypes';
 import { useSafeCopilot } from '@hooks/useSafeCopilot';
-import type { BottomTabNavigationOptions } from '@react-navigation/bottom-tabs';
+import { BottomTabBarHeightCallbackContext } from '@react-navigation/bottom-tabs';
+import type { BottomTabBarProps, BottomTabNavigationOptions } from '@react-navigation/bottom-tabs';
 
 const testId = 'BottomTabs';
 
@@ -78,62 +80,97 @@ export function resolveTabLabel(
   return typeof tabBarLabel === 'string' ? tabBarLabel : routeName;
 }
 
+type TabIcons = { focused: dictionaryIcons; unfocused: dictionaryIcons };
+
+// The `Icons` keys read inverted: `homeUnselectedIcon` is the filled glyph, shown on focus.
+const TAB_ICONS: Record<keyof TabScreenParamList, TabIcons> & Record<string, TabIcons> = {
+  Home: { focused: Icons.homeUnselectedIcon, unfocused: Icons.homeSelectedIcon },
+  Search: { focused: Icons.searchIcon, unfocused: Icons.searchIcon },
+  Menu: { focused: Icons.menuUnselectedIcon, unfocused: Icons.menuSelectedIcon },
+  Shopping: { focused: Icons.shoppingUnselectedIcon, unfocused: Icons.shoppingSelectedIcon },
+  Parameters: { focused: Icons.parametersUnselectedIcon, unfocused: Icons.parametersSelectedIcon },
+};
+
+function getTabIconName(routeName: string, focused: boolean): dictionaryIcons {
+  const icons = TAB_ICONS[routeName];
+  if (!icons) {
+    return Icons.crossIcon;
+  }
+  return focused ? icons.focused : icons.unfocused;
+}
+
+/**
+ * Material Design 3 tab bar backed by Paper's navigation bar.
+ *
+ * @param props - Tab bar props supplied by the bottom tab navigator
+ * @returns JSX element representing the app's bottom navigation bar
+ */
+export function BottomTabBar({ navigation, state, descriptors, insets }: BottomTabBarProps) {
+  const { colors } = useTheme();
+  const reportTabBarHeight = React.useContext(BottomTabBarHeightCallbackContext);
+
+  const getLabel = (route: (typeof state.routes)[number]): string =>
+    resolveTabLabel(descriptors[route.key]?.options.tabBarLabel, route.name);
+
+  return (
+    <View
+      testID={testId + '::Bar'}
+      // Paper takes the bar out of the flow with the keyboard up, collapsing this to zero.
+      onLayout={event => {
+        const { height } = event.nativeEvent.layout;
+        if (height > 0) {
+          reportTabBarHeight?.(height);
+        }
+      }}
+    >
+      <BottomNavigation.Bar
+        navigationState={state}
+        safeAreaInsets={insets}
+        style={{ backgroundColor: colors.surface }}
+        activeColor={colors.onPrimaryContainer}
+        inactiveColor={colors.onPrimaryContainer}
+        activeIndicatorStyle={{ backgroundColor: colors.primaryContainer }}
+        onTabPress={({ route, preventDefault }) => {
+          const event = navigation.emit({
+            type: 'tabPress',
+            target: route.key,
+            canPreventDefault: true,
+          });
+          if (event.defaultPrevented) {
+            preventDefault();
+          } else {
+            navigation.dispatch({
+              ...CommonActions.navigate(route.name, route.params),
+              target: state.key,
+            });
+          }
+        }}
+        renderIcon={({ route, focused, color }) => (
+          <Icon
+            source={getTabIconName(route.name, focused)}
+            size={iconsSize.medium}
+            color={color}
+          />
+        )}
+        getLabelText={({ route }) => getLabel(route)}
+        getTestID={({ route }) => descriptors[route.key]?.options.tabBarButtonTestID}
+        // BottomNavigation.Bar draws two label layers (active/inactive crossfade); on iOS
+        // both are exposed to accessibility and compose into a doubled name ("Home, Home").
+        // An explicit accessibilityLabel collapses each tab to a single leaf, so the visible
+        // label is announced once and stays queryable by E2E.
+        getAccessibilityLabel={({ route }) => getLabel(route)}
+      />
+    </View>
+  );
+}
+
 /**
  * BottomTabs component - Material Design 3 tab navigation
  *
  * @returns JSX element representing the main app tab navigation
  */
 export function BottomTabs() {
-  const { colors } = useTheme();
   const { t } = useI18n();
-
-  /**
-   * Returns the appropriate icon for active (selected) tab states
-   * @param routeName - Name of the route/tab
-   * @returns Icon name for the active state
-   */
-  function getActiveIconName(routeName: string): string {
-    switch (routeName) {
-      case 'Home':
-        return Icons.homeUnselectedIcon;
-      case 'Search':
-        return Icons.searchIcon;
-      case 'Menu':
-        return Icons.menuUnselectedIcon;
-      case 'Shopping':
-        return Icons.shoppingUnselectedIcon;
-      case 'Plannification':
-        return Icons.plannerUnselectedIcon;
-      case 'Parameters':
-        return Icons.parametersUnselectedIcon;
-      default:
-        return Icons.crossIcon;
-    }
-  }
-
-  /**
-   * Returns the appropriate icon for inactive (unselected) tab states
-   * @param routeName - Name of the route/tab
-   * @returns Icon name for the inactive state
-   */
-  function getInactiveIconName(routeName: string): string {
-    switch (routeName) {
-      case 'Home':
-        return Icons.homeSelectedIcon;
-      case 'Search':
-        return Icons.searchIcon;
-      case 'Menu':
-        return Icons.menuSelectedIcon;
-      case 'Shopping':
-        return Icons.shoppingSelectedIcon;
-      case 'Plannification':
-        return Icons.plannerSelectedIcon;
-      case 'Parameters':
-        return Icons.parametersSelectedIcon;
-      default:
-        return Icons.crossIcon;
-    }
-  }
 
   // Only disable lazy loading during tutorial mode (when copilot is active)
   // to ensure all tutorial steps are registered before copilot starts.
@@ -157,49 +194,7 @@ export function BottomTabs() {
       // crashes Fabric's Yoga layout. Outside the tutorial, detach normally.
       detachInactiveScreens={!copilotData}
       screenOptions={{ headerShown: false }}
-      tabBar={({ navigation, state, descriptors, insets }) => {
-        const getLabel = (route: (typeof state.routes)[number]): string =>
-          resolveTabLabel(descriptors[route.key]?.options.tabBarLabel, route.name);
-        return (
-          <BottomNavigation.Bar
-            navigationState={state}
-            safeAreaInsets={insets}
-            style={{ backgroundColor: colors.surface }}
-            activeColor={colors.onPrimaryContainer}
-            inactiveColor={colors.onPrimaryContainer}
-            activeIndicatorStyle={{ backgroundColor: colors.primaryContainer }}
-            onTabPress={({ route, preventDefault }) => {
-              const event = navigation.emit({
-                type: 'tabPress',
-                target: route.key,
-                canPreventDefault: true,
-              });
-              if (event.defaultPrevented) {
-                preventDefault();
-              } else {
-                navigation.dispatch({
-                  ...CommonActions.navigate(route.name, route.params),
-                  target: state.key,
-                });
-              }
-            }}
-            renderIcon={({ route, focused, color }) => (
-              <Icon
-                source={focused ? getActiveIconName(route.name) : getInactiveIconName(route.name)}
-                size={iconsSize.medium}
-                color={color}
-              />
-            )}
-            getLabelText={({ route }) => getLabel(route)}
-            getTestID={({ route }) => descriptors[route.key]?.options.tabBarButtonTestID}
-            // BottomNavigation.Bar draws two label layers (active/inactive crossfade); on iOS
-            // both are exposed to accessibility and compose into a doubled name ("Home, Home").
-            // An explicit accessibilityLabel collapses each tab to a single leaf, so the visible
-            // label is announced once and stays queryable by E2E.
-            getAccessibilityLabel={({ route }) => getLabel(route)}
-          />
-        );
-      }}
+      tabBar={props => <BottomTabBar {...props} />}
     >
       <Tab.Screen
         name='Home'

--- a/src/screens/IngredientsSettings.tsx
+++ b/src/screens/IngredientsSettings.tsx
@@ -39,21 +39,19 @@ import {
 import { SettingsItemList } from '@components/organisms/SettingsItemList';
 import { AppBar } from '@components/organisms/AppBar';
 import { BottomActionButton } from '@components/atomic/BottomActionButton';
+import { bottomActionButtonHeight } from '@styles/spacing';
 import { DialogMode, ItemDialog } from '@components/dialogs/ItemDialog';
 import { ingredientsSettingsLogger } from '@utils/logger';
 import { useIngredients } from '@hooks/useIngredients';
 import { byName } from '@utils/sorting';
 import { useI18n } from '@utils/i18n';
 import { Icons } from '@assets/Icons';
-import { padding } from '@styles/spacing';
 
 /**
  * IngredientsSettings screen component - Ingredient database management
  *
  * @returns JSX element representing the ingredient management interface
  */
-const BUTTON_HEIGHT = 48;
-const BUTTON_CONTAINER_HEIGHT = BUTTON_HEIGHT + padding.small * 2;
 
 export function IngredientsSettings() {
   const { ingredients, addIngredient, editIngredient, deleteIngredient } = useIngredients();
@@ -156,7 +154,7 @@ export function IngredientsSettings() {
   return (
     <ScreenWrapper>
       <AppBar title={t('ingredients')} onGoBack={() => navigation.goBack()} testID={testId} />
-      <View style={{ flex: 1, paddingBottom: BUTTON_CONTAINER_HEIGHT }}>
+      <View style={{ flex: 1, paddingBottom: bottomActionButtonHeight }}>
         <SettingsItemList
           items={ingredientsSortedAlphabetically}
           testIdPrefix={testId}

--- a/src/screens/TagsSettings.tsx
+++ b/src/screens/TagsSettings.tsx
@@ -39,21 +39,19 @@ import { TagDraft, tagTableElement, withId } from '@customTypes/DatabaseElementT
 import { SettingsItemList } from '@components/organisms/SettingsItemList';
 import { AppBar } from '@components/organisms/AppBar';
 import { BottomActionButton } from '@components/atomic/BottomActionButton';
+import { bottomActionButtonHeight } from '@styles/spacing';
 import { DialogMode, ItemDialog } from '@components/dialogs/ItemDialog';
 import { tagsSettingsLogger } from '@utils/logger';
 import { useTags } from '@hooks/useTags';
 import { byName } from '@utils/sorting';
 import { useI18n } from '@utils/i18n';
 import { Icons } from '@assets/Icons';
-import { padding } from '@styles/spacing';
 
 /**
  * TagsSettings screen component - Recipe tag management
  *
  * @returns JSX element representing the tag management interface
  */
-const BUTTON_HEIGHT = 48;
-const BUTTON_CONTAINER_HEIGHT = BUTTON_HEIGHT + padding.small * 2;
 
 export function TagsSettings() {
   const { tags, addTag, editTag, deleteTag } = useTags();
@@ -140,7 +138,7 @@ export function TagsSettings() {
   return (
     <ScreenWrapper>
       <AppBar title={t('tags')} onGoBack={() => navigation.goBack()} testID={testId} />
-      <View style={{ flex: 1, paddingBottom: BUTTON_CONTAINER_HEIGHT }}>
+      <View style={{ flex: 1, paddingBottom: bottomActionButtonHeight }}>
         <SettingsItemList
           items={tagsSortedAlphabetically}
           testIdPrefix={testId}

--- a/src/screens/recipe/RecipeFormScreen.tsx
+++ b/src/screens/recipe/RecipeFormScreen.tsx
@@ -41,7 +41,6 @@ import {
 } from '@customTypes/DatabaseElementTypes';
 import { RecipePropType } from '@customTypes/RecipeNavigationTypes';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
-import { padding } from '@styles/spacing';
 import { clearCache } from '@utils/FileGestion';
 import { useRecipes } from '@hooks/useRecipes';
 import { AppBar } from '@components/organisms/AppBar';
@@ -54,6 +53,7 @@ import { cropImage } from '@utils/ImagePicker';
 import { getDefaultPersons } from '@utils/settings';
 import { recipeLogger, validationLogger } from '@utils/logger';
 import { BottomActionButton } from '@components/atomic/BottomActionButton';
+import { bottomActionButtonHeight } from '@styles/spacing';
 
 import { useRecipeTags } from '@hooks/useRecipeTags';
 import { RecipeDialogsProvider, useRecipeDialogs } from '@context/RecipeDialogsContext';
@@ -92,9 +92,6 @@ import { RecipeIngredientsField } from '@screens/recipe/fields/IngredientsField'
 import { IngredientArrayActionsProvider } from '@screens/recipe/fields/IngredientArrayActionsContext';
 import { RecipePreparationField } from '@screens/recipe/fields/PreparationField';
 import type { OcrModalTarget } from '@utils/OCR';
-
-const BUTTON_HEIGHT = 48;
-const BUTTON_CONTAINER_HEIGHT = BUTTON_HEIGHT + padding.small * 2;
 
 /**
  * Identifies which editable route is being rendered. Drives the AppBar
@@ -511,7 +508,7 @@ function RecipeFormBody({
           horizontal={false}
           showsVerticalScrollIndicator={false}
           style={{ flex: 1, backgroundColor: colors.background }}
-          contentContainerStyle={{ paddingBottom: BUTTON_CONTAINER_HEIGHT + insets.bottom }}
+          contentContainerStyle={{ paddingBottom: bottomActionButtonHeight }}
           keyboardShouldPersistTaps={'handled'}
           keyboardDismissMode='on-drag'
           nestedScrollEnabled={true}

--- a/src/screens/recipe/RecipeView.tsx
+++ b/src/screens/recipe/RecipeView.tsx
@@ -21,13 +21,11 @@
 
 import React, { useState } from 'react';
 import { ScrollView } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Snackbar, useTheme } from 'react-native-paper';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 import { StackScreenParamList, recipeStateType } from '@customTypes/ScreenTypes';
 import { ScreenWrapper } from '@components/templates/ScreenWrapper';
-import { padding } from '@styles/spacing';
 import { useRecipes } from '@hooks/useRecipes';
 import { useMenu } from '@hooks/useMenu';
 import { AppBar } from '@components/organisms/AppBar';
@@ -35,6 +33,7 @@ import { useI18n } from '@utils/i18n';
 import { Alert } from '@components/dialogs/Alert';
 import { recipeLogger } from '@utils/logger';
 import { BottomActionButton } from '@components/atomic/BottomActionButton';
+import { bottomActionButtonHeight } from '@styles/spacing';
 import { RecipeImage } from '@components/organisms/RecipeImage';
 import { RecipeText } from '@components/organisms/RecipeText';
 import { RecipeTags } from '@components/organisms/RecipeTags';
@@ -55,9 +54,6 @@ import {
 } from '@utils/RecipeFormHelpers';
 import { noop, RECIPE_TEST_ID } from '@screens/recipe/constants';
 
-const BUTTON_HEIGHT = 48;
-const BUTTON_CONTAINER_HEIGHT = BUTTON_HEIGHT + padding.small * 2;
-
 // The scaling notice stays until the user explicitly dismisses it — it reports
 // that stored quantities differ from what was just entered, which the user
 // must not miss. A long duration plus a dismiss action keeps it on screen
@@ -77,7 +73,6 @@ export function RecipeView({ route, navigation }: RecipeViewProps) {
   const { recipe, scaledFromServings } = route.params;
   const { t } = useI18n();
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [scalingNoticeVisible, setScalingNoticeVisible] = useState(scaledFromServings != null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -164,7 +159,7 @@ export function RecipeView({ route, navigation }: RecipeViewProps) {
         horizontal={false}
         showsVerticalScrollIndicator={false}
         style={{ flex: 1, backgroundColor: colors.background }}
-        contentContainerStyle={{ paddingBottom: BUTTON_CONTAINER_HEIGHT + insets.bottom }}
+        contentContainerStyle={{ paddingBottom: bottomActionButtonHeight }}
         keyboardShouldPersistTaps={'handled'}
         nestedScrollEnabled={true}
       >

--- a/src/styles/spacing.tsx
+++ b/src/styles/spacing.tsx
@@ -134,6 +134,9 @@ export const progressBarHeight = screenHeight * 0.01;
 /** Maximum height for dialogs to prevent overflow on small screens */
 export const dialogMaxHeight = Dimensions.get('window').height;
 
+/** Space to reserve behind a pinned BottomActionButton, minus the safe-area strip it spans */
+export const bottomActionButtonHeight = 48 + padding.small * 2;
+
 /**
  * Standard screen and section view styles for consistent layout
  * Provides common container styles used throughout the application

--- a/tests/mocks/deps/react-native-paper-mock.tsx
+++ b/tests/mocks/deps/react-native-paper-mock.tsx
@@ -104,6 +104,32 @@ const MenuItem: React.FC<any> = props => (
 MenuItem.displayName = 'Menu.Item';
 Menu.Item = MenuItem;
 
+const BottomNavigationBar: React.FC<any> = props => (
+  <View testID='BottomNavigation.Bar' style={props.style}>
+    <RNText testID='BottomNavigation.Bar::SafeAreaInsets'>
+      {JSON.stringify(props.safeAreaInsets)}
+    </RNText>
+    {props.navigationState.routes.map((route: any, index: number) => (
+      <TouchableOpacity
+        key={route.key}
+        testID={props.getTestID({ route })}
+        accessibilityLabel={props.getAccessibilityLabel({ route })}
+        onPress={() => props.onTabPress({ route, preventDefault: () => {} })}
+      >
+        <RNText>{props.getLabelText({ route })}</RNText>
+        {props.renderIcon({
+          route,
+          focused: index === props.navigationState.index,
+          color: index === props.navigationState.index ? props.activeColor : props.inactiveColor,
+        })}
+      </TouchableOpacity>
+    ))}
+  </View>
+);
+BottomNavigationBar.displayName = 'BottomNavigation.Bar';
+
+export const BottomNavigation: { Bar: React.FC<any> } = { Bar: BottomNavigationBar };
+
 export const Portal: React.FC<any> & { Host: React.FC<any> } = props => (
   <View testID={props.testID}>{props.children}</View>
 );
@@ -559,10 +585,11 @@ const FABGroup: React.FC<any> = props => {
   };
 
   return (
-    <View testID='FAB.Group' style={props.fabStyle}>
+    <View testID='FAB.Group' style={props.style}>
       {renderActions()}
       <TouchableOpacity
         testID={props.testID}
+        style={props.fabStyle}
         onPress={() => props.onStateChange && props.onStateChange({ open: !props.open })}
       >
         <RNText testID={props.testID + '::Icon'}>{props.icon}</RNText>

--- a/tests/unit/components/organisms/VerticalBottomButtons.test.tsx
+++ b/tests/unit/components/organisms/VerticalBottomButtons.test.tsx
@@ -21,6 +21,8 @@ import {
 } from '@mocks/modules/recipe-scraper-mock';
 import { mockFetchHtmlSuccess } from '@mocks/deps/fetch-mock';
 import { pickImage } from '@utils/ImagePicker';
+import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
+import { padding } from '@styles/spacing';
 
 jest.mock('@utils/ImagePicker', () => require('@mocks/utils/ImagePicker-mock').imagePickerMock());
 
@@ -39,8 +41,12 @@ jest.mock(
 
 jest.mock('react-i18next', () => require('@mocks/utils/i18n-mock').i18nMock());
 
-function renderWithProvider(component: React.ReactElement) {
-  return render(<DefaultPersonsProvider>{component}</DefaultPersonsProvider>);
+function renderWithProvider(component: React.ReactElement, tabBarHeight?: number) {
+  return render(
+    <BottomTabBarHeightContext.Provider value={tabBarHeight}>
+      <DefaultPersonsProvider>{component}</DefaultPersonsProvider>
+    </BottomTabBarHeightContext.Provider>
+  );
 }
 
 function openUrlDialog(getByTestId: (id: string) => any) {
@@ -517,6 +523,41 @@ describe('VerticalBottomButtons Component', () => {
 
       expect(mockEvents.off).toHaveBeenCalledWith('stepChange', expect.any(Function));
       expect(mockEvents.off).toHaveBeenCalledWith('stop', expect.any(Function));
+    });
+  });
+
+  describe('Tab bar clearance', () => {
+    test('clears the measured tab bar height', () => {
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />, 128);
+
+      expect(getByTestId('FAB.Group').props.style).toEqual({ paddingBottom: 128 });
+    });
+
+    test('adds no clearance when no tab bar is mounted', () => {
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />);
+
+      expect(getByTestId('FAB.Group').props.style).toEqual({ paddingBottom: 0 });
+    });
+
+    test('spaces the FAB off the tab bar without restating the safe-area inset', () => {
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />, 128);
+
+      expect(getByTestId('ExpandButton').props.style).toEqual(
+        expect.objectContaining({ marginBottom: padding.small, marginRight: padding.small })
+      );
+    });
+
+    test('anchors the tutorial highlight to the FAB, not to the tab bar', async () => {
+      setMockCopilotState({
+        isActive: true,
+        currentStep: { order: 1, name: 'Home', text: 'Home step' },
+      });
+
+      const { getByTestId } = renderWithProvider(<VerticalBottomButtons />, 128);
+
+      await waitFor(() => {
+        expect(getByTestId('HomeTutorial').props.style.bottom).toBe(padding.small);
+      });
     });
   });
 });

--- a/tests/unit/navigation/BottomTabs.test.tsx
+++ b/tests/unit/navigation/BottomTabs.test.tsx
@@ -1,4 +1,31 @@
-import { resolveTabLabel } from '@navigation/BottomTabs';
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { ReactTestInstance } from 'react-test-renderer';
+import { BottomTabBarHeightCallbackContext } from '@react-navigation/bottom-tabs';
+import { BottomTabBar, resolveTabLabel } from '@navigation/BottomTabs';
+import { mockInsets } from '@mocks/deps/safe-area-context-mock';
+
+function buildTabBarProps() {
+  const routes = [
+    { key: 'Home-1', name: 'Home', params: undefined },
+    { key: 'Search-1', name: 'Search', params: undefined },
+  ];
+  return {
+    state: { index: 0, key: 'tabs-1', routes },
+    descriptors: {
+      'Home-1': { options: { tabBarLabel: 'Accueil', tabBarButtonTestID: 'BottomTabs::Home' } },
+      'Search-1': {
+        options: { tabBarLabel: 'Recherche', tabBarButtonTestID: 'BottomTabs::Search' },
+      },
+    },
+    navigation: { emit: jest.fn(() => ({ defaultPrevented: false })), dispatch: jest.fn() },
+    insets: mockInsets,
+  } as any;
+}
+
+function layout(element: ReactTestInstance, height: number) {
+  fireEvent(element, 'layout', { nativeEvent: { layout: { height } } });
+}
 
 describe('resolveTabLabel', () => {
   it('returns the string tabBarLabel when set', () => {
@@ -15,5 +42,70 @@ describe('resolveTabLabel', () => {
 
   it('returns an empty string label verbatim without falling back', () => {
     expect(resolveTabLabel('', 'Shopping')).toBe('');
+  });
+});
+
+describe('BottomTabBar', () => {
+  test('reports its measured height to the navigator', () => {
+    const reportHeight = jest.fn();
+    const { getByTestId } = render(
+      <BottomTabBarHeightCallbackContext.Provider value={reportHeight}>
+        <BottomTabBar {...buildTabBarProps()} />
+      </BottomTabBarHeightCallbackContext.Provider>
+    );
+
+    layout(getByTestId('BottomTabs::Bar'), 92);
+
+    expect(reportHeight).toHaveBeenCalledWith(92);
+  });
+
+  test('ignores the zero height measured while the keyboard hides the bar', () => {
+    const reportHeight = jest.fn();
+    const { getByTestId } = render(
+      <BottomTabBarHeightCallbackContext.Provider value={reportHeight}>
+        <BottomTabBar {...buildTabBarProps()} />
+      </BottomTabBarHeightCallbackContext.Provider>
+    );
+
+    layout(getByTestId('BottomTabs::Bar'), 92);
+    layout(getByTestId('BottomTabs::Bar'), 0);
+
+    expect(reportHeight).toHaveBeenCalledTimes(1);
+    expect(reportHeight).toHaveBeenLastCalledWith(92);
+  });
+
+  test('renders without a navigator height callback', () => {
+    const { getByTestId } = render(<BottomTabBar {...buildTabBarProps()} />);
+
+    expect(() => layout(getByTestId('BottomTabs::Bar'), 92)).not.toThrow();
+  });
+
+  test('hands the system bar insets to the navigation bar', () => {
+    const { getByTestId } = render(<BottomTabBar {...buildTabBarProps()} />);
+
+    expect(getByTestId('BottomNavigation.Bar::SafeAreaInsets').props.children).toBe(
+      JSON.stringify(mockInsets)
+    );
+  });
+
+  test('navigates to the pressed tab', () => {
+    const props = buildTabBarProps();
+    const { getByTestId } = render(<BottomTabBar {...props} />);
+
+    fireEvent.press(getByTestId('BottomTabs::Search'));
+
+    expect(props.navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'tabs-1' })
+    );
+  });
+
+  test('does not navigate when the tab press event is prevented', () => {
+    const props = buildTabBarProps();
+    props.navigation.emit = jest.fn(() => ({ defaultPrevented: true }));
+    const { getByTestId } = render(<BottomTabBar {...props} />);
+
+    fireEvent.press(getByTestId('BottomTabs::Home'));
+
+    expect(props.navigation.dispatch).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/screens/recipe/RecipeView.test.tsx
+++ b/tests/unit/screens/recipe/RecipeView.test.tsx
@@ -5,6 +5,7 @@ import { testRecipes } from '@test-data/recipesDataset';
 import RecipeDatabase from '@utils/RecipeDatabase';
 import { RecipePropType } from '@customTypes/RecipeNavigationTypes';
 import { RecipeView } from '@screens/recipe/RecipeView';
+import { bottomActionButtonHeight } from '@styles/spacing';
 
 import {
   checkAppbarButtons,
@@ -246,5 +247,15 @@ describe('RecipeView', () => {
     const { UNSAFE_getAllByType } = await renderRoute({ mode: 'addManually' });
     const { ScrollView } = require('react-native');
     expectKeyboardDismissesOnDrag(UNSAFE_getAllByType, ScrollView);
+  });
+
+  test('reserves the pinned button height without re-adding the bottom safe-area inset', async () => {
+    const { UNSAFE_getAllByType } = await renderRoute(mockRouteReadOnly);
+    const { ScrollView } = require('react-native');
+    const scrollView = UNSAFE_getAllByType(ScrollView)[0]!;
+
+    expect(scrollView.props.contentContainerStyle).toEqual({
+      paddingBottom: bottomActionButtonHeight,
+    });
   });
 });


### PR DESCRIPTION
Closes #501.

## Context

`targetSdkVersion: 36` makes edge-to-edge mandatory, and Expo SDK 56 no longer accepts `android.edgeToEdgeEnabled` at all — its prebuild plugin only warns if you set it. So the app always draws under the system bars, the window now spans them, and `insets.bottom` is non-zero on Android where it used to be `0`. Several surfaces either guessed that inset or counted it twice.

## Changes

**FAB menu clears the real tab bar height.** It used `screenHeight / 9 + insets.bottom`. Paper's `FAB.Group` already pads its own container by `insets.bottom`, and `Dimensions.get('window')` now includes the system bars, so the FAB floated a full inset too high. It now clears the measured tab bar height — which already contains the inset — by replacing that container padding rather than stacking a margin on top of it.

**The tab bar reports its height.** React Navigation only learns a tab bar's height from its own built-in bar, so with Paper's `BottomNavigation.Bar` as a custom `tabBar`, `useBottomTabBarHeight` kept returning the initial ~49dp estimate forever. The bar is now an extracted `BottomTabBar` that measures itself and reports through `BottomTabBarHeightCallbackContext`. It ignores the zero height measured while the keyboard pulls the bar out of the flow (`keyboardHidesNavigationBar`), which would otherwise drop the FAB onto the navigation bar on every keyboard open.

**Scroll padding stops double-counting.** `RecipeView` and `RecipeFormScreen` added `insets.bottom` to their scroll `contentContainerStyle` even though `ScreenWrapper`'s `SafeAreaView` already applies it. The pinned `BottomActionButton` is absolutely positioned, so it spans that padding strip and only occludes `bottomActionButtonHeight` of the scroll box.

**Tutorial highlight anchored to the FAB.** It derived its offset from the tab bar height while living in scene coordinates that already stop at the bar, leaving it one bar height too high. Both now read a shared offset.

**Pinned button height has one owner.** `48 + padding.small * 2` was copy-pasted across four screens; it now lives in `@styles/spacing` as `bottomActionButtonHeight`.

## Verification

Measured on an Android emulator (density 3.0, 3-button nav, edge-to-edge active):

| | before | after |
|---|---|---|
| FAB bottom edge above screen bottom | 176dp | 144dp |
| gap to tab bar top (128dp) | 48dp | 16dp |

4134 unit tests and 80 integration tests pass; `npm run quality` is clean.

**Not verified:** gesture navigation, a real Android 15/16 image, and landscape/display cutouts. The emulator used is API 34 — edge-to-edge is active there regardless, but the remaining checkboxes on #501 need a device.

## Follow-ups (not in this PR)

- The `Icons` constants are misnamed — `homeUnselectedIcon` is the *filled* glyph — which makes the tab icon mapping read inverted.
- `ValidationReviewList`'s `LIST_BOTTOM_PADDING = 80` doesn't match the shared button height.
- `ScreenWrapper` could derive its `edges` from the tab bar context instead of ~15 call sites restating `['top','left','right']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)