### PR TITLE
test(flash-list): render real FlashList instead of FlatList mock

### DIFF
--- a/tests/helpers/expectKeyboardDismissesOnDrag.ts
+++ b/tests/helpers/expectKeyboardDismissesOnDrag.ts
@@ -11,11 +11,11 @@ interface ScrollableInstance {
  * keyboard-facing scroll surfaces.
  *
  * @param getAllByType - a render result's `UNSAFE_getAllByType`
- * @param scrollableType - the scrollable component to look for (`FlatList` or `ScrollView`)
+ * @param scrollableType - the scrollable component to look for (`ScrollView`)
  */
-export function expectKeyboardDismissesOnDrag(
-  getAllByType: (type: ComponentType<never>) => ScrollableInstance[],
-  scrollableType: ComponentType<never>
+export function expectKeyboardDismissesOnDrag<P>(
+  getAllByType: (type: ComponentType<P>) => ScrollableInstance[],
+  scrollableType: ComponentType<P>
 ): void {
   const scrollables = getAllByType(scrollableType);
   expect(scrollables.some(node => node.props.keyboardDismissMode === 'on-drag')).toBe(true);

--- a/tests/mocks/deps/flash-list-measure-layout-mock.ts
+++ b/tests/mocks/deps/flash-list-measure-layout-mock.ts
@@ -1,0 +1,13 @@
+const MEASURE_LAYOUT_MODULE = '@shopify/flash-list/dist/recyclerview/utils/measureLayout';
+
+const parentLayout = { x: 0, y: 0, width: 400, height: 900 };
+const itemLayout = { x: 0, y: 0, width: 100, height: 100 };
+
+export function flashListMeasureLayoutMock() {
+  return {
+    ...jest.requireActual(MEASURE_LAYOUT_MODULE),
+    measureParentSize: jest.fn(() => parentLayout),
+    measureFirstChildLayout: jest.fn(() => parentLayout),
+    measureItemLayout: jest.fn(() => itemLayout),
+  };
+}

--- a/tests/mocks/deps/flash-list-mock.tsx
+++ b/tests/mocks/deps/flash-list-mock.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { FlatList } from 'react-native';
-
-export function flashListMock() {
-  return {
-    FlashList: FlatList,
-    AnimatedFlashList: FlatList,
-  };
-}

--- a/tests/setup-community-mocks.js
+++ b/tests/setup-community-mocks.js
@@ -6,7 +6,13 @@ import 'react-native-gesture-handler/jestSetup';
 // react-native-safe-area-context
 import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 
-jest.mock('@shopify/flash-list', () => require('@mocks/deps/flash-list-mock').flashListMock());
+// Mirrors @shopify/flash-list 2.0.3+ `jestSetup.js`, which only stubs layout measurement so the
+// real FlashList renders under Jest. Vendored because the 2.0.2 pinned by Expo SDK 56 ships a
+// broken `jestSetup.js` (it swaps FlashList for the unexported RecyclerView). Replace this with
+// `import '@shopify/flash-list/jestSetup'` once Expo bundles >= 2.0.3.
+jest.mock('@shopify/flash-list/dist/recyclerview/utils/measureLayout', () =>
+  require('@mocks/deps/flash-list-measure-layout-mock').flashListMeasureLayoutMock()
+);
 
 jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
 

--- a/tests/unit/components/dialogs/DatabasePickerDialog.test.tsx
+++ b/tests/unit/components/dialogs/DatabasePickerDialog.test.tsx
@@ -639,8 +639,8 @@ describe('DatabasePickerDialog', () => {
         />
       );
 
-      const { FlatList } = require('react-native');
-      expectKeyboardDismissesOnDrag(UNSAFE_getAllByType, FlatList);
+      const { ScrollView } = require('react-native');
+      expectKeyboardDismissesOnDrag(UNSAFE_getAllByType, ScrollView);
     });
   });
 });

--- a/tests/unit/screens/Search.test.tsx
+++ b/tests/unit/screens/Search.test.tsx
@@ -8,7 +8,7 @@ import { testRecipes } from '@test-data/recipesDataset';
 import { createStackNavigator } from '@react-navigation/stack';
 import { NavigationContainer } from '@react-navigation/native';
 import React from 'react';
-import { Button } from 'react-native';
+import { Button, ScrollView } from 'react-native';
 import { SeasonFilterProvider, useSeasonFilter } from '@context/SeasonFilterContext';
 import { resetFiltersSelection } from '@mocks/components/organisms/FiltersSelection-mock';
 
@@ -611,14 +611,12 @@ describe('Search Screen', () => {
 
   test('recipe list dismisses the keyboard on drag', async () => {
     const { UNSAFE_getAllByType } = await renderSearchComponent();
-    const { FlatList } = require('react-native');
-    expectKeyboardDismissesOnDrag(UNSAFE_getAllByType, FlatList);
+    expectKeyboardDismissesOnDrag(UNSAFE_getAllByType, ScrollView);
   });
 
   test('recipe list delivers a suggestion tap on the first press while the keyboard is open', async () => {
     const { UNSAFE_getAllByType } = await renderSearchComponent();
-    const { FlatList } = require('react-native');
-    const lists = UNSAFE_getAllByType(FlatList);
+    const lists = UNSAFE_getAllByType(ScrollView);
     expect(lists.some(node => node.props.keyboardShouldPersistTaps === 'handled')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Unit tests rendered a `FlatList` in place of `FlashList`. They now render the real recycler.

The alias mock existed because `@shopify/flash-list` 2.0.2 — the version Expo SDK 56 bundles — ships a broken `jestSetup.js`: it does `jest.requireActual("@shopify/flash-list").RecyclerView`, which is not a public export, so `FlashList` ends up `undefined` and every render throws *"Element type is invalid"*.

Issue #335 tracked this as "wait until Expo bundles flash-list > 2.0.2". That premise was wrong: 2.0.3 fixed it by **deleting** the module-swap block from `jestSetup.js`, leaving only a `measureLayout` stub. `src/index.ts` is byte-identical between 2.0.2 and 2.0.3 (`RecyclerView` is still unexported there), so the fix was to the setup file alone — and running 2.0.3's `jestSetup.js` content against the installed 2.0.2 renders `FlashList` correctly.

## Changes

- `tests/mocks/deps/flash-list-mock.tsx` (FlatList alias) deleted, replaced by `tests/mocks/deps/flash-list-measure-layout-mock.ts` mirroring upstream 2.0.3
- `tests/setup-community-mocks.js` now mocks `@shopify/flash-list/dist/recyclerview/utils/measureLayout` instead of the whole module, with a note to replace the vendored stub with `import '@shopify/flash-list/jestSetup'` once Expo bundles >= 2.0.3
- three assertions retargeted from `FlatList` to `ScrollView` (`expectKeyboardDismissesOnDrag.ts`, `Search.test.tsx`, `DatabasePickerDialog.test.tsx`) — they only matched a `FlatList` node because the old mock rendered one; the helper signature became generic so a typed `ScrollView` passes typecheck

`@shopify/flash-list` is deliberately **not** upgraded past the Expo pin: that would require adding it to `expo.install.exclude` to keep `expo-doctor` green, trading a test-only nuisance for an unverified native dependency version — the same reason `.github/dependabot.yml` ignores this package.

## Impact

`getItemType`, `stickyHeaderIndices`, `drawDistance` and viewability are now actually exercised instead of being stubbed away by `FlatList`.

## Testing

- `npm run test:unit` — 4134 passed, 16 skipped, 207 suites green
- `npm run quality` — lint (0 errors), prettier, typecheck, knip, expo-doctor 21/21 all green

The other three items of #335 (masonry, v2 state hooks, auto-sizing) were evaluated and need no code; findings are recorded in [this comment](https://github.com/AntoC-dev/Recipedia/issues/335#issuecomment-5271537640).

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
