### PR TITLE
perf(db): decode recipes from in-memory ingredient/tag maps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,9 +100,27 @@ When writing: the rich type is encoded to flat primitives before the SQL stateme
 
 ### In-memory cache and pub/sub
 
-On initialization, all rows are loaded into memory (`_recipes`, `_ingredients`, `_tags`, `_menu`, `_purchasedIngredients`). After any mutation, `notify(slice)` fires all listeners registered for that slice via `subscribe(slice, callback)`. The focused hooks bind this to `useSyncExternalStore`.
+On initialization, all rows are loaded into memory (`_recipes`, `_ingredients`, `_tags`, `_menu`, `_purchasedIngredients`). Ingredients and tags load first: recipe rows store only ingredient and tag ids, and decoding resolves them through id-keyed maps built over those caches rather than one query per reference. After any mutation, `notify(slice)` fires all listeners registered for that slice via `subscribe(slice, callback)`. The focused hooks bind this to `useSyncExternalStore`.
 
 The `StoreSlice` type enumerates the available slices: `'recipes' | 'ingredients' | 'tags' | 'menu' | 'purchased'`.
+
+### Decode integrity
+
+Decoding resolves cross-table references and casts stored strings into application types, and neither can be trusted blindly — a corrupt row silently loses data instead of failing. Each decoder therefore validates what it cannot assume, using only data already in memory (no extra queries):
+
+| Decoder | Checks |
+|---|---|
+| recipes | ingredient and tag ids that resolve against no cached row |
+| ingredients | `TYPE` outside the `ingredientType` enum; `SEASON` months outside `ALL_MONTHS` |
+| ingredients, tags | duplicate ids, which would make id-keyed lookups return an arbitrary row |
+
+One check is not a decode concern and lives beside them rather than inside a decoder: `reportUnresolvedMenuRecipes` compares `_menu` against `_recipes` after `init()` has filled both, since decoding a menu row cannot see the recipes.
+
+Every failure is logged through `recordDecodeError`, which also records the first one on `RecipeDatabase._decodeError` when `__DEV__ || getDatasetType() === 'test'`. Logging and recording live in one function so a new check cannot do one without the other. The recorded error is exposed by `get_decode_error()`, returned as `decodeError` from `useRecipes`, `useMenu`, `useIngredients` and `useTags`, and rethrown during render by `AppWrapper`, so the root `ErrorBoundary` in `App.tsx` replaces the app with the `ErrorFallback` screen. Recording notifies the `recipes` slice so consumers mounted before the failure re-render. Production keeps the log and degrades the affected row.
+
+The `performance` build records nothing, so benchmark flows never surface the guard; detection itself is cheap enough (set lookups over already-loaded rows, no queries) to run everywhere.
+
+**Adding a decoder that resolves a reference to another table means adding its check here**, otherwise the corruption it can produce goes unnoticed.
 
 ### Schema migrations
 
@@ -332,6 +350,8 @@ These must not be violated. Violating them causes subtle bugs or breaks CI.
 **All new utility functions outside React components must have unit tests and TypeDoc comments.** See `CLAUDE.md`.
 
 **Schema changes require a migration.** Adding a column without a `PRAGMA`-guarded `ALTER TABLE` in `init()` breaks existing app installs.
+
+**Recipe decoding resolves ingredients and tags from the in-memory caches, never from SQL.** `_ingredients` and `_tags` must be loaded before any recipe is decoded, and `_recipes` before the menu — `init()` loads them in that order for this reason. Mutating an ingredient or tag patches the cached recipes in place; do not reload all recipes from the database. Any new mutation path must leave the caches equal to a full reload, which the table-driven test in `tests/unit/utils/RecipeDatabase.test.tsx` asserts for every mutation method.
 
 ---
 

--- a/src/components/organisms/AppWrapper.tsx
+++ b/src/components/organisms/AppWrapper.tsx
@@ -7,6 +7,8 @@ import { appLogger, tutorialLogger } from '@utils/logger';
 import { deleteOldLogFiles } from '@utils/BugReport';
 import { useRecipes } from '@hooks/useRecipes';
 import { useMenu } from '@hooks/useMenu';
+import { useIngredients } from '@hooks/useIngredients';
+import { useTags } from '@hooks/useTags';
 
 enum AppMode {
   Loading = 'loading',
@@ -33,13 +35,31 @@ enum AppMode {
  * - Tutorial mode with pre-populated shopping list
  * - Shopping list reset on app launch
  * - State management for app flow
+ * - Decode integrity: a corrupt row found while decoding any cached table is
+ *   rethrown here during render, so the root error boundary shows the recovery
+ *   screen instead of the app running on silently truncated data. Every table's
+ *   hook is read, so the throw does not depend on which slice happens to notify.
+ *   Development and E2E builds only — `decodeError` is always null in production.
  *
  * @returns JSX element representing the current app mode
  */
 export default function AppWrapper() {
-  const { recipes } = useRecipes();
-  const { clearMenu, addRecipeToMenu, toggleMenuItemCooked } = useMenu();
+  const { recipes, decodeError: recipesDecodeError } = useRecipes();
+  const {
+    clearMenu,
+    addRecipeToMenu,
+    toggleMenuItemCooked,
+    decodeError: menuDecodeError,
+  } = useMenu();
+  const { decodeError: ingredientsDecodeError } = useIngredients();
+  const { decodeError: tagsDecodeError } = useTags();
   const [mode, setMode] = useState<AppMode>(AppMode.Loading);
+
+  const decodeError =
+    recipesDecodeError ?? menuDecodeError ?? ingredientsDecodeError ?? tagsDecodeError;
+  if (decodeError) {
+    throw decodeError;
+  }
 
   useEffect(() => {
     deleteOldLogFiles();

--- a/src/hooks/useIngredients.ts
+++ b/src/hooks/useIngredients.ts
@@ -39,8 +39,8 @@ const getIngredientsIndex = makeItemIndexCache<ingredientTableElement>({
  * `editIngredient` and `deleteIngredient` also invalidate the `recipes` slice
  * (handled internally by RecipeDatabase) so recipe consumers re-render too.
  *
- * @returns Object containing reactive `ingredients` array and all ingredient
- *   mutation functions
+ * @returns Object containing reactive `ingredients` array, `decodeError` (see
+ *   {@link RecipeDatabase.get_decode_error}), and all ingredient mutation functions
  */
 export function useIngredients() {
   const db = RecipeDatabase.getInstance();
@@ -48,6 +48,7 @@ export function useIngredients() {
     cb => db.subscribe('ingredients', cb),
     () => db.get_ingredients()
   );
+  const decodeError = db.get_decode_error();
 
   useWarmSearchIndex(getIngredientsIndex, ingredients);
 
@@ -83,6 +84,7 @@ export function useIngredients() {
 
   return {
     ingredients,
+    decodeError,
     addIngredient,
     editIngredient,
     deleteIngredient,

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -21,7 +21,8 @@ import { recipeTableElement } from '@customTypes/DatabaseElementTypes';
  * purchase flags of ingredients that leave the shopping list on every menu
  * mutation, and clearing the menu empties it entirely.
  *
- * @returns Object containing reactive `menu` array and all menu mutation functions
+ * @returns Object containing reactive `menu` array, `decodeError` (see
+ *   {@link RecipeDatabase.get_decode_error}), and all menu mutation functions
  */
 export function useMenu() {
   const db = RecipeDatabase.getInstance();
@@ -29,6 +30,7 @@ export function useMenu() {
     cb => db.subscribe('menu', cb),
     () => db.get_menu()
   );
+  const decodeError = db.get_decode_error();
   const purchasedIngredients = useSyncExternalStore(
     cb => db.subscribe('purchased', cb),
     () => db.get_purchasedIngredients()
@@ -69,6 +71,7 @@ export function useMenu() {
 
   return {
     menu,
+    decodeError,
     addRecipeToMenu,
     getRecipeById,
     toggleMenuItemCooked,

--- a/src/hooks/useRecipes.ts
+++ b/src/hooks/useRecipes.ts
@@ -29,8 +29,13 @@ import { databaseLogger } from '@utils/logger';
  * `scaleAllRecipesForNewDefaultPersons` observes it; other consumers of this
  * hook see `undefined`.
  *
+ * `decodeError` is store-wide rather than slice-scoped: it reports corrupt data
+ * found while decoding any cached table. Recording one notifies the `recipes`
+ * slice, so the subscription above is what re-renders consumers when it appears.
+ *
  * @returns Object containing reactive `recipes` array, `scalingProgress`,
- *   and all recipe mutation functions
+ *   `decodeError` (see {@link RecipeDatabase.get_decode_error}), and all recipe
+ *   mutation functions
  */
 export function useRecipes() {
   const db = RecipeDatabase.getInstance();
@@ -38,6 +43,7 @@ export function useRecipes() {
     cb => db.subscribe('recipes', cb),
     () => db.get_recipes()
   );
+  const decodeError = db.get_decode_error();
   const [scalingProgress, setScalingProgress] = useState<number | undefined>(undefined);
 
   const addRecipe = async (recipe: RecipeDraft): Promise<recipeTableElement> => {
@@ -120,6 +126,7 @@ export function useRecipes() {
 
   return {
     recipes,
+    decodeError,
     scalingProgress,
     addRecipe,
     editRecipe,

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -31,7 +31,8 @@ const getTagsIndex = makeItemIndexCache<tagTableElement>({
  * Note that `editTag` and `deleteTag` also invalidate the `recipes` slice
  * (handled internally by RecipeDatabase) so recipe consumers re-render too.
  *
- * @returns Object containing reactive `tags` array and all tag mutation functions
+ * @returns Object containing reactive `tags` array, `decodeError` (see
+ *   {@link RecipeDatabase.get_decode_error}), and all tag mutation functions
  */
 export function useTags() {
   const db = RecipeDatabase.getInstance();
@@ -39,6 +40,7 @@ export function useTags() {
     cb => db.subscribe('tags', cb),
     () => db.get_tags()
   );
+  const decodeError = db.get_decode_error();
 
   useWarmSearchIndex(getTagsIndex, tags);
 
@@ -76,6 +78,7 @@ export function useTags() {
 
   return {
     tags,
+    decodeError,
     addTag,
     editTag,
     deleteTag,

--- a/src/utils/RecipeDatabase.tsx
+++ b/src/utils/RecipeDatabase.tsx
@@ -66,6 +66,7 @@ import {
   isTemporaryImageUri,
   saveRecipeImage,
 } from '@utils/FileGestion';
+import { getDatasetType } from '@utils/DatasetLoader';
 import { buildItemIndex, searchItems } from '@utils/FuzzyIndex';
 import { parseQuantity, scaleQuantityForPersons } from '@utils/Quantity';
 import { computeShoppingList } from '@utils/ShoppingComputation';
@@ -86,6 +87,22 @@ const RECIPE_TITLE_FUZZY = 0.3;
 export type StoreSlice = 'recipes' | 'ingredients' | 'tags' | 'menu' | 'purchased';
 
 /**
+ * Whether decode integrity checking is active for this build.
+ *
+ * Enabled in development and in the Maestro E2E build, which is compiled in
+ * release mode (`__DEV__` is false there). Excluded from the `performance` build,
+ * whose flows measure app cost, and from production, where a corrupt row should
+ * degrade the screen rather than take the app down.
+ */
+const DECODE_INTEGRITY_CHECK_ENABLED = __DEV__ || getDatasetType() === 'test';
+
+/** Valid `TYPE` column values, used to police the enum cast in ingredient decoding. */
+const INGREDIENT_TYPES = new Set<string>(Object.values(ingredientType));
+
+/** Valid `SEASON` column entries, used to police the months an ingredient row carries. */
+const MONTHS = new Set<string>(ALL_MONTHS);
+
+/**
  * A recipe whose embedded tags and ingredients have been resolved to persisted
  * master rows (each carrying its database `id`), ready for encoding and
  * insertion. The recipe's own `id` presence is preserved from the input draft.
@@ -94,6 +111,61 @@ type PreparedRecipe<T extends RecipeDraft = RecipeDraft> = Omit<T, 'tags' | 'ing
   tags: tagTableElement[];
   ingredients: ingredientTableElement[];
 };
+
+/**
+ * Id-keyed views over the cached ingredient and tag tables, used to resolve the
+ * ingredient and tag references embedded in an encoded recipe row without
+ * issuing a database query per reference.
+ */
+type decodeIndexes = {
+  ingredientsById: Map<number, ingredientTableElement>;
+  tagsById: Map<number, tagTableElement>;
+  unresolvedIngredientIds: Set<number>;
+  unresolvedTagIds: Set<number>;
+};
+
+/**
+ * Number of unresolved reference ids included in the decode integrity report.
+ * A drifted cache can strand thousands of references; logging a sample keeps the
+ * entry readable while still naming the rows to investigate.
+ */
+const UNRESOLVED_ID_SAMPLE_SIZE = 20;
+
+/**
+ * Takes the reportable head of a set of offending ids.
+ *
+ * @param ids - Every id found to be at fault
+ * @returns At most {@link UNRESOLVED_ID_SAMPLE_SIZE} of them, in insertion order
+ */
+function sampleIds(ids: Iterable<number>): number[] {
+  return [...ids].slice(0, UNRESOLVED_ID_SAMPLE_SIZE);
+}
+
+/**
+ * Combines an ingredient's master row with the quantity and note a recipe uses
+ * it at.
+ *
+ * A recipe row stores only an ingredient id plus its own quantity and optional
+ * note; everything else comes from the ingredients table. Both decoding and the
+ * ingredient-edit cache patch resolve references this way, so the rule lives
+ * here and an absent note stays an absent key in both.
+ *
+ * @param master - Ingredient as stored in the ingredients table
+ * @param quantity - Amount this recipe uses
+ * @param note - Recipe-specific usage note, if any
+ * @returns The ingredient as a recipe embeds it
+ */
+function mergeIngredientUsage(
+  master: ingredientTableElement,
+  quantity: string | undefined,
+  note: string | undefined
+): ingredientTableElement {
+  const used: ingredientTableElement = { ...master, quantity };
+  if (note) {
+    used.note = note;
+  }
+  return used;
+}
 
 /**
  * RecipeDatabase - Singleton class for managing recipe data storage and operations
@@ -149,6 +221,7 @@ export class RecipeDatabase {
   private _listeners = new Map<StoreSlice, Set<() => void>>();
   private _isReady = false;
   private _initPromise: Promise<void> | null = null;
+  private _decodeError: Error | null = null;
 
   /*    PRIVATE METHODS     */
   private constructor() {
@@ -351,30 +424,25 @@ export class RecipeDatabase {
 
     await this.migrateAddSourceColumns();
 
-    const [
-      ingredients,
-      tags,
-      recipes,
-      importHistory,
-      dismissedRecipes,
-      menu,
-      purchasedIngredients,
-    ] = await Promise.all([
-      this.getAllIngredients(),
-      this.getAllTags(),
-      this.getAllRecipes(),
-      this.getAllImportHistory(),
-      this.getAllDismissedRecipes(),
-      this.getAllMenu(),
-      this.getAllPurchasedIngredients(),
-    ]);
+    const [ingredients, tags] = await Promise.all([this.getAllIngredients(), this.getAllTags()]);
     this._ingredients = ingredients;
     this._tags = tags;
+
+    const [recipes, importHistory, dismissedRecipes, menu, purchasedIngredients] =
+      await Promise.all([
+        this.getAllRecipes(),
+        this.getAllImportHistory(),
+        this.getAllDismissedRecipes(),
+        this.getAllMenu(),
+        this.getAllPurchasedIngredients(),
+      ]);
     this._recipes = recipes;
     this._importHistory = importHistory;
     this._dismissedRecipes = dismissedRecipes;
     this._menu = menu;
     this._purchasedIngredients = purchasedIngredients;
+
+    this.reportUnresolvedMenuRecipes();
 
     databaseLogger.info('Database initialization completed', {
       recipesCount: this._recipes.length,
@@ -677,7 +745,7 @@ export class RecipeDatabase {
       });
       throw new Error(`Failed to retrieve recipe "${recipe.title}" after insertion`);
     }
-    const decodedRecipe = await this.decodeRecipe(dbRecipe);
+    const decodedRecipe = this.decodeArrayOfRecipe([dbRecipe])[0]!;
     this.add_recipes(decodedRecipe);
     this._recipes = [...this._recipes];
     this.notify('recipes');
@@ -767,7 +835,7 @@ export class RecipeDatabase {
    * Updates an existing ingredient in the database.
    *
    * After a successful update the in-memory ingredients cache is refreshed and
-   * all recipes that reference this ingredient are reloaded from the database,
+   * every cached recipe that references this ingredient is patched in place,
    * then both the `ingredients` and `recipes` store slices are notified.
    *
    * @param ingredient - The ingredient to update. Must have a valid `id`.
@@ -783,7 +851,7 @@ export class RecipeDatabase {
     if (success) {
       this.update_ingredient(ingredient);
       this._ingredients = [...this._ingredients];
-      this._recipes = await this.getAllRecipes();
+      this._recipes = this._recipes.map(recipe => this.applyIngredientToRecipe(recipe, ingredient));
       this.notify('ingredients');
       this.notify('recipes');
     }
@@ -791,11 +859,55 @@ export class RecipeDatabase {
   }
 
   /**
+   * Re-resolves an updated ingredient inside a cached recipe
+   *
+   * Recipes embed a copy of each ingredient they use, so an ingredient rename or
+   * unit change has to be reflected in every recipe referencing it. The
+   * recipe-specific quantity and note are preserved and the recipe season is
+   * recomputed. Recipes that do not use the ingredient are returned untouched.
+   *
+   * @private
+   * @param recipe - Cached recipe to patch
+   * @param ingredient - Updated ingredient, matched by `id`
+   * @returns The patched recipe, or the original one when unaffected
+   */
+  private applyIngredientToRecipe(
+    recipe: recipeTableElement,
+    ingredient: ingredientTableElement
+  ): recipeTableElement {
+    if (!recipe.ingredients.some(used => used.id === ingredient.id)) {
+      return recipe;
+    }
+    const ingredients = recipe.ingredients.map(used =>
+      used.id === ingredient.id ? mergeIngredientUsage(ingredient, used.quantity, used.note) : used
+    );
+    return { ...recipe, ingredients, season: this.computeRecipeSeason(ingredients) };
+  }
+
+  /**
+   * Re-resolves an updated tag inside a cached recipe
+   *
+   * Mirror of {@link applyIngredientToRecipe} for tags, which carry no
+   * recipe-specific fields and so are replaced outright.
+   *
+   * @private
+   * @param recipe - Cached recipe to patch
+   * @param tag - Updated tag, matched by `id`
+   * @returns The patched recipe, or the original one when unaffected
+   */
+  private applyTagToRecipe(recipe: recipeTableElement, tag: tagTableElement): recipeTableElement {
+    if (!recipe.tags.some(used => used.id === tag.id)) {
+      return recipe;
+    }
+    return { ...recipe, tags: recipe.tags.map(used => (used.id === tag.id ? tag : used)) };
+  }
+
+  /**
    * Updates an existing tag in the database.
    *
-   * After a successful update the in-memory tags cache is refreshed and all
-   * recipes that reference this tag are reloaded from the database, then both
-   * the `tags` and `recipes` store slices are notified.
+   * After a successful update the in-memory tags cache is refreshed and every
+   * cached recipe that references this tag is patched in place, then both the
+   * `tags` and `recipes` store slices are notified.
    *
    * @param tag - The tag to update. Must have a valid `id`.
    * @returns `true` if the update succeeded, `false` otherwise.
@@ -806,7 +918,7 @@ export class RecipeDatabase {
     if (success) {
       this.update_tag(tag);
       this._tags = [...this._tags];
-      this._recipes = await this.getAllRecipes();
+      this._recipes = this._recipes.map(recipe => this.applyTagToRecipe(recipe, tag));
       this.notify('tags');
       this.notify('recipes');
     }
@@ -949,14 +1061,16 @@ export class RecipeDatabase {
       );
 
       for (const recipe of recipesToUpdate) {
+        const remainingIngredients = recipe.ingredients.filter(i => i.id !== ingredient.id);
         const updatedRecipe = {
           ...recipe,
-          ingredients: recipe.ingredients.filter(i => i.id !== ingredient.id),
+          ingredients: remainingIngredients,
+          season: this.computeRecipeSeason(remainingIngredients),
         };
         await this.editRecipe(updatedRecipe);
       }
 
-      this._recipes = await this.getAllRecipes();
+      this._recipes = [...this._recipes];
       this.notify('ingredients');
       this.notify('recipes');
     }
@@ -991,7 +1105,7 @@ export class RecipeDatabase {
         await this.editRecipe(updatedRecipe);
       }
 
-      this._recipes = await this.getAllRecipes();
+      this._recipes = [...this._recipes];
       this.notify('tags');
       this.notify('recipes');
     }
@@ -1941,9 +2055,7 @@ export class RecipeDatabase {
       return;
     }
 
-    const decodedRecipes = await Promise.all(
-      insertedRecipes.map(encoded => this.decodeRecipe(encoded))
-    );
+    const decodedRecipes = this.decodeArrayOfRecipe(insertedRecipes);
 
     for (const recipe of decodedRecipes) {
       this.add_recipes(recipe);
@@ -2012,6 +2124,7 @@ export class RecipeDatabase {
     this._dismissedRecipes = [];
     this._menu = [];
     this._purchasedIngredients = new Map();
+    this._decodeError = null;
   }
 
   /**
@@ -2273,16 +2386,20 @@ export class RecipeDatabase {
    * @param encodedRecipe - The encoded recipe data from database
    * @returns Promise resolving to fully decoded recipe object
    */
-  private async decodeRecipe(encodedRecipe: encodedRecipeElement): Promise<recipeTableElement> {
-    const [decodedIngredients, decodedSeason] = await this.decodeIngredientFromRecipe(
-      encodedRecipe.INGREDIENTS
+  private decodeRecipe(
+    encodedRecipe: encodedRecipeElement,
+    indexes: decodeIndexes
+  ): recipeTableElement {
+    const [decodedIngredients, decodedSeason] = this.decodeIngredientFromRecipe(
+      encodedRecipe.INGREDIENTS,
+      indexes
     );
     return {
       id: encodedRecipe.ID,
       image_Source: constructImageUri(encodedRecipe.IMAGE_SOURCE),
       title: encodedRecipe.TITLE,
       description: encodedRecipe.DESCRIPTION,
-      tags: await this.decodeTagFromRecipe(encodedRecipe.TAGS),
+      tags: this.decodeTagFromRecipe(encodedRecipe.TAGS, indexes),
       persons: encodedRecipe.PERSONS,
       ingredients: decodedIngredients,
       season: decodedSeason,
@@ -2298,19 +2415,113 @@ export class RecipeDatabase {
    * Decodes an array of recipes from database storage format
    *
    * Processes multiple encoded recipe elements from database queries,
-   * decoding each one into the full application format.
+   * decoding each one into the full application format. The ingredient and tag
+   * lookup indexes are built once and shared across the whole batch.
    *
    * @private
    * @param queryResult - Array of encoded recipe elements from database
-   * @returns Promise resolving to array of fully decoded recipe objects
+   * @returns Array of fully decoded recipe objects
    */
-  private async decodeArrayOfRecipe(
-    queryResult: encodedRecipeElement[]
-  ): Promise<recipeTableElement[]> {
+  private decodeArrayOfRecipe(queryResult: encodedRecipeElement[]): recipeTableElement[] {
     if (queryResult.length === 0) {
       return [];
     }
-    return await Promise.all(queryResult.map(recipeEncoded => this.decodeRecipe(recipeEncoded)));
+    const indexes = this.buildDecodeIndexes();
+    const decoded = queryResult.map(recipeEncoded => this.decodeRecipe(recipeEncoded, indexes));
+    this.reportUnresolvedReferences(indexes, queryResult.length);
+    return decoded;
+  }
+
+  /**
+   * Builds id-keyed lookup indexes over the cached ingredients and tags
+   *
+   * Recipe rows only store ingredient and tag ids, so decoding needs to resolve
+   * each id to its full element. Both tables are already fully cached in memory,
+   * so the lookups are served from these maps instead of one query per reference.
+   *
+   * @private
+   * @returns Ingredient and tag lookup maps keyed by database id, plus the sets
+   *          collecting the ids that decoding could not resolve
+   */
+  private buildDecodeIndexes(): decodeIndexes {
+    return {
+      ingredientsById: new Map(this._ingredients.map(ingredient => [ingredient.id, ingredient])),
+      tagsById: new Map(this._tags.map(tag => [tag.id, tag])),
+      unresolvedIngredientIds: new Set(),
+      unresolvedTagIds: new Set(),
+    };
+  }
+
+  /**
+   * Reports references that a decode pass could not resolve against the caches
+   *
+   * Every ingredient and tag a recipe row points at must exist in the caches,
+   * which mirror their whole tables. An unresolved id therefore means either a
+   * cache that drifted from the database or a recipe row pointing at a deleted
+   * row — both silently drop data from the decoded recipe, so they are logged as
+   * errors. Ids are reported once per decode pass rather than once per reference.
+   *
+   * @private
+   * @param indexes - Decode indexes carrying the unresolved id sets
+   * @param decodedRecipeCount - Number of recipes the decode pass covered
+   */
+  private reportUnresolvedReferences(indexes: decodeIndexes, decodedRecipeCount: number): void {
+    const { unresolvedIngredientIds, unresolvedTagIds } = indexes;
+    if (unresolvedIngredientIds.size === 0 && unresolvedTagIds.size === 0) {
+      return;
+    }
+    const ingredientSample = sampleIds(unresolvedIngredientIds);
+    const tagSample = sampleIds(unresolvedTagIds);
+    this.recordDecodeError(
+      `${unresolvedIngredientIds.size} ingredient and ${unresolvedTagIds.size} tag reference(s) in recipes could not be resolved` +
+        ` — ingredients: [${ingredientSample.join(', ')}], tags: [${tagSample.join(', ')}]`,
+      {
+        decodedRecipeCount,
+        cachedIngredientCount: this._ingredients.length,
+        cachedTagCount: this._tags.length,
+        unresolvedIngredientIds: ingredientSample,
+        unresolvedTagIds: tagSample,
+      }
+    );
+  }
+
+  /**
+   * Logs a corrupt-data condition found while decoding a table, and records it
+   *
+   * Decoding resolves cross-table references and casts stored strings into
+   * application types; neither can be trusted blindly, and a failure means the
+   * decoded row silently loses data. Every failure is logged. In development and
+   * E2E builds the first one is also kept, so the UI layer can rethrow it during
+   * render and let the root error boundary replace the app with the recovery
+   * screen — making the corruption impossible to miss. Production keeps the log
+   * and degrades the affected row rather than taking the whole app down.
+   *
+   * Logging and recording live together so a future check cannot do one without
+   * the other, and publishes on the `recipes` slice so a subscriber mounted
+   * before the failure re-renders and can surface it.
+   *
+   * @private
+   * @param message - What was found to be corrupt, including the offending ids
+   * @param context - Structured detail for the log entry
+   */
+  private recordDecodeError(message: string, context: Record<string, unknown>): void {
+    databaseLogger.error(message, context);
+    if (!DECODE_INTEGRITY_CHECK_ENABLED || this._decodeError !== null) {
+      return;
+    }
+    this._decodeError = new Error(message);
+    this.notify('recipes');
+  }
+
+  /**
+   * Returns the first corrupt-data condition found while decoding, if any.
+   *
+   * Always `null` in production builds.
+   *
+   * @returns The recorded decode error, or `null` when every decode succeeded
+   */
+  public get_decode_error(): Error | null {
+    return this._decodeError;
   }
 
   /**
@@ -2369,7 +2580,8 @@ export class RecipeDatabase {
    *
    * @private
    * @param encodedIngredient - Encoded string containing ingredient IDs, quantities, and optional notes
-   * @returns Promise resolving to tuple of [decoded ingredients array, combined season array]
+   * @param indexes - Decode indexes providing the cached ingredients and collecting unresolved ids
+   * @returns Tuple of [decoded ingredients array, combined season array]
    *
    * @example
    * // Old format (backward compatible)
@@ -2380,16 +2592,15 @@ export class RecipeDatabase {
    * Input: "1--200%%For sauce__1--100%%For garnish"
    * Output: [[ingredient1 with quantity 200 and note "For sauce", ingredient1 with quantity 100 and note "For garnish"], ...]
    */
-  private async decodeIngredientFromRecipe(
-    encodedIngredient: string
-  ): Promise<[ingredientTableElement[], string[]]> {
-    const arrDecoded = [];
-    let recipeSeason: string[] = [...ALL_MONTHS];
-    let firstSeasonFound = true;
+  private decodeIngredientFromRecipe(
+    encodedIngredient: string,
+    indexes: decodeIndexes
+  ): [ingredientTableElement[], string[]] {
+    const arrDecoded: ingredientTableElement[] = [];
 
-    const ingSplit = encodedIngredient.includes(EncodingSeparator)
-      ? encodedIngredient.split(EncodingSeparator)
-      : [encodedIngredient];
+    // A recipe with no ingredient stores an empty string, which must decode to no
+    // reference at all rather than to a reference to id 0.
+    const ingSplit = encodedIngredient === '' ? [] : encodedIngredient.split(EncodingSeparator);
 
     for (const ingredient of ingSplit) {
       const id = Number(ingredient.split(textSeparator)[0]);
@@ -2399,32 +2610,36 @@ export class RecipeDatabase {
         ? quantityAndNote.split(noteSeparator)
         : [quantityAndNote, undefined];
 
-      const tableIngredient =
-        await this._ingredientsTable.searchElementById<encodedIngredientElement>(
-          id,
-          this._dbConnection
-        );
-      if (tableIngredient === undefined) {
-        databaseLogger.warn('Failed to find ingredient during recipe decoding', {
-          ingredientId: id,
-        });
+      const cachedIngredient = indexes.ingredientsById.get(id);
+      if (cachedIngredient === undefined) {
+        indexes.unresolvedIngredientIds.add(id);
       } else {
-        const decodedIngredient = this.decodeIngredient(tableIngredient);
-        decodedIngredient.quantity = ingQuantity;
-        if (ingNote) {
-          decodedIngredient.note = ingNote;
-        }
-        arrDecoded.push(decodedIngredient);
-
-        if (firstSeasonFound) {
-          recipeSeason = decodedIngredient.season;
-          firstSeasonFound = false;
-        } else {
-          recipeSeason = this.decodeSeason(recipeSeason, decodedIngredient.season);
-        }
+        arrDecoded.push(mergeIngredientUsage(cachedIngredient, ingQuantity, ingNote));
       }
     }
-    return [arrDecoded, recipeSeason];
+    return [arrDecoded, this.computeRecipeSeason(arrDecoded)];
+  }
+
+  /**
+   * Computes the seasonal availability of a recipe from its ingredients
+   *
+   * Intersects the seasons of every ingredient the recipe uses. A recipe with no
+   * resolvable ingredients is available all year.
+   *
+   * @private
+   * @param ingredients - Ingredients composing the recipe
+   * @returns Months during which every ingredient is available
+   */
+  private computeRecipeSeason(ingredients: ingredientTableElement[]): string[] {
+    const firstIngredient = ingredients[0];
+    if (firstIngredient === undefined) {
+      return [...ALL_MONTHS];
+    }
+    let season = firstIngredient.season;
+    for (let i = 1; i < ingredients.length && season.length > 0; i++) {
+      season = this.decodeSeason(season, ingredients[i]!.season);
+    }
+    return season;
   }
 
   /**
@@ -2489,12 +2704,31 @@ export class RecipeDatabase {
    */
   private decodeIngredient(dbIngredient: encodedIngredientElement): ingredientTableElement {
     // Ex :  {"ID":1,"INGREDIENT":"INGREDIENT NAME","UNIT":"g", "TYPE":"BASE", "SEASON":"*"}
+    // An ingredient with no month selected stores an empty SEASON, which splits into
+    // [''] — decode it as the empty season it encodes rather than an impossible month.
+    const season = dbIngredient.SEASON === '' ? [] : dbIngredient.SEASON.split(EncodingSeparator);
+
+    if (!INGREDIENT_TYPES.has(dbIngredient.TYPE)) {
+      this.recordDecodeError(
+        `Ingredient ${dbIngredient.ID} has an unknown type "${dbIngredient.TYPE}"`,
+        { ingredientId: dbIngredient.ID, storedType: dbIngredient.TYPE }
+      );
+    }
+
+    if (season.some(month => !MONTHS.has(month))) {
+      const invalidMonths = season.filter(month => !MONTHS.has(month));
+      this.recordDecodeError(
+        `Ingredient ${dbIngredient.ID} has invalid season months [${invalidMonths.join(', ')}]`,
+        { ingredientId: dbIngredient.ID, invalidMonths }
+      );
+    }
+
     return {
       id: dbIngredient.ID,
       name: dbIngredient.INGREDIENT,
       unit: dbIngredient.UNIT,
       type: dbIngredient.TYPE as ingredientType,
-      season: dbIngredient.SEASON.split(EncodingSeparator),
+      season,
     };
   }
 
@@ -2515,7 +2749,39 @@ export class RecipeDatabase {
     if (!queryResult || !Array.isArray(queryResult) || queryResult.length === 0) {
       return [];
     }
-    return queryResult.map(ingredient => this.decodeIngredient(ingredient));
+    const decoded = queryResult.map(ingredient => this.decodeIngredient(ingredient));
+    this.reportDuplicateIds(decoded, 'ingredient');
+    return decoded;
+  }
+
+  /**
+   * Reports rows sharing a database id within a cached table
+   *
+   * Recipe decoding resolves ingredient and tag references through id-keyed maps
+   * built over these caches, so two rows with the same id silently shadow one
+   * another and every recipe referencing that id gets whichever row was indexed
+   * last. Cheap to detect while the table is already in hand.
+   *
+   * @private
+   * @param elements - Decoded rows of a cached table
+   * @param label - Table name used in the log and error message
+   */
+  private reportDuplicateIds(elements: { id: number }[], label: string): void {
+    const seen = new Set(elements.map(element => element.id));
+    if (seen.size === elements.length) {
+      return;
+    }
+    const duplicates = sampleIds(
+      new Set(
+        elements
+          .filter((element, index) => elements.findIndex(e => e.id === element.id) !== index)
+          .map(e => e.id)
+      )
+    );
+    this.recordDecodeError(
+      `Duplicate ${label} ids [${duplicates.join(', ')}] — recipe references to them resolve to an arbitrary row`,
+      { table: label, duplicateIds: duplicates, rowCount: elements.length }
+    );
   }
 
   /**
@@ -2564,33 +2830,30 @@ export class RecipeDatabase {
    * Decodes tags from a recipe's encoded tag string
    *
    * Parses the encoded tag string from a recipe, looking up each tag by ID
-   * in the database to get the full tag information including names.
+   * in the cached tags to get the full tag information including names.
    *
    * @private
    * @param encodedTag - Encoded string containing tag IDs separated by encoding separators
-   * @returns Promise resolving to array of decoded tag objects
+   * @param indexes - Decode indexes providing the cached tags and collecting unresolved ids
+   * @returns Array of decoded tag objects
    *
    * @example
    * Input: "1__2__5__3__4"
    * Output: [{id: 1, name: "Italian"}, {id: 2, name: "Dinner"}, ...]
    */
-  private async decodeTagFromRecipe(encodedTag: string): Promise<tagTableElement[]> {
-    const arrDecoded = [];
+  private decodeTagFromRecipe(encodedTag: string, indexes: decodeIndexes): tagTableElement[] {
+    const arrDecoded: tagTableElement[] = [];
 
-    // Ex : "1__2__5__3__4"
-    const tagSplit = encodedTag.includes(EncodingSeparator)
-      ? encodedTag.split(EncodingSeparator)
-      : [encodedTag];
+    // Ex : "1__2__5__3__4". An untagged recipe stores an empty string, which must
+    // decode to no reference at all rather than to a reference to id 0.
+    const tagSplit = encodedTag === '' ? [] : encodedTag.split(EncodingSeparator);
 
     for (const tag of tagSplit) {
-      const tableTag = await this._tagsTable.searchElementById<encodedTagElement>(
-        +tag,
-        this._dbConnection
-      );
-      if (tableTag !== undefined) {
-        arrDecoded.push(this.decodeTag(tableTag));
+      const cachedTag = indexes.tagsById.get(+tag);
+      if (cachedTag !== undefined) {
+        arrDecoded.push(cachedTag);
       } else {
-        databaseLogger.warn('Failed to find tag during recipe decoding', { tagId: +tag });
+        indexes.unresolvedTagIds.add(+tag);
       }
     }
 
@@ -2630,7 +2893,9 @@ export class RecipeDatabase {
     if (!queryResult || !Array.isArray(queryResult) || queryResult.length === 0) {
       return [];
     }
-    return queryResult.map(tagFound => this.decodeTag(tagFound));
+    const decoded = queryResult.map(tagFound => this.decodeTag(tagFound));
+    this.reportDuplicateIds(decoded, 'tag');
+    return decoded;
   }
 
   /**
@@ -2736,13 +3001,14 @@ export class RecipeDatabase {
    * Retrieves all recipes from the database
    *
    * Fetches all recipe records from the database and decodes them into
-   * the application format for use in the local cache.
+   * the application format for use in the local cache. Embedded ingredients and
+   * tags are resolved from the in-memory caches, which must already be loaded.
    *
    * @private
    * @returns Promise resolving to array of all recipes in application format
    */
   private async getAllRecipes(): Promise<recipeTableElement[]> {
-    return await this.decodeArrayOfRecipe(
+    return this.decodeArrayOfRecipe(
       (await this._recipesTable.searchElement(this._dbConnection)) as encodedRecipeElement[]
     );
   }
@@ -2850,6 +3116,36 @@ export class RecipeDatabase {
       return [];
     }
     return queryResult.map(menuElement => this.decodeMenu(menuElement));
+  }
+
+  /**
+   * Reports menu rows pointing at a recipe that no longer exists
+   *
+   * Menu rows keep only a recipe id, resolved against the recipe cache when the
+   * menu is rendered. A row whose recipe was deleted therefore renders as an
+   * empty entry rather than failing outright, so it is surfaced here instead.
+   *
+   * Checked against the caches rather than inside the menu decoder, because both
+   * sides are plain cached data — decoding a menu row cannot see the recipes.
+   * Resolved from the cache, so it costs no query.
+   *
+   * @private
+   */
+  private reportUnresolvedMenuRecipes(): void {
+    const recipeIds = new Set(this._recipes.map(recipe => recipe.id));
+    const unresolved = this._menu
+      .map(item => item.recipeId)
+      .filter(recipeId => !recipeIds.has(recipeId));
+
+    if (unresolved.length === 0) {
+      return;
+    }
+    const sample = sampleIds(unresolved);
+    this.recordDecodeError(`Menu rows reference missing recipes [${sample.join(', ')}]`, {
+      unresolvedRecipeIds: sample,
+      menuRowCount: this._menu.length,
+      cachedRecipeCount: this._recipes.length,
+    });
   }
 
   /**

--- a/tests/helpers/corruptIngredientType.ts
+++ b/tests/helpers/corruptIngredientType.ts
@@ -1,0 +1,26 @@
+import RecipeDatabase from '@utils/RecipeDatabase';
+
+/** Type string no `ingredientType` member holds, so decoding must reject it. */
+export const CORRUPT_INGREDIENT_TYPE = 'not-a-real-type';
+
+/**
+ * Writes an unknown `TYPE` straight into an ingredient row, bypassing the
+ * application layer, then reloads the ingredient cache so decoding sees it.
+ *
+ * Reaches through the database's private table handles on purpose: no public
+ * API can produce a row this broken, which is the point of the decode guard.
+ *
+ * @param db - Database instance to corrupt
+ * @param ingredientId - Row to give an unknown type
+ */
+export async function corruptIngredientType(
+  db: RecipeDatabase,
+  ingredientId: number
+): Promise<void> {
+  await db['_ingredientsTable'].editElementById(
+    ingredientId,
+    new Map([['TYPE', CORRUPT_INGREDIENT_TYPE]]),
+    db['_dbConnection']
+  );
+  await db['getAllIngredients']();
+}

--- a/tests/perf/RecipeDatabaseDecode.perf.tsx
+++ b/tests/perf/RecipeDatabaseDecode.perf.tsx
@@ -1,0 +1,75 @@
+import { measureAsyncFunction } from 'reassure';
+import RecipeDatabase from '@utils/RecipeDatabase';
+import { performanceRecipes } from '@assets/datasets/performance/recipes';
+import { performanceIngredients } from '@assets/datasets/performance/ingredients';
+import { performanceTags } from '@assets/datasets/performance/tags';
+import { HEAVY_WARMUP } from './perfOptions';
+
+jest.mock('@utils/i18n', () => require('@mocks/utils/i18n-mock').i18nMock());
+
+const RUNS = 10;
+
+describe('RecipeDatabase decode and cache mutation performance', () => {
+  const database = RecipeDatabase.getInstance();
+
+  const seed = async () => {
+    await database.init();
+    await database.addMultipleIngredients(performanceIngredients);
+    await database.addMultipleTags(performanceTags);
+    await database.addMultipleRecipes(performanceRecipes);
+  };
+
+  const teardown = async () => {
+    await database.closeAndReset();
+  };
+
+  beforeEach(seed);
+  afterEach(teardown);
+
+  test('decode every recipe from the database', async () => {
+    await measureAsyncFunction(
+      async () => {
+        await database['getAllRecipes']();
+      },
+      { runs: RUNS, ...HEAVY_WARMUP }
+    );
+  });
+
+  test('editIngredient propagates to every recipe using it', async () => {
+    const target = performanceIngredients[0]!;
+    let rename = 0;
+
+    await measureAsyncFunction(
+      async () => {
+        rename += 1;
+        await database.editIngredient({ ...target, name: `${target.name} ${rename}` });
+      },
+      { runs: RUNS, ...HEAVY_WARMUP }
+    );
+  });
+
+  test('editTag propagates to every recipe using it', async () => {
+    const target = performanceTags[0]!;
+    let rename = 0;
+
+    await measureAsyncFunction(
+      async () => {
+        rename += 1;
+        await database.editTag({ ...target, name: `${target.name} ${rename}` });
+      },
+      { runs: RUNS, ...HEAVY_WARMUP }
+    );
+  });
+
+  test('deleteIngredient removes it from every recipe using it', async () => {
+    let index = 0;
+
+    await measureAsyncFunction(
+      async () => {
+        await database.deleteIngredient(performanceIngredients[index]!);
+        index += 1;
+      },
+      { runs: RUNS, ...HEAVY_WARMUP }
+    );
+  });
+});

--- a/tests/unit/components/organisms/AppWrapper.test.tsx
+++ b/tests/unit/components/organisms/AppWrapper.test.tsx
@@ -5,6 +5,7 @@ import RecipeDatabase from '@utils/RecipeDatabase';
 import { testIngredients } from '@test-data/ingredientsDataset';
 import { testTags } from '@test-data/tagsDataset';
 import { testRecipes } from '@test-data/recipesDataset';
+import { corruptIngredientType } from '@test-helpers/corruptIngredientType';
 
 jest.mock('@navigation/RootNavigator', () =>
   require('@mocks/navigation/RootNavigator-mock').rootNavigatorMock()
@@ -217,5 +218,20 @@ describe('AppWrapper Component', () => {
     });
 
     expect(database.get_menu().length).toBe(0);
+  });
+
+  describe('decode integrity', () => {
+    beforeEach(async () => {
+      await database.addMultipleIngredients(testIngredients);
+      await database.addMultipleTags(testTags);
+      await database.addMultipleRecipes(testRecipes);
+      isFirstLaunch.mockResolvedValue(false);
+    });
+
+    test('throws the decode error so an error boundary can catch it', async () => {
+      await corruptIngredientType(database, testIngredients[0]!.id);
+
+      expect(() => render(<AppWrapper />)).toThrow(/has an unknown type "not-a-real-type"/);
+    });
   });
 });

--- a/tests/unit/hooks/decodeError.test.tsx
+++ b/tests/unit/hooks/decodeError.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react-native';
+import { useRecipes } from '@hooks/useRecipes';
+import { useMenu } from '@hooks/useMenu';
+import { useIngredients } from '@hooks/useIngredients';
+import { useTags } from '@hooks/useTags';
+import RecipeDatabase from '@utils/RecipeDatabase';
+import { testIngredients } from '@test-data/ingredientsDataset';
+import { testTags } from '@test-data/tagsDataset';
+import { testRecipes } from '@test-data/recipesDataset';
+import { corruptIngredientType } from '@test-helpers/corruptIngredientType';
+
+describe('decodeError exposure across the focused hooks', () => {
+  const db = RecipeDatabase.getInstance();
+
+  const hookReaders: [string, () => Error | null][] = [
+    ['useRecipes', () => renderHook(() => useRecipes()).result.current.decodeError],
+    ['useMenu', () => renderHook(() => useMenu()).result.current.decodeError],
+    ['useIngredients', () => renderHook(() => useIngredients()).result.current.decodeError],
+    ['useTags', () => renderHook(() => useTags()).result.current.decodeError],
+  ];
+
+  beforeEach(async () => {
+    await db.init();
+    await db.addMultipleIngredients(testIngredients);
+    await db.addMultipleTags(testTags);
+    await db.addMultipleRecipes(testRecipes);
+  });
+
+  afterEach(async () => {
+    await db.closeAndReset();
+  });
+
+  test.each(hookReaders)('%s exposes null while every row decodes', (_name, read) => {
+    expect(read()).toBeNull();
+  });
+
+  test.each(hookReaders)(
+    '%s exposes the recorded error once a row is corrupt',
+    async (_name, read) => {
+      await corruptIngredientType(db, testIngredients[0]!.id);
+
+      expect(read()?.message).toMatch(/has an unknown type "not-a-real-type"/);
+    }
+  );
+});

--- a/tests/unit/utils/RecipeDatabase.test.tsx
+++ b/tests/unit/utils/RecipeDatabase.test.tsx
@@ -14,6 +14,8 @@ import {
   tagTableElement,
 } from '@customTypes/DatabaseElementTypes';
 import { getRandomRecipes } from '@utils/FilterFunctions';
+import { ALL_MONTHS } from '@styles/typography';
+import { corruptIngredientType } from '@test-helpers/corruptIngredientType';
 
 describe('RecipeDatabase', () => {
   describe('RecipeDatabase basic tests', () => {
@@ -531,6 +533,235 @@ describe('RecipeDatabase', () => {
             i => i.id === ingredientToDelete!.id
           );
           expect(hasDeletedIngredient).toBe(false);
+        });
+      });
+    });
+
+    describe('Recipe decoding from the in-memory ingredient and tag caches', () => {
+      test('decoding every recipe issues no per-ingredient or per-tag lookup', async () => {
+        const ingredientLookup = jest.spyOn(db['_ingredientsTable'], 'searchElementById');
+        const tagLookup = jest.spyOn(db['_tagsTable'], 'searchElementById');
+
+        const decodedRecipes = await db['getAllRecipes']();
+
+        expect(decodedRecipes).toEqual(testRecipes);
+        expect(ingredientLookup).not.toHaveBeenCalled();
+        expect(tagLookup).not.toHaveBeenCalled();
+
+        ingredientLookup.mockRestore();
+        tagLookup.mockRestore();
+      });
+
+      test('addRecipe decodes the inserted recipe without per-reference lookups', async () => {
+        const ingredientLookup = jest.spyOn(db['_ingredientsTable'], 'searchElementById');
+        const tagLookup = jest.spyOn(db['_tagsTable'], 'searchElementById');
+
+        const added = await db.addRecipe({
+          ...testRecipes[0]!,
+          id: undefined,
+          title: 'Decoded Without Lookups',
+        });
+
+        expect(added.ingredients).toEqual(testRecipes[0]!.ingredients);
+        expect(added.tags).toEqual(testRecipes[0]!.tags);
+        expect(ingredientLookup).not.toHaveBeenCalled();
+        expect(tagLookup).not.toHaveBeenCalled();
+
+        ingredientLookup.mockRestore();
+        tagLookup.mockRestore();
+      });
+
+      const cacheMutations: [string, () => Promise<unknown>][] = [
+        [
+          'editIngredient',
+          () => db.editIngredient({ ...testIngredients[0]!, name: 'Renamed Spaghetti' }),
+        ],
+        ['editTag', () => db.editTag({ ...testTags[0]!, name: 'Renamed Tag' })],
+        ['deleteIngredient', () => db.deleteIngredient(testIngredients[0]!)],
+        ['deleteTag', () => db.deleteTag(testTags[0]!)],
+        [
+          'addIngredient',
+          () => db.addIngredient({ ...testIngredients[0]!, id: undefined, name: 'Added' }),
+        ],
+        ['addTag', () => db.addTag({ ...testTags[0]!, id: undefined, name: 'Added' })],
+        ['addRecipe', () => db.addRecipe({ ...testRecipes[1]!, id: undefined, title: 'Added' })],
+        ['editRecipe', () => db.editRecipe({ ...testRecipes[0]!, title: 'Edited' })],
+        ['deleteRecipe', () => db.deleteRecipe(testRecipes[2]!)],
+      ];
+
+      test.each(cacheMutations)(
+        '%s leaves the cached recipes equal to a full database reload and records no decode error',
+        async (_operation, mutate) => {
+          await mutate();
+
+          expect(db.get_recipes()).toEqual(await db['getAllRecipes']());
+          expect(db.get_decode_error()).toBeNull();
+        }
+      );
+
+      test.each(cacheMutations.slice(0, 4))(
+        '%s patches the cached recipes without reloading them',
+        async (_operation, mutate) => {
+          const reload = jest.spyOn(
+            db as unknown as { getAllRecipes: () => Promise<recipeTableElement[]> },
+            'getAllRecipes'
+          );
+
+          await mutate();
+
+          expect(reload).not.toHaveBeenCalled();
+          reload.mockRestore();
+        }
+      );
+
+      test('editIngredient narrows the season of every recipe using it', async () => {
+        const recipeBefore = db.get_recipes().find(r => r.id === testRecipes[0]!.id)!;
+        expect(recipeBefore.season).toEqual(ALL_MONTHS);
+
+        await db.editIngredient({ ...testIngredients[0]!, season: ['5', '6', '7'] });
+
+        const recipeAfter = db.get_recipes().find(r => r.id === testRecipes[0]!.id)!;
+        expect(recipeAfter.season).toEqual(['5', '6', '7']);
+      });
+
+      test('deleteIngredient widens the season back to the remaining ingredients', async () => {
+        await db.editIngredient({ ...testIngredients[0]!, season: ['5', '6', '7'] });
+        expect(db.get_recipes().find(r => r.id === testRecipes[0]!.id)!.season).toEqual([
+          '5',
+          '6',
+          '7',
+        ]);
+
+        await db.deleteIngredient(testIngredients[0]!);
+
+        const recipeAfter = db.get_recipes().find(r => r.id === testRecipes[0]!.id)!;
+        expect(recipeAfter.ingredients.some(i => i.id === testIngredients[0]!.id)).toBe(false);
+        expect(recipeAfter.season).toEqual(ALL_MONTHS);
+      });
+
+      test('a recipe referencing a missing ingredient records a decode error', async () => {
+        await db['_ingredientsTable'].deleteElementById(
+          testIngredients[0]!.id,
+          db['_dbConnection']
+        );
+
+        await db['getAllIngredients']().then(loaded => (db['_ingredients'] = loaded));
+        await db['getAllRecipes']();
+
+        expect(db.get_decode_error()?.message).toMatch(
+          /reference\(s\) in recipes could not be resolved/
+        );
+      });
+
+      test('an ingredient row with an unknown type records a decode error', async () => {
+        await corruptIngredientType(db, testIngredients[0]!.id);
+
+        expect(db.get_decode_error()?.message).toMatch(/has an unknown type "not-a-real-type"/);
+      });
+
+      test('an ingredient row with an impossible month records a decode error', async () => {
+        await db['_ingredientsTable'].editElementById(
+          testIngredients[0]!.id,
+          new Map([['SEASON', '1__13']]),
+          db['_dbConnection']
+        );
+
+        await db['getAllIngredients']();
+
+        expect(db.get_decode_error()?.message).toMatch(/invalid season months \[13\]/);
+      });
+
+      test('duplicate ingredient ids record a decode error', async () => {
+        db['reportDuplicateIds']([{ id: 1 }, { id: 2 }, { id: 1 }], 'ingredient');
+
+        expect(db.get_decode_error()?.message).toMatch(/Duplicate ingredient ids \[1\]/);
+      });
+
+      test('duplicate tag ids record a decode error', async () => {
+        db['reportDuplicateIds']([{ id: 4 }, { id: 4 }], 'tag');
+
+        expect(db.get_decode_error()?.message).toMatch(/Duplicate tag ids \[4\]/);
+      });
+
+      test('a menu row pointing at a deleted recipe records a decode error', async () => {
+        await db.addRecipeToMenu(testRecipes[0]!);
+        db['_recipes'] = db['_recipes'].filter(recipe => recipe.id !== testRecipes[0]!.id);
+
+        db['reportUnresolvedMenuRecipes']();
+
+        expect(db.get_decode_error()?.message).toMatch(/Menu rows reference missing recipes/);
+      });
+
+      test('only the first decode error is kept', async () => {
+        db['reportDuplicateIds']([{ id: 1 }, { id: 1 }], 'ingredient');
+        const firstError = db.get_decode_error();
+
+        db['reportDuplicateIds']([{ id: 9 }, { id: 9 }], 'tag');
+
+        expect(db.get_decode_error()).toBe(firstError);
+      });
+
+      test('a clean database records no decode error', () => {
+        expect(db.get_decode_error()).toBeNull();
+      });
+
+      test('an ingredient saved with no month records no decode error', async () => {
+        await db.addIngredient({
+          name: 'Seasonless Ingredient',
+          unit: 'g',
+          type: ingredientType.condiment,
+          season: [],
+        });
+
+        await db['getAllIngredients']();
+
+        expect(db.get_decode_error()).toBeNull();
+        expect(db.get_ingredients().find(i => i.name === 'Seasonless Ingredient')?.season).toEqual(
+          []
+        );
+      });
+
+      test('a recipe saved without tags records no decode error', async () => {
+        const added = await db.addRecipe({ ...testRecipes[0]!, id: undefined, tags: [] });
+
+        const reloaded = await db['getAllRecipes']();
+
+        expect(db.get_decode_error()).toBeNull();
+        expect(reloaded.find(recipe => recipe.id === added.id)?.tags).toEqual([]);
+      });
+
+      test('a recipe left without ingredients records no decode error', async () => {
+        const added = await db.addRecipe({
+          ...testRecipes[0]!,
+          id: undefined,
+          title: 'Ingredientless',
+          ingredients: [testIngredients[0]!],
+        });
+
+        await db.deleteIngredient(testIngredients[0]!);
+        const reloaded = await db['getAllRecipes']();
+
+        expect(db.get_decode_error()).toBeNull();
+        expect(reloaded.find(recipe => recipe.id === added.id)?.ingredients).toEqual([]);
+      });
+
+      test('editIngredient preserves recipe-specific quantity and note', async () => {
+        const addedRecipe = await db.addRecipe({
+          ...testRecipes[0]!,
+          id: undefined,
+          title: 'Recipe With Ingredient Notes',
+          ingredients: [{ ...testIngredients[0]!, quantity: '123', note: 'For the sauce' }],
+        });
+
+        await db.editIngredient({ ...testIngredients[0]!, name: 'Renamed Spaghetti', unit: 'kg' });
+
+        const refreshed = db.get_recipes().find(r => r.id === addedRecipe.id)!;
+        expect(refreshed.ingredients[0]).toEqual({
+          ...testIngredients[0]!,
+          name: 'Renamed Spaghetti',
+          unit: 'kg',
+          quantity: '123',
+          note: 'For the sauce',
         });
       });
     });


### PR DESCRIPTION
Closes #435.

`decodeRecipe` resolved every embedded ingredient and tag with its own `searchElementById`, awaited in a loop — 10–15k serialized SQLite round-trips per full decode at 1000 recipes. That cost was paid on every cold start, every bulk import, and after every ingredient/tag mutation, each of which then re-decoded the whole recipe table.

Both tables are already cached in full, so decoding now resolves ids through maps built once per pass, and the mutation paths patch cached recipes in place instead of reloading. `init()` orders the loads so ingredients and tags are cached before any recipe decodes, and recipes before the menu.

## Measured

Reassure `measureAsyncFunction`, 1000-recipe performance dataset:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| full decode | 450.1 ms | 84.7 ms | −81% |
| `editIngredient` | 534.3 ms | 8.1 ms | −98% |
| `editTag` | 628.7 ms | 0.4 ms | −99% |
| `deleteIngredient` | 512.4 ms | 24.4 ms | −95% |

## Decode integrity

Reading from caches instead of SQL widens what a stale or corrupt cache can break, so decoding now validates what it cannot assume — using only already-loaded data, no extra queries:

| Decoder | Checks |
|---|---|
| recipes | ingredient/tag ids resolving to no cached row |
| ingredients | `TYPE` outside `ingredientType`; `SEASON` months outside the calendar |
| ingredients, tags | duplicate ids, which make id-keyed lookups return an arbitrary row |
| menu vs recipes | `recipeId` pointing at a deleted recipe (checked after `init()`, not inside a decoder) |

Failures are always logged. In dev and E2E builds the first is recorded and rethrown by `AppWrapper` during render, so the root `ErrorBoundary` shows `ErrorFallback` — a logged error would otherwise be invisible in CI, since the Maestro build is release-mode and its logs never reach the artifacts. Production keeps the log and degrades the affected row.

## Tests

- Table-driven test over all 9 mutation methods asserting the cache equals a full DB reload — this is what guards against stale-value drift now that no runtime re-read exists
- Decode-error tests per corruption class, hook exposure tests, and an `AppWrapper` test proving the throw escapes to a boundary
- Regression tests for three empty-string edge cases (seasonless ingredient, tagless recipe, recipe left with no ingredients) — all confirmed failing against the unfixed code first
- New permanent Reassure benchmark so the N+1 can't return unnoticed

Unit 4172 / 208 suites, integration 80, typecheck + lint + prettier + knip + expo-doctor + TypeDoc all clean.

## Reviewer notes

- **Not yet run on a real device database.** If the shipped seed data holds a row with an out-of-enum type or a duplicate id, dev and E2E builds will stop at `ErrorFallback` on launch. Worth one `ingredients-db` E2E run before merge.
- `computeRecipeSeason` returns the first ingredient's `season` array by reference, so a single-ingredient recipe aliases the cache. No code mutates a season array today — left latent rather than churning the hot path.
- Deriving `season` at a single cache-write choke point would also fix `deleteTag`, `scaleRecipe` and UI `editRecipe`, which skip the recompute today. Pre-existing, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
