### PR TITLE
test(e2e): upgrade CI to macos-26 + iOS 26.2 with Maestro 2.8.0 (Part 2/2)

### DIFF
--- a/.github/scripts/prepare-maestro-logs.sh
+++ b/.github/scripts/prepare-maestro-logs.sh
@@ -13,12 +13,11 @@ fi
 
 cd "$OUTPUT_DIR"
 
-# Flatten structure - move logs and screenshots from .maestro/tests/*/ to root
+# Hoist the session's contents to the artifact root. Move whole entries, not
+# matching extensions: since 2.7.0 each flow's screenshots and hierarchies live in
+# its own subdirectory, which extension globs skipped and the rm below then deleted.
 if [ -d ".maestro/tests" ]; then
-  mv .maestro/tests/*/maestro.log . 2>/dev/null || true
-  mv .maestro/tests/*/*.png . 2>/dev/null || true
-  mv .maestro/tests/*/*.json . 2>/dev/null || true
-  mv .maestro/tests/*/*.html . 2>/dev/null || true
+  find .maestro/tests -mindepth 2 -maxdepth 2 -exec mv {} . \; || true
   rm -rf .maestro
 fi
 

--- a/.github/workflows/e2e-maestro.yml
+++ b/.github/workflows/e2e-maestro.yml
@@ -25,14 +25,14 @@ on:
 jobs:
   e2e-tests:
     name: E2E ${{ inputs.platform }} (${{ matrix.suite }})
-    runs-on: ${{ inputs.platform == 'ios' && 'macos-15' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.platform == 'ios' && 'macos-26' || 'ubuntu-latest' }}
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
         suite: ${{ fromJson(inputs.suites) }}
     steps:
-      - name: Select Xcode 26
+      - name: Select Xcode 26.2
         if: inputs.platform == 'ios'
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
@@ -48,6 +48,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - name: Setup Maestro CLI
+        uses: dniHze/maestro-test-action@v1
+        with:
+          version: '2.8.0'
 
       # ============================================
       # Android Setup
@@ -68,12 +73,6 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-
-      - name: Setup Maestro CLI (Android)
-        if: inputs.platform == 'android'
-        uses: dniHze/maestro-test-action@v1
-        with:
-          version: '2.6.0'
 
       - name: Run E2E tests (Android)
         if: inputs.platform == 'android'
@@ -120,7 +119,8 @@ jobs:
         uses: futureware-tech/simulator-action@v5
         with:
           model: 'iPhone 16e'
-          os_version: '18.6'
+          # 26.2 is the only 26.x runtime carrying an iPhone 16e.
+          os_version: '26.2'
           wait_for_boot: true
           erase_before_boot: false
           shutdown_after_job: true
@@ -147,12 +147,19 @@ jobs:
           xcrun simctl spawn booted defaults write -g KeyboardAutocorrection -bool NO
           xcrun simctl spawn booted defaults write -g KeyboardSpellChecking -bool NO
           xcrun simctl spawn booted defaults write com.apple.assistant.support "Assistant Enabled" -bool NO
+          xcrun simctl spawn booted defaults write com.apple.Accessibility ReduceTransparencyEnabled -bool YES
 
-      - name: Setup Maestro CLI (iOS)
+      - name: Freeze simulator status bar
         if: inputs.platform == 'ios'
-        uses: dniHze/maestro-test-action@v1
-        with:
-          version: '2.6.0'
+        run: |
+          # --time must not end in ":00" — iOS 26 rejects "HH:00" as non-ISO.
+          xcrun simctl status_bar booted override \
+            --time "9:41" \
+            --batteryState charged \
+            --batteryLevel 100 \
+            --cellularBars 4 \
+            --wifiBars 3 \
+            || echo "::warning::Status bar override failed — clock/battery animation not frozen"
 
       - name: Run E2E tests (iOS)
         if: inputs.platform == 'ios'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -208,5 +208,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maestro-logs-performance
-          path: maestro_logs_performance.zip
+          path: maestro_logs_performance/
           retention-days: 7

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Maestro CLI
         uses: dniHze/maestro-test-action@v1
         with:
-          version: '2.6.0'
+          version: '2.8.0'
 
       - name: Enable KVM
         run: |

--- a/guides/ci-setup.md
+++ b/guides/ci-setup.md
@@ -113,7 +113,10 @@ recipe-edit, search, settings, shopping, tags-db, web, web-edge-cases
 ```
 
 - Android: `ubuntu-latest`, API 34 Google APIs x86_64 emulator, KVM enabled, 4 GB RAM, 4 cores
-- iOS: `macos-15`, iPhone 16e simulator, iOS 18.6, Xcode 26.2, hardware keyboard disabled, animations reduced
+- iOS: `macos-26`, iPhone 16e simulator, iOS 26.2, Xcode 26.2, hardware keyboard disabled, animations reduced,
+  Liquid Glass flattened (`ReduceTransparency`), status bar frozen
+  - Runtime is pinned to 26.2 exactly, so local sims reproduce CI. iPhone 16e ships only on that runtime
+    (26.4/26.5 carry iPhone 17e instead), so a range would buy no flexibility.
 
 Each suite uploads:
 - `maestro-logs-{platform}-{suite}.zip` — Maestro step logs + app logs

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -167,7 +167,7 @@ E2E tests are YAML-based Maestro flows, organized into named suites. Each suite 
 
 Available suites: `app-init`, `bulk-import`, `duplicates-ingredient`, `duplicates-recipe`, `duplicates-tag`, `ingredient-dialog`, `ingredients-db`, `menu`, `ocr`, `recipe-create`, `recipe-edit`, `recipe-readonly`, `search`, `settings`, `shopping`, `tags-db`, `web`, `web-edge-cases`, `performance`.
 
-CI runs every suite in a matrix job (fail-fast: false), on both Android (API 34) and iOS (iPhone 16e, iOS 18.6). Each test case has a `ci/` wrapper that adds `retry: maxRetries: 2` for infrastructure flakiness without affecting local runs.
+CI runs every suite in a matrix job (fail-fast: false), on both Android (API 34) and iOS (iPhone 16e, iOS 26.2). Each test case has a `ci/` wrapper that adds `retry: maxRetries: 2` for infrastructure flakiness without affecting local runs.
 
 For full architecture, TestID conventions, OCR patterns, and troubleshooting see [tests/e2e/E2E_TESTING.md](../tests/e2e/E2E_TESTING.md).
 
@@ -212,7 +212,7 @@ All test jobs are defined in `.github/workflows/build-test.yml` and `.github/wor
 | `integration-tests` | push/PR to main | `npm run test:integration`; uploads JUnit summary |
 | `reassure-performance` | push/PR to main | Runs Reassure against base SHA; posts compact diff comment on PR |
 | `e2e-tests-android` | after APK build | Runs all suites in parallel matrix on Android API 34 emulator |
-| `e2e-tests-ios` | after iOS build | Runs all suites in parallel matrix on iOS simulator (macos-15) |
+| `e2e-tests-ios` | after iOS build | Runs all suites in parallel matrix on iOS simulator (macos-26) |
 | `e2e-tests-android-performance` | after perf APK build | Runs `performance` suite only |
 | `merge-test-artifacts` | always, after E2E | Merges per-suite JUnit reports and Maestro logs into single artifacts |
 | `test-result-summary` | always, after merge | Posts combined unit + E2E test summary comment on PRs |

--- a/tests/e2e/VISUAL_TESTING_EVALUATION.md
+++ b/tests/e2e/VISUAL_TESTING_EVALUATION.md
@@ -5,13 +5,13 @@ answering issue #323 item 3. **Decision: defer.**
 
 ## Environment
 
-- **Maestro:** `2.6.0` (pinned in `.github/workflows/e2e-maestro.yml`).
+- **Maestro:** `2.8.0` (pinned in `.github/workflows/e2e-maestro.yml`).
 - **CI model:** E2E runs on **local emulators/simulators inside GitHub Actions**
-  — Android on `ubuntu-latest`, iOS on `macos-15`. Not Maestro Cloud.
+  — Android on `ubuntu-latest`, iOS on `macos-26`. Not Maestro Cloud.
 - **Current screenshot usage:** none (`takeScreenshot` / `assertScreenshot` /
   `assertWithAI` absent from `tests/e2e/`).
 
-## What Maestro 2.6.0 offers
+## What Maestro 2.8.0 offers
 
 ### 1. `assertScreenshot` — pixel-diff (local, free)
 


### PR DESCRIPTION
Closes #449 (Part 2/2, follows #448).

Moves the iOS E2E matrix from `macos-15` / iOS 18.6 to `macos-26` / iOS 26.2, bumps Maestro `2.6.0` -> `2.8.0`, and adds the iOS 26 flake mitigations. Device stays iPhone 16e, so this is a single-axis flip — runner and OS only — and reverts in one line.

## Commits

- `test(e2e): migrate iOS CI to macos-26 + iOS 26.2`
- `fix(ci): upload the perf Maestro logs directory, not a missing zip`

## Three issue premises turned out wrong

**1. The "BLOCKER" has no fix to bump to.** Maestro [#3318](https://github.com/mobile-dev-inc/maestro/issues/3318) and [#3254](https://github.com/mobile-dev-inc/maestro/issues/3254) were closed by stale-bot (`waiting for customer response`), not fixed — a maintainer disputed the repro was universal. No release ties a driver-lifecycle fix to a version. The 2.8.0 bump is still justified, but by the 2.7.0 changelog instead: recover from transient `kAXErrorInvalidUIElement` during hierarchy retrieval, clean up leftover driver files after runs, fix taps after `scrollUntilVisible`, fix hierarchy retrieval on iOS 26. Related, not the same claim. Directory mode is kept — the per-flow loop workaround would discard each suite's `executionOrder`.

**2. Permission pre-grants are a no-op that would regress us.** `Orchestra.launchAppCommand` runs `clearAppState` and then `setPermissions(command.permissions ?: mapOf("all" to "allow"))`. All permissions are already granted, after the reinstall, on every flow. An explicit `{camera, photos}` map would narrow that to two. A CI-side `simctl privacy grant` is wiped anyway, because iOS `clearState` is uninstall + reinstall. No flow changes.

**3. The Maestro bump silently destroys CI screenshots.** Not flagged in the issue. 2.7.0 moved artifacts into per-flow subdirectories; `prepare-maestro-logs.sh` globbed only session-level extensions and then `rm -rf .maestro`. Reproduced on a fixture: old script kept **0 of 2** screenshots. Fixed and re-tested across the 2.7.0 nested layout, the 2.6.0 flat layout, a missing `.maestro`, and a missing directory.

## `os_version` is pinned, not ranged

The issue asked for a loose range, but that assumed iPhone 16e exists across runtimes. On the current image it exists on **26.2 only** — 26.4 and 26.5 ship iPhone 17e. A range floats nowhere, does not survive 26.2 being dropped, and would silently change the test substrate if a later image added a 16e elsewhere. An exact pin fails loudly and lets a local simulator reproduce CI.

## Verified on a real iPhone 16e / iOS 26.2 simulator

- **Found a job-killing bug in the issue's own snippet.** `--time "12:00"` fails on iOS 26 with `Invalid, non-ISO date/time string`, and the step had no guard. Narrowed empirically: **any time ending in `:00` is rejected** (`9:00`, `12:00`, `00:00`, and full ISO all fail; `9:41`, `1:15`, `12:01`, `23:59` pass). Now `9:41`, with a `::warning::` fallback so a cosmetic setting can never take down the matrix.
- Status bar freeze and `ReduceTransparency` confirmed applied (`status_bar list` plus a screenshot showing a flat, unblurred tab bar).
- All 715 flow files pass `maestro check-syntax` under 2.8.0. The 21 reported failures are all top-level suite *configs*, which the checker reads as flows (`Invalid Command: platform`).

## Known-open, deliberately not fixed here

`com.apple.Accessibility ReduceMotion` is very likely the wrong key — the domain carries `ReduceMotionEnabled` as an OS-owned default, matching the `*Enabled` form of the working `ReduceTransparencyEnabled`. iOS E2E has probably never had reduced motion. Correcting it is a behavior change that would trip `useReducedMotion` and silently disable the tutorial auto-demos, breaking those flows — it needs its own tested PR.

The `verify simulator settings` step considered during review was dropped: `defaults read` returns whatever `defaults write` just stored, so it cannot detect a key iOS ignores (confirmed — a fabricated key reads back `1`). The issue's "verify each key still applies on iOS 26" item therefore remains open.

## Acceptance criteria not closable from this PR

`>=5 green runs with flake rate and retry consumption tracked` needs CI runs on this branch. Everything else is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
