### PR TITLE
feat(settings): enable tapToSeek on the persons slider

### DIFF
--- a/src/screens/DefaultPersonsSettings.tsx
+++ b/src/screens/DefaultPersonsSettings.tsx
@@ -75,6 +75,7 @@ export function DefaultPersonsSettings({ navigation }: DefaultPersonsSettingsPro
           minimumValue={1}
           maximumValue={10}
           step={1}
+          tapToSeek
           minimumTrackTintColor={colors.primary}
           maximumTrackTintColor={colors.backdrop}
           thumbTintColor={colors.primary}

--- a/tests/e2e/flows/parameters/persons/changeTo4Persons.yaml
+++ b/tests/e2e/flows/parameters/persons/changeTo4Persons.yaml
@@ -1,23 +1,9 @@
 appId: "com.recipedia"
 ---
-- runFlow:
-    when:
-      platform: Android
-    commands:
-      - tapOn:
-          id: "DefaultPersonSettings::Slider"
-          point: "33%,50%"
-          label: "Set slider to 4 persons on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - swipe:
-          start: "56%,25%"
-          end: "34%,25%"
-          duration: 300
-          label: "Drag slider to 4 persons on iOS"
+- tapOn:
+    id: "DefaultPersonSettings::Slider"
+    point: "33%,50%"
+    label: "Set slider to 4 persons"
 
 - assertVisible:
     id: "DefaultPersonSettings::PersonsValue"

--- a/tests/e2e/flows/parameters/persons/changeTo6Persons.yaml
+++ b/tests/e2e/flows/parameters/persons/changeTo6Persons.yaml
@@ -1,23 +1,9 @@
 appId: "com.recipedia"
 ---
-- runFlow:
-    when:
-      platform: Android
-    commands:
-      - tapOn:
-          id: "DefaultPersonSettings::Slider"
-          point: "56%,50%"
-          label: "Set slider to 6 persons on Android"
-
-- runFlow:
-    when:
-      platform: iOS
-    commands:
-      - swipe:
-          start: "34%,25%"
-          end: "56%,25%"
-          duration: 300
-          label: "Drag slider to 6 persons on iOS"
+- tapOn:
+    id: "DefaultPersonSettings::Slider"
+    point: "56%,50%"
+    label: "Set slider to 6 persons"
 
 - assertVisible:
     id: "DefaultPersonSettings::PersonsValue"

--- a/tests/mocks/deps/slider-mock.tsx
+++ b/tests/mocks/deps/slider-mock.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 
-const Slider = ({ value, testID, onValueChange }: any) => (
+const Slider = ({ value, testID, onValueChange, tapToSeek }: any) => (
   <TouchableOpacity testID={testID} onPress={() => onValueChange(value + 1)}>
     <Text testID={testID + '::Text'}>{value}</Text>
+    <Text testID={testID + '::TapToSeek'}>{String(!!tapToSeek)}</Text>
   </TouchableOpacity>
 );
 

--- a/tests/unit/screens/DefaultPersonsSettings.test.tsx
+++ b/tests/unit/screens/DefaultPersonsSettings.test.tsx
@@ -71,6 +71,12 @@ describe('DefaultPersonsSettings Screen', () => {
     expect(getByTestId('DefaultPersonSettings::Save')).toBeTruthy();
   });
 
+  test('enables tapToSeek on the slider', async () => {
+    const { getByTestId } = await renderDefaultPersonsSettings();
+
+    expect(getByTestId('DefaultPersonSettings::Slider::TapToSeek').props.children).toEqual('true');
+  });
+
   test('updates persons value when slider changes', async () => {
     const { getByTestId } = await renderDefaultPersonsSettings();
 


### PR DESCRIPTION
## Description

Enables `tapToSeek` on the `DefaultPersonsSettings` slider, giving iOS the tap-to-seek behaviour Android already had, and collapses the two persons E2E flows to a single platform-agnostic `tapOn`.

UIKit's `UISlider` only tracks touches that land on the thumb, so on iOS the track was dead — users had to grab the thumb and drag. `@react-native-community/slider` attaches a `UITapGestureRecognizer` unconditionally, but gates the handler on `tapToSeek`, which defaults to `false`:

```objc
// RNCSliderComponentView.mm:76
if (!slider.tapToSeek) {
    return;
}
```

The prop is an explicit no-op on Android — `ReactSliderManager.setTapToSeek` has an empty body — so this is pure iOS→Android parity with no Android behaviour change.

### Why it matters beyond UX

This removes the last app-side screen-percentage coordinate site in the E2E suite. Both `changeTo4Persons.yaml` and `changeTo6Persons.yaml` had to fork by platform: an element-relative `tapOn` on Android, a raw screen-percentage `swipe` on iOS. That swipe's vertical coordinate had to be re-derived by hand for the iPhone 16e in #448, and would have needed re-deriving on every future CI device change.

With the track live on iOS, both platforms collapse to the single element-relative `tapOn`, and the `runFlow` platform fork disappears:

```yaml
- tapOn:
    id: "DefaultPersonSettings::Slider"
    point: "33%,50%"
    label: "Set slider to 4 persons"
```

The percentages are element-relative, so they're device-independent. With `minimumValue=1 / maximumValue=10 / step=1`, the native handler computes `min + (max-min) × (touch.x / bounds.width)` and rounds to the nearest step: `33%` → 3.97 → **4**, `56%` → 6.04 → **6**. Both land mid-bucket.

## Type of Change

- [x] New feature

## Testing

- [x] Unit tests pass — added `enables tapToSeek on the slider` to `DefaultPersonsSettings.test.tsx`; scoped run green (27 tests across `DefaultPersonsSettings` + `Parameters`)
- [x] `npm run quality` clean — 0 errors, lint/format/typecheck/knip/expo-doctor all pass
- [x] Manual testing completed — verified on an iOS simulator via Maestro: tapping the track at `56%,50%` seeks to "6 persons", at `33%,50%` back to "4 persons"
- [ ] Full `settings` E2E suite on both platforms — not yet run in CI

The slider Jest mock now renders `tapToSeek` as a `::TapToSeek` child, per the repo convention that mocks render all their props.

## Breaking Changes

None.

Closes #532

### Note on issue scope

The final scope item — dropping the `@react-native-community/slider` carve-out from the tier-3 list in `tests/e2e/E2E_TESTING.md` → "Coordinate Pattern" — was **not actioned because no such text exists** in that file. It has no `slider` or `tier` mentions; its only coordinate references (lines 1430, 1955) concern the SearchBar and back navigation. Nothing to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
